### PR TITLE
Issue 6 - Definition of Event in the terminology section is confusing

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -71,11 +71,11 @@ system. This is most typically when that system receives an external signal
 
 #### Event
 Data representing an occurrence, a change in state, that something happened
-(or did not happen), usually used for notification. Events include context
-and data. Each occurrence might be uniquely identified with data in the event.
-Events are considered as facts that have no given destination, whereas
-messages contain intent and tend to transport data from a source to a given
-destination.
+(or did not happen).  Events include context and data.  Each occurrence MAY be
+uniquely identified with data in the event. Events ought not to be confused 
+with messages which are used to transport or distribute data without assumptions 
+regarding its semantic. Events are considered to be facts that have no given 
+destination. Events are used to notify other systems that something has happened.
 
 #### Context
 A set of consistent metadata attributes included with the event about the


### PR DESCRIPTION
Reworded the description of the term event to remove ambiguity around words message and notification

Fixes #6 

Signed-off-by: Suhas Chatekar <suhas.chatekar@gmail.com>

