### PR TITLE
Definition "Event" #85

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -71,8 +71,8 @@ about to perform a scheduled reboot.
 #### Event
 An "event" is a data record expressing an occurrence and its context. Events
 are routed from the emitting source to interested parties for the purpose of
-notifying them about the source occurrence. The routing may be performed based
-on information contained in the event, but an event will generally not identify
+notifying them about the source occurrence. The routing can be performed based
+on information contained in the event, but an event will not identify
 a specific routing destination.
 
 #### Context

--- a/spec.md
+++ b/spec.md
@@ -69,13 +69,11 @@ go into an alert state because the battery is low, or a virtual machine is
 about to perform a scheduled reboot.
 
 #### Event
-Data representing an occurrence, a change in state, that something happened
-(or did not happen).  Events include context and data.  Each occurrence MAY be
-uniquely identified with data in the event. Events ought not to be confused
-with messages which are used to transport or distribute data without assumptions
-regarding its semantic. Events are considered to be facts that have no given
-destination. Events are used to notify other systems that something has
-happened.
+An "event" is a data record expressing an occurrence and its context. Events
+are routed from the emitting source to interested parties for the purpose of
+notifying them about the source occurrence. The routing may be performed based
+on information contained in the event, but an event will generally not identify
+a specific routing destination.
 
 #### Context
 A set of consistent metadata attributes included with the event about the


### PR DESCRIPTION
Closes: https://github.com/cloudevents/spec/issues/85

Eliminating overlap with occurrence definition. Also taking out the delineation from message since that's not a defining characteristic.