### PR TITLE
WIP: include more async participation

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -80,7 +80,7 @@ If a minority viewpoint is supported by a member with a demonstrable
 implementation (even of a closed source implementation), the vote cannot be held
 until there is an open source implementation that illustrates the benefits or drawbacks of the proposal.
 
-If a vote is taken during a WG meeting, the follow rules will be followed:
+If a vote is taken during a WG meeting, the following rules will be followed:
 
 * There is only 1 vote per Active Member
 * A vote passes if more than 50% of the votes cast approve the motion.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,18 +20,19 @@ the following process will be followed:
 
 Anyone is welcome to attend Working Group meetings and invited to review
 PRs, whether or not they have declared formal membership in the Working Group.
+We encourage everyone to document your participation so that new people can
+learn about other folks who are involved.
 
-We encourage everyone to document your participation in the [member list](),
-then people new to the group can learn about other folks who are involved.
-Each member identifies their affiliation with an organization, company or
-open source project, along with their specific use case(s) for events.
+Each member (company, organization, or independent project) which
+wishes to be considered for membership should add their name to the
+[member list]() with the following information:
 
 - company / org / project
     - representative, (optional) alternate representative
     - describe how you are using or intend to use the Event specification
 
-**Active Members** participate in at least three Working Group meetings per
-month.
+**Active Members** have participated in 3 out of the last 4 meetings, along
+with participation outside of the meetings by reviewing PRs.
 
 ## PRs
 
@@ -75,9 +76,9 @@ Most of the time we come to agreement simply by revising a proposed change or ad
 Working Group may choose to overrule a minority viewpoint by calling for a vote
 by active members of the Working Group, as described below.
 
-If a minority viewpoint is supported by an member with an implementation, the
-vote cannot be held until there is an open source implementation that
-illustrates the benefits or drawbacks of the proposal.
+If a minority viewpoint is supported by a member with a demonstrable
+implementation (even of a closed source implementation), the vote cannot be held
+until there is an open source implementation that illustrates the benefits or drawbacks of the proposal.
 
 If a vote is taken during a WG meeting, the follow rules will be followed:
 
@@ -89,7 +90,3 @@ If a vote is taken during a WG meeting, the follow rules will be followed:
   [here](https://docs.google.com/spreadsheets/d/1bw5s9sC2ggYyAiGJHEk7xm-q2KG6jyrfBy69ifkdmt0/edit#gid=0).
   Members must acknowledge their presence verbally, meaning, adding yourself
   to the "Attendees" section of the Agenda document is not sufficient.
-
-
-
-

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -9,7 +9,7 @@ In order to provide equitable rights to all Working Group members,
 the following process will be followed:
 
 * Official WG meetings will be announced at least a week in advance.
-* Proposed changes to any document will be done via a Pull Request (PR), 
+* Proposed changes to any document will be done via a Pull Request (PR),
   see below for policy on review and acceptance of PRs.
 * During meetings, priority will be given to PRs that appear to be ready for
   a vote over those that appear to require discussions.
@@ -18,38 +18,44 @@ the following process will be followed:
 
 ## Working Group Membership
 
-Anyone is welcome to attend Working Group meetings and invited to review 
+Anyone is welcome to attend Working Group meetings and invited to review
 PRs, whether or not they have declared formal membership in the Working Group.
 
-We encourage everyone to document your participation in the [member list](), 
+We encourage everyone to document your participation in the [member list](),
 then people new to the group can learn about other folks who are involved.
 Each member identifies their affiliation with an organization, company or
 open source project, along with their specific use case(s) for events.
 
-- company / org / project 
+- company / org / project
     - representative, (optional) alternate representative
     - describe how you are using or intend to use the Event specification
-    
-**Active Members** participate in at least three Working Group meetings per month.
+
+**Active Members** participate in at least three Working Group meetings per
+month.
 
 ## PRs
 
 Changes fall into two categories:
-- **Administrative**: grammar, spelling, minor clarifications, or git rebase.  These must be left open for at least 24 hours, then they may be merged by someone who is not the author (or +1 from a member representing a different company or organization). All comments must be addressed before merging with additional +1 once any comment has been addressed.
-- **Substantive**: modifications to the name or definition of a term or additions to the specification.  When in doubt, committers should assume that a PR is substantive and leave open until next WG meeting.
+- **Administrative**: grammar, spelling, minor clarifications, or git rebase.
+These must be left open for at least 24 hours, then they may be merged by
+someone who is not the author (or +1 from a member representing a different
+company or organization). All comments must be addressed before merging with additional +1 once any comment has been addressed.
+- **Substantive**: modifications to the name or definition of a term or
+additions to the specification.  When in doubt, committers should assume that a
+PR is substantive and leave open until next WG meeting.
 
 PRs are expected to meet the following criteria prior to being
 merged:
 
 * The author of the PR indicates that it is ready for review by asking for it
   to be discussed in an upcoming meeting - eg. by adding it to the agenda
-  document.  If the author has become inactive, then another WG member can 
+  document.  If the author has become inactive, then another WG member can
   volunteeer to take on this role.
 * All comments have been addressed.
 * PRs that have objections/concerns will be discussed off-line by interested
   parties. A resolution, updated PR, will be expected from those talks.
 * Resolving PRs ("merging" or "closing with no action") will be done as a
-  result of a motion made via comment at least two days in advance of a 
+  result of a motion made via comment at least two days in advance of a
   WG meeting, and approved at that meeting.
 * Reopening a PR can be done if new information is made available via
   github issue, which can then be added to the agenda for WG meeting.
@@ -57,12 +63,21 @@ merged:
 ## Decision Making
 
 Process:
-- [Optional] Add an item to the [agenda]() for a working group meeting if you have an idea or suggestion and want some feedback before drafting a proposal. If the WG has a busy agenda, then you may be asked to convene a group of interested parties separately from the WG meetings.
-- Proposals, added via PR to this github repo, must be open for at least a week, and will not be considered for decision if substantive changes were made within two days of a meeting
+- [Optional] Add an item to the [agenda]() for a working group meeting if you
+have an idea or suggestion and want some feedback before drafting a proposal.
+If the WG has a busy agenda, then you may be asked to convene a group of
+interested parties separately from the WG meetings.
+- Proposals, added via PR to this github repo, must be open for at least a week,
+and will not be considered for decision if substantive changes were made within
+two days of a meeting
 
-Most of the time we come to agreement simply by revising a proposed change or addition until all of the issues raised are addressed.  Occasionally, the Working Group may choose to overrule a minority viewpoint by calling for a vote by active members of the Working Group, as described below.  
+Most of the time we come to agreement simply by revising a proposed change or addition until all of the issues raised are addressed.  Occasionally, the
+Working Group may choose to overrule a minority viewpoint by calling for a vote
+by active members of the Working Group, as described below.
 
-If a minority viewpoint is supported by an member with an implementation, the vote cannot be held until there is an open source implementation that illustrates the benefits or drawbacks of the proposal.  
+If a minority viewpoint is supported by an member with an implementation, the
+vote cannot be held until there is an open source implementation that
+illustrates the benefits or drawbacks of the proposal.
 
 If a vote is taken during a WG meeting, the follow rules will be followed:
 
@@ -74,7 +89,7 @@ If a vote is taken during a WG meeting, the follow rules will be followed:
   [here](https://docs.google.com/spreadsheets/d/1bw5s9sC2ggYyAiGJHEk7xm-q2KG6jyrfBy69ifkdmt0/edit#gid=0).
   Members must acknowledge their presence verbally, meaning, adding yourself
   to the "Attendees" section of the Agenda document is not sufficient.
-  
-  
-  
+
+
+
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -9,44 +9,64 @@ In order to provide equitable rights to all Working Group members,
 the following process will be followed:
 
 * Official WG meetings will be announced at least a week in advance.
-* Proposed changes to any document will be done via a Pull Request (PR).
-* PRs will be reviewed during official WG meetings.
+* Proposed changes to any document will be done via a Pull Request (PR), 
+  see below for policy on review and acceptance of PRs.
 * During meetings, priority will be given to PRs that appear to be ready for
   a vote over those that appear to require discussions.
-* PRs should not be merged if they have had substantial changes made within
-  two days of the meeting.
-  Rebases, typo fixes, etc. do not count as substantial.
-  Note, administrivia PRs that do not materially modify WG output documents
-  may be processed by WG admins as needed.
-* Resolving PRs ("merging" or "closing with no action") will be done as a
-  result of a motion made during a WG meeting, and approved.
-* Reopening a PR can be done if new information is made available, and a
-  motion to do so is approved.
 * Any motion that does not have "unanimous consent" will result in a formal
   vote. See [Voting](#voting).
 
+## Working Group Membership
+
+Anyone is welcome to attend Working Group meetings and invited to review 
+PRs, whether or not they have declared formal membership in the Working Group.
+
+We encourage everyone to document your participation in the [member list](), 
+then people new to the group can learn about other folks who are involved.
+Each member identifies their affiliation with an organization, company or
+open source project, along with their specific use case(s) for events.
+
+- company / org / project 
+    - representative, (optional) alternate representative
+    - describe how you are using or intend to use the Event specification
+    
+**Active Members** participate in at least three Working Group meetings per month.
+
 ## PRs
 
-Typically, PRs are expected to meet the following criteria prior to being
+Changes fall into two categories:
+- **Administrative**: grammar, spelling, minor clarifications, or git rebase.  These must be left open for at least 24 hours, then they may be merged by someone who is not the author (or +1 from a member representing a different company or organization). All comments must be addressed before merging with additional +1 once any comment has been addressed.
+- **Substantive**: modifications to the name or definition of a term or additions to the specification.  When in doubt, committers should assume that a PR is substantive and leave open until next WG meeting.
+
+PRs are expected to meet the following criteria prior to being
 merged:
 
 * The author of the PR indicates that it is ready for review by asking for it
   to be discussed in an upcoming meeting - eg. by adding it to the agenda
-  document.
+  document.  If the author has become inactive, then another WG member can 
+  volunteeer to take on this role.
 * All comments have been addressed.
 * PRs that have objections/concerns will be discussed off-line by interested
   parties. A resolution, updated PR, will be expected from those talks.
+* Resolving PRs ("merging" or "closing with no action") will be done as a
+  result of a motion made via comment at least two days in advance of a 
+  WG meeting, and approved at that meeting.
+* Reopening a PR can be done if new information is made available via
+  github issue, which can then be added to the agenda for WG meeting.
 
-## Voting
+## Decision Making
+
+Process:
+- [Optional] Add an item to the [agenda]() for a working group meeting if you have an idea or suggestion and want some feedback before drafting a proposal. If the WG has a busy agenda, then you may be asked to convene a group of interested parties separately from the WG meetings.
+- Proposals, added via PR to this github repo, must be open for at least a week, and will not be considered for decision if substantive changes were made within two days of a meeting
+
+Most of the time we come to agreement simply by revising a proposed change or addition until all of the issues raised are addressed.  Occasionally, the Working Group may choose to overrule a minority viewpoint by calling for a vote by active members of the Working Group, as described below.  
+
+If a minority viewpoint is supported by an member with an implementation, the vote cannot be held until there is an open source implementation that illustrates the benefits or drawbacks of the proposal.  
 
 If a vote is taken during a WG meeting, the follow rules will be followed:
 
-* There is only 1 vote per participating company, or nonaffiliated individual.
-* Each participating company can assign a primary and secondary representative.
-* A participating company, or nonaffiliated individual, attains voting rights
-  by having any of their assigned representative(s) attend 3 out of the last
-  4 meetings. They obtain voting rights after the 3rd meeting, not during.
-* Only WG members with voting rights will be allowed to vote.
+* There is only 1 vote per Active Member
 * A vote passes if more than 50% of the votes cast approve the motion.
 * Only "yes" or "no" votes count, "abstain" votes do not count towards the
   total.
@@ -54,4 +74,7 @@ If a vote is taken during a WG meeting, the follow rules will be followed:
   [here](https://docs.google.com/spreadsheets/d/1bw5s9sC2ggYyAiGJHEk7xm-q2KG6jyrfBy69ifkdmt0/edit#gid=0).
   Members must acknowledge their presence verbally, meaning, adding yourself
   to the "Attendees" section of the Agenda document is not sufficient.
+  
+  
+  
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -14,7 +14,7 @@ the following process will be followed:
 * During meetings, priority will be given to PRs that appear to be ready for
   a vote over those that appear to require discussions.
 * Any motion that does not have "unanimous consent" will result in a formal
-  vote. See [Voting](#voting).
+  vote. See [Decisions](#Decisions).
 
 ## Working Group Membership
 
@@ -60,7 +60,7 @@ merged:
 * Reopening a PR can be done if new information is made available via
   github issue, which can then be added to the agenda for WG meeting.
 
-## Decision Making
+## Decisions
 
 Process:
 - [Optional] Add an item to the [agenda]() for a working group meeting if you


### PR DESCRIPTION
- proposed member list (link goes nowhere, will create separately if others like this idea)
- slight increase in commitment by active members
    - members identify themselves, affiliation & interest
    - members need to comment on a PR in advance of the meeting to be eligible to vote
- also added something to suggest that a minority view could strengthen their point with an implementation

Signed-off-by: Sarah Allen <sarahallen@google.com>