### PR TITLE
move references out of the specification into supporting material

### DIFF
--- a/about/landscape/README.md
+++ b/about/landscape/README.md
@@ -1,0 +1,129 @@
+Prior to the CloudEvents specification, many systems implemented similar models for events that allowed late-binding of services to actions.
+
+The folowing references were evaluated in the formation of the first draft
+of the specification. (We welcome pull requests with more context or
+additional references)
+
+### Microsoft - Event Grid
+```
+{
+    "topic":"/subscriptions/{subscription-id}",
+    "subject":"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501",
+    "eventType":"Microsoft.Resources.ResourceWriteSuccess",
+    "eventTime":"2017-08-16T03:54:38.2696833Z",
+    "id":"25b3b0d0-d79b-44d5-9963-440d4e6a9bba",
+    "data": {
+        "authorization":"{azure_resource_manager_authorizations}",
+        "claims":"{azure_resource_manager_claims}",
+        "correlationId":"54ef1e39-6a82-44b3-abc1-bdeb6ce4d3c6",
+        "httpRequest":"",
+        "resourceProvider":"Microsoft.EventGrid",
+        "resourceUri":"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501",
+        "operationName":"Microsoft.EventGrid/eventSubscriptions/write",
+        "status":"Succeeded",
+        "subscriptionId":"{subscription-id}",
+        "tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"
+    }
+}
+```
+[Documentation](https://docs.microsoft.com/en-us/azure/event-grid/event-schema)
+
+### Google - Cloud Functions (potential future)
+```
+{
+  "data": {
+    "@type": "types.googleapis.com/google.pubsub.v1.PubsubMessage",
+    "attributes": {
+      "foo": "bar",
+     },
+     "messageId": "12345",
+     "publishTime": "2017-06-05T12:00:00.000Z",
+     "data": "somebase64encodedmessage"
+  },
+  "context": {
+    "eventId": "12345",
+    "timestamp": "2017-06-05T12:00:00.000Z",
+    "eventTypeId": "google.pubsub.topic.publish",
+    "resource": {
+      "name": "projects/myProject/topics/myTopic",
+      "service": "pubsub.googleapis.com"
+    }
+  }
+}
+```
+
+### AWS - SNS
+```
+{
+  "Records": [
+    {
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": eventsubscriptionarn,
+      "EventSource": "aws:sns",
+      "Sns": {
+        "SignatureVersion": "1",
+        "Timestamp": "1970-01-01T00:00:00.000Z",
+        "Signature": "EXAMPLE",
+        "SigningCertUrl": "EXAMPLE",
+        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+        "Message": "Hello from SNS!",
+        "MessageAttributes": {
+          "Test": {
+            "Type": "String",
+            "Value": "TestString"
+          },
+          "TestBinary": {
+            "Type": "Binary",
+            "Value": "TestBinary"
+          }
+        },
+        "Type": "Notification",
+        "UnsubscribeUrl": "EXAMPLE",
+        "TopicArn": topicarn,
+        "Subject": "TestInvoke"
+      }
+    }
+  ]
+}
+```
+[Documentation](http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html)
+
+### AWS - Kinesis
+```
+{
+  "Records": [
+    {
+      "eventID": "shardId-000000000000:49545115243490985018280067714973144582180062593244200961",
+      "eventVersion": "1.0",
+      "kinesis": {
+        "partitionKey": "partitionKey-3",
+        "data": "SGVsbG8sIHRoaXMgaXMgYSB0ZXN0IDEyMy4=",
+        "kinesisSchemaVersion": "1.0",
+        "sequenceNumber": "49545115243490985018280067714973144582180062593244200961"
+      },
+      "invokeIdentityArn": identityarn,
+      "eventName": "aws:kinesis:record",
+      "eventSourceARN": eventsourcearn,
+      "eventSource": "aws:kinesis",
+      "awsRegion": "us-east-1"
+    }
+  ]
+}
+```
+
+### IBM - OpenWhisk - Web Action Event
+```
+{
+  "__ow_method": "post",
+  "__ow_headers": {
+    "accept": "*/*",
+    "connection": "close",
+    "content-length": "4",
+    "content-type": "text/plain",
+    "host": "172.17.0.1",
+    "user-agent": "curl/7.43.0"
+  },
+  "__ow_path": "",
+  "__ow_body": "Jane"
+}
+```

--- a/about/landscape/README.md
+++ b/about/landscape/README.md
@@ -1,6 +1,7 @@
-Prior to the CloudEvents specification, many systems implemented similar models for events that allowed late-binding of services to actions.
+Prior to the CloudEvents specification, many systems implemented similar models
+for events that allowed late-binding of services to actions.
 
-The folowing references were evaluated in the formation of the first draft
+The following references were evaluated in the formation of the first draft
 of the specification. (We welcome pull requests with more context or
 additional references)
 

--- a/spec.md
+++ b/spec.md
@@ -202,7 +202,7 @@ that contains both context and data).
 
 ### content-type
 * Type: String per [RFC 2046](https://tools.ietf.org/html/rfc2046)
-* Description: Describe the data encoding format 
+* Description: Describe the data encoding format
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in
@@ -225,7 +225,7 @@ that contains both context and data).
 ### data
 * Type: Arbitrary payload
 * Description: The event payload. The payload depends on the event-type,
-  schema-url and event-type-version, the pyload is encoded into a media format 
+  schema-url and event-type-version, the pyload is encoded into a media format
   which is specified by the content-type attribute (e.g. application/json).
 * Constraints:
   * OPTIONAL
@@ -257,131 +257,3 @@ that contains both context and data).
   serverless function which listens on the source event, opens a connection to
   the destination protocol and maps every incoming event (received through
   event API) to an event message over the destination protocol.
-
-## Reference
-
-Examples of current event formats that exist today.
-
-### Microsoft - Event Grid
-```
-{
-    "topic":"/subscriptions/{subscription-id}",
-    "subject":"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501",
-    "eventType":"Microsoft.Resources.ResourceWriteSuccess",
-    "eventTime":"2017-08-16T03:54:38.2696833Z",
-    "id":"25b3b0d0-d79b-44d5-9963-440d4e6a9bba",
-    "data": {
-        "authorization":"{azure_resource_manager_authorizations}",
-        "claims":"{azure_resource_manager_claims}",
-        "correlationId":"54ef1e39-6a82-44b3-abc1-bdeb6ce4d3c6",
-        "httpRequest":"",
-        "resourceProvider":"Microsoft.EventGrid",
-        "resourceUri":"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501",
-        "operationName":"Microsoft.EventGrid/eventSubscriptions/write",
-        "status":"Succeeded",
-        "subscriptionId":"{subscription-id}",
-        "tenantId":"72f988bf-86f1-41af-91ab-2d7cd011db47"
-    }
-}
-```
-[Documentation](https://docs.microsoft.com/en-us/azure/event-grid/event-schema)
-
-### Google - Cloud Functions (potential future)
-```
-{
-  "data": {
-    "@type": "types.googleapis.com/google.pubsub.v1.PubsubMessage",
-    "attributes": {
-      "foo": "bar",
-     },
-     "messageId": "12345",
-     "publishTime": "2017-06-05T12:00:00.000Z",
-     "data": "somebase64encodedmessage"
-  },
-  "context": {
-    "eventId": "12345",
-    "timestamp": "2017-06-05T12:00:00.000Z",
-    "eventTypeId": "google.pubsub.topic.publish",
-    "resource": {
-      "name": "projects/myProject/topics/myTopic",
-      "service": "pubsub.googleapis.com"
-    }
-  }
-}
-```
-
-### AWS - SNS
-```
-{
-  "Records": [
-    {
-      "EventVersion": "1.0",
-      "EventSubscriptionArn": eventsubscriptionarn,
-      "EventSource": "aws:sns",
-      "Sns": {
-        "SignatureVersion": "1",
-        "Timestamp": "1970-01-01T00:00:00.000Z",
-        "Signature": "EXAMPLE",
-        "SigningCertUrl": "EXAMPLE",
-        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
-        "Message": "Hello from SNS!",
-        "MessageAttributes": {
-          "Test": {
-            "Type": "String",
-            "Value": "TestString"
-          },
-          "TestBinary": {
-            "Type": "Binary",
-            "Value": "TestBinary"
-          }
-        },
-        "Type": "Notification",
-        "UnsubscribeUrl": "EXAMPLE",
-        "TopicArn": topicarn,
-        "Subject": "TestInvoke"
-      }
-    }
-  ]
-}
-```
-[Documentation](http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html)
-
-### AWS - Kinesis
-```
-{
-  "Records": [
-    {
-      "eventID": "shardId-000000000000:49545115243490985018280067714973144582180062593244200961",
-      "eventVersion": "1.0",
-      "kinesis": {
-        "partitionKey": "partitionKey-3",
-        "data": "SGVsbG8sIHRoaXMgaXMgYSB0ZXN0IDEyMy4=",
-        "kinesisSchemaVersion": "1.0",
-        "sequenceNumber": "49545115243490985018280067714973144582180062593244200961"
-      },
-      "invokeIdentityArn": identityarn,
-      "eventName": "aws:kinesis:record",
-      "eventSourceARN": eventsourcearn,
-      "eventSource": "aws:kinesis",
-      "awsRegion": "us-east-1"
-    }
-  ]
-}
-```
-
-### IBM - OpenWhisk - Web Action Event
-```
-{
-  "__ow_method": "post",
-  "__ow_headers": {
-    "accept": "*/*",
-    "connection": "close",
-    "content-length": "4",
-    "content-type": "text/plain",
-    "host": "172.17.0.1",
-    "user-agent": "curl/7.43.0"
-  },
-  "__ow_path": "",
-  "__ow_body": "Jane"
-}
-```


### PR DESCRIPTION
addresses https://github.com/cloudevents/spec/issues/19

- named directory `/about` since that is the name of the directory in work-in-progress PR https://github.com/cloudevents/spec/pull/53
- proposed `/landscape` sub-directory, since I thought it would be nice to refactor this later into an area with a page for each product/software that implements this type of a system -- currently is for historical context, but in the future could contain references to systems that implement the spec

Signed-off-by: Sarah Allen <sarahallen@google.com>