### PR TITLE
Propose a new "service" sub-field of "source"

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -170,8 +170,21 @@ that contains both context and data).
 * Constraints:
   * REQUIRED
   * MUST be a non-empty string
+  * MUST be a unique resource relative to source-service
 * Examples:
-  * my.s3.bucket
+  * mybucket.s3.amazonaws.com
+  * /projects/myProject/databases/(default)/documents/users/aNewUser
+
+### source-service
+* Type: String
+* Description: The physical (e.g. IP address) or logical (e.g. DNS address) of
+  the source software.
+* Constraints:
+  * REQUIRED
+  * MUST be a non-empty string
+* Examples:
+  * s3.amazonaws.com
+  * firestore.googleapis.com
 
 ### event-id
 * Type: String


### PR DESCRIPTION
(Note: this is a compound review; it may be more useful to skip the first commit when reviewing)

At Google we have found it useful to separate the service name from the rest of the resource string:

* When registering an event trigger, the service name is a key into an address where we register our hooks. This service name can be a key into a private API hosted on another server address or on another protocol (e.g. gRPC)
* The service name can tersely be the only difference in trigger or event objects between:
  * Production, integration, and development tiers of a service.
  * Common APIs hosted across multiple services by a cloud provider (e.g. IAM access control).
  * Enterprise versions of software such as IBM OpenWhisk, GitHub, or HipChat.
  * Open-source services running in local infrastructure.