### PR TITLE
removing trailing whitespace from the end of lines

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -72,9 +72,9 @@ system. This is most typically when that system receives an external signal
 #### Event
 Data representing an occurrence, a change in state, that something happened
 (or did not happen).  Events include context and data.  Each occurrence MAY be
-uniquely identified with data in the event. Events ought not to be confused 
-with messages which are used to transport or distribute data without assumptions 
-regarding its semantic. Events are considered to be facts that have no given 
+uniquely identified with data in the event. Events ought not to be confused
+with messages which are used to transport or distribute data without assumptions
+regarding its semantic. Events are considered to be facts that have no given
 destination. Events are used to notify other systems that something has happened.
 
 #### Context


### PR DESCRIPTION
My editor keeps automatically stripping whitespace from the ends of lines. I don't think the linter for this repo cares one way or the other, but it seems unfortunate for 3 lines to end with a space while the rest don't. 

Normally I would just include this in some more relevant actual PR but in the interests of not confusing things, making it its own change. 

Signed-off-by: Ben Hartshorne <ben@honeycomb.io>