### PR TITLE
Add sample rate field to the spec

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -202,7 +202,7 @@ that contains both context and data).
 
 ### content-type
 * Type: String per [RFC 2046](https://tools.ietf.org/html/rfc2046)
-* Description: Describe the data encoding format 
+* Description: Describe the data encoding format
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in
@@ -212,14 +212,14 @@ that contains both context and data).
 ### sampled-rate
 * Type: Positive Integer
 * Description: The rate at which this event has already been sampled. Represents
-  the number of similar events that happened but were not sent.
+  the number of similar events that happened but were not sent plus this event.
 * Constraints:
   * OPTIONAL
   * If present, MUST be a positive integer
-  * When absent means that no sampling has yet been applied
+  * When absent, a default value of 1 MAY be assumed, indicating no sampling
 * Examples:
   * If a system sees 30 occurrences and emits a single event as a sample,
-    `sampled-rate` would be 30.
+    `sampled-rate` would be 30 (29 not sent and 1 sent).
 
 ### extensions
 * Type: Map <String, Object>
@@ -237,7 +237,7 @@ that contains both context and data).
 ### data
 * Type: Arbitrary payload
 * Description: The event payload. The payload depends on the event-type,
-  schema-url and event-type-version, the pyload is encoded into a media format 
+  schema-url and event-type-version, the payload is encoded into a media format
   which is specified by the content-type attribute (e.g. application/json).
 * Constraints:
   * OPTIONAL

--- a/spec.md
+++ b/spec.md
@@ -202,7 +202,7 @@ that contains both context and data).
 
 ### content-type
 * Type: String per [RFC 2046](https://tools.ietf.org/html/rfc2046)
-* Description: Describe the data encoding format
+* Description: Describe the data encoding format 
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in
@@ -212,12 +212,14 @@ that contains both context and data).
 ### sampled-rate
 * Type: Positive Integer
 * Description: The rate at which this event has already been sampled. Represents
-  the denominator of a fraction: when `1/n` events are sent, this field holds
-  `n`.
+  the number of similar events that happened but were not sent.
 * Constraints:
   * OPTIONAL
   * If present, MUST be a positive integer
   * When absent means that no sampling has yet been applied
+* Examples:
+  * If a system sees 30 occurrences and emits a single event as a sample,
+    `sampled-rate` would be 30.
 
 ### extensions
 * Type: Map <String, Object>
@@ -235,7 +237,7 @@ that contains both context and data).
 ### data
 * Type: Arbitrary payload
 * Description: The event payload. The payload depends on the event-type,
-  schema-url and event-type-version, the pyload is encoded into a media format
+  schema-url and event-type-version, the pyload is encoded into a media format 
   which is specified by the content-type attribute (e.g. application/json).
 * Constraints:
   * OPTIONAL

--- a/spec.md
+++ b/spec.md
@@ -200,6 +200,7 @@ that contains both context and data).
   * If present, MUST adhere to the format specified in
     [RFC 3986](https://tools.ietf.org/html/rfc3986)
 
+<<<<<<< HEAD
 ### content-type
 * Type: String per [RFC 2046](https://tools.ietf.org/html/rfc2046)
 * Description: Describe the data encoding format 
@@ -208,6 +209,17 @@ that contains both context and data).
   * If present, MUST adhere to the format specified in
     [RFC 2046](https://tools.ietf.org/html/rfc2046)
 * For Media Type examples see [IANA Media Types](http://www.iana.org/assignments/media-types/media-types.xhtml)
+=======
+### sampled-rate
+* Type: Positive Integer
+* Description: The rate at which this event has already been sampled. Represents
+  the denominator of a fraction: when `1/n` events are sent, this field should
+  hold `n`.
+* Constraints:
+  * OPTIONAL
+  * If present, MUST be a positive integer
+  * When absent, may be assumed to be 1, meaning unsampled
+>>>>>>> Add sample rate field to the spec
 
 ### extensions
 * Type: Map <String, Object>

--- a/spec.md
+++ b/spec.md
@@ -200,26 +200,24 @@ that contains both context and data).
   * If present, MUST adhere to the format specified in
     [RFC 3986](https://tools.ietf.org/html/rfc3986)
 
-<<<<<<< HEAD
 ### content-type
 * Type: String per [RFC 2046](https://tools.ietf.org/html/rfc2046)
-* Description: Describe the data encoding format 
+* Description: Describe the data encoding format
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in
     [RFC 2046](https://tools.ietf.org/html/rfc2046)
 * For Media Type examples see [IANA Media Types](http://www.iana.org/assignments/media-types/media-types.xhtml)
-=======
+
 ### sampled-rate
 * Type: Positive Integer
 * Description: The rate at which this event has already been sampled. Represents
-  the denominator of a fraction: when `1/n` events are sent, this field should
-  hold `n`.
+  the denominator of a fraction: when `1/n` events are sent, this field holds
+  `n`.
 * Constraints:
   * OPTIONAL
   * If present, MUST be a positive integer
-  * When absent, may be assumed to be 1, meaning unsampled
->>>>>>> Add sample rate field to the spec
+  * When absent means that no sampling has yet been applied
 
 ### extensions
 * Type: Map <String, Object>
@@ -237,7 +235,7 @@ that contains both context and data).
 ### data
 * Type: Arbitrary payload
 * Description: The event payload. The payload depends on the event-type,
-  schema-url and event-type-version, the pyload is encoded into a media format 
+  schema-url and event-type-version, the pyload is encoded into a media format
   which is specified by the content-type attribute (e.g. application/json).
 * Constraints:
   * OPTIONAL


### PR DESCRIPTION
There are many cases in an Event's life when a system (either the system creating the event or a system transporting the event) may wish to only emit a portion of the events that actually happened.  In a high throughput system where creating the event is costly, a system may wish to only create an event for 1/100 of the times that something happened. Additionally, during the transmission of an event from the source to the eventual recipient, any step along the way may choose to only pass along a fraction of the events it receives.

In order for the system receiving the event to understand what is actually happening in the system that generated the event, information about how many similar events may have happened must be included in the event itself. This field provides a place for a system generating an event to indicate that the emitted event reepresents a given number of other similar events. It also provides a place for intermediary transport systems to modify the event when they impose additional sampling.

Two examples for context:

Every time our API server at Honeycomb accepts an incoming HTTP request, it generates an Event identifying the request. It is not necessary to actually transmit every one of these events, so to save on server and network resources as well as minimize the necessary size for the receiving cluster, we only send on average 1 event for every 3000 requests received. The actual sample rate varies according to attributes of the incoming traffic, so the sample rate is necessarily a part of the context of the Event.

Deep in the storage engine for Honeycomb, there is an operation that generates an event. Much of the metadata that is necessary to give the data in that event necessary context is expensive to compute. In order to avoid spending precious computational time on generating metadata that will then be thrown out, we only generate the contextual data for events that will actually get sent. It is necessary to indicate the sample rate in the event emitted to get an accurate reflection of the actual operation of the service.

Signed-off-by: Ben Hartshorne <ben@honeycomb.io>