### PR TITLE
Add some more git help text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ as well as the guidelines we follow for how our documents are formatted.
 ## Reporting an Issue
 
 To report an issue, or to suggest an idea for a change that you haven't
-had time to write-up yet, open an 
+had time to write-up yet, open an
 [issue](https://github.com/cloudevents/spec/issues). It is best to check
 our existing [issues](https://github.com/cloudevents/spec/issues) first
 to see if a similar one has already been opened and discussed.
@@ -20,7 +20,7 @@ to see if a similar one has already been opened and discussed.
 
 To suggest a change to to this repository, submit a [pull
 request](https://github.com/cloudevents/spec/pulls)(PR) with the complete
-set of changes you'd like to see. See the 
+set of changes you'd like to see. See the
 [Spec Formatting Conventions](#spec-formatting-conventions) section for
 the guidelines we follow for how documents are formatted.
 
@@ -80,6 +80,21 @@ Use your real name (sorry, no pseudonyms or anonymous contributions.)
 
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.
+
+Note: If your git config information is set properly then viewing the
+ `git log` information for your commit will look something like this:
+
+```
+Author: Joe Smith <joe.smith@email.com>
+Date:   Thu Feb 2 11:41:15 2018 -0800
+
+    Update README
+
+    Signed-off-by: Joe Smith <joe.smith@email.com>
+```
+
+Notice the `Author` and `Signed-off-by` lines match. If they don't
+your PR will be rejected by the automated DCO check.
 
 ## Spec Formatting Conventions
 


### PR DESCRIPTION
Per our call last week people wanted a bit more guidance about the
DCO checker and what their git commits should look like w.r.t. signing.

Signed-off-by: Doug Davis <dug@us.ibm.com>