### PR TITLE
Definition "Context" #86

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -80,8 +80,8 @@ destination. Events are used to notify other systems that something has happened
 #### Context
 A set of metadata attributes included with the event that describe circumstances
 of the occurrence which are not specific to the occurrence. Tools and application
-code may use context information to identify the relationship of events to aspects of
-the system or to other events. Context attributes may describe the event source,
+code can use context information to identify the relationship of events to aspects of
+the system or to other events. Context attributes describe the event source,
 the originating system, the emitting process, and other circumstantial information.
 
 #### Message

--- a/spec.md
+++ b/spec.md
@@ -78,11 +78,12 @@ regarding its semantic. Events are considered to be facts that have no given
 destination. Events are used to notify other systems that something has happened.
 
 #### Context
-A set of metadata attributes included with the event that describe circumstances
-of the occurrence which are not specific to the occurrence. Tools and application
-code can use context information to identify the relationship of events to aspects of
-the system or to other events. Context attributes describe the event source,
-the originating system, the emitting process, and other circumstantial information.
+As described in the Event definition, an Event contains two parts, the data
+representing the Occurrence and additional metadata that provides other
+circumstantial information about the Occurrence (e.g. information about the
+originating system). This additional metadata is referred to as Context data.
+Tools and application code can use this information to identify the
+relationship of Events to aspects of the system or to other Events.
 
 #### Message
 Events are transported from a source to a destination via messages.

--- a/spec.md
+++ b/spec.md
@@ -78,10 +78,11 @@ regarding its semantic. Events are considered to be facts that have no given
 destination. Events are used to notify other systems that something has happened.
 
 #### Context
-A set of consistent metadata attributes included with the event about the
-occurrence that tools and developers can rely upon to better handle the event.
-These attributes describe the event and the structure of its data, include
-information about the originating system, and more.
+A set of metadata attributes included with the event that describe circumstances
+of the occurrence which are not specific to the occurrence. Tools and application
+code may use context information to identify the relationship of events to aspects of
+the system or to other events. Context attributes may describe the event source,
+the originating system, the emitting process, and other circumstantial information.
 
 #### Message
 Events are transported from a source to a destination via messages.


### PR DESCRIPTION
Closes: https://github.com/cloudevents/spec/issues/86

Clarification that context information describes the circumstances of the event and not the occurrence per-se.