### PR TITLE
Renaming/broadening "source" to "topic", consolidating source-id/source-type into "subject"

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -161,9 +161,11 @@ that contains both context and data).
   system might identify the CRM system as the "source", might further qualify the
   event as 'new-customer-added' in the "event-type" relative to its "namespace",
   and then further qualify the subject of the event (the new record) with the content
-  of this field. The subject is a free-form string defined by the publisher.
+  of this property. The subject is a free-form string defined by the publisher. The
+  property is optional, because the subject might already be self-evident from 
+  the "source" context.
 * Constraints:
-  * OPTIONAL. The subject may be self-evident from the "source" context.
+  * OPTIONAL 
 * Examples:
   * File system event, a newly created file being the subject, with a partial URI 
     relative to the source URI: /data/app/alice.txt

--- a/spec.md
+++ b/spec.md
@@ -161,11 +161,9 @@ that contains both context and data).
   system might identify the CRM system as the "source", might further qualify the
   event as 'new-customer-added' in the "event-type" relative to its "namespace",
   and then further qualify the subject of the event (the new record) with the content
-  of this property. The subject is a free-form string defined by the publisher. The
-  property is optional, because the subject might already be self-evident from 
-  the "source" context.
+  of this property. The subject is a free-form string defined by the publisher. 
 * Constraints:
-  * OPTIONAL 
+  * OPTIONAL. The subject might already be self-evident from the "source" context. 
 * Examples:
   * File system event, a newly created file being the subject, with a partial URI 
     relative to the source URI: /data/app/alice.txt

--- a/spec.md
+++ b/spec.md
@@ -154,24 +154,21 @@ that contains both context and data).
   * REQUIRED
   * MUST contain at least one non-empty sub-property.
 
-### source-type
+### subject
 * Type: String
-* Description: Type of the event source. Providers define list of event
-  sources.
+* Description: Identifies the subject of the event in relation to the source.
+  For example, a notification about a new customer record being added to a CRM
+  system might identify the CRM system as the "source", might further qualify the
+  event as 'new-customer-added' in the "event-type" relative to its "namespace",
+  and then further qualify the subject of the event (the new record) with the content
+  of this field. The subject is a free-form string defined by the publisher.
 * Constraints:
-  * REQUIRED
-  * MUST be a non-empty string
+  * OPTIONAL. The subject may be self-evident from the "source" context.
 * Examples:
-  * s3
-
-### source-id
-* Type: String
-* Description: ID of the event source.
-* Constraints:
-  * REQUIRED
-  * MUST be a non-empty string
-* Examples:
-  * my.s3.bucket
+  * File system event, a newly created file being the subject, with a partial URI 
+    relative to the source URI: /data/app/alice.txt
+  * Customer relationship management (CRM) solution event, new customer record being 
+    the subject, with fully qualified URI: https://example.com/crm/c/2662773
 
 ### event-id
 * Type: String

--- a/spec.md
+++ b/spec.md
@@ -146,29 +146,48 @@ that contains both context and data).
   * REQUIRED
   * MUST be a non-empty string
 
-### source
-* Type: Object
-* Description: This describes the software instance that emits the event at
-  runtime (i.e. the producer). It contains sub-properties (listed below)
+### topic
+* Type: String
+* Description: This expression is a classification of the event that 
+  enables groupwise publishing of and subscription to events of the 
+  described class. The classification might reflect the identity of 
+  the party raising the event, and/or the context of where and/or why 
+  the event was raised, and/or a structured classification of the 
+  information contained in the event. The value SHOULD be a URI. 
+  The value MAY be used to map directly to the "topic" concept found
+  in many middleware products. The value MAY also be a interpreted as 
+  a URL. The topic property value's scope is set by the "namespace" 
+  property. 
 * Constraints:
   * REQUIRED
-  * MUST contain at least one non-empty sub-property.
+* Examples:
+  * Resource path, relative URI reference: 
+    /tenant/group/type/myresource
+  * Machine component, relative URI reference:
+    /robot/drives/3/temperature
+  * US City, relative URI reference:
+    /USA/Alaska/Juneau
+  * Virtual machine alerting, URI with custom scheme: 
+    alerts://mymachine.example.com/
+  * Web service notification triggers, URI/URL network resolvable: 
+    https://myservice.example.com, https://myservice.example.com/mytrigger   
 
 ### subject
 * Type: String
-* Description: Identifies the subject of the event in relation to the source.
-  For example, a notification about a new customer record being added to a CRM
-  system might identify the CRM system as the "source", might further qualify the
-  event as 'new-customer-added' in the "event-type" relative to its "namespace",
-  and then further qualify the subject of the event (the new record) with the content
-  of this property. The subject is a free-form string defined by the publisher. 
+* Description: Identifies the subject of the event in relation to the topic.
+  For example, a notification about a new customer record being added to 
+  a CRM system might identify a CRM system's tenant as the ´topic´, might 
+  further qualify the ´event-type´ as 'new-customer-added', and then further 
+  qualify the subject of the event (the new record) with the content of this 
+  property. The subject is a free-form string defined by the publisher. 
 * Constraints:
-  * OPTIONAL. The subject might already be self-evident from the "source" context. 
+  OPTIONAL. The subject might already be self-evident from the "source" context. 
 * Examples:
-  * File system event, a newly created file being the subject, with a partial URI 
-    relative to the source URI: /data/app/alice.txt
-  * Customer relationship management (CRM) solution event, new customer record being 
-    the subject, with fully qualified URI: https://example.com/crm/c/2662773
+  * File system event, with `topic` reflecting the emitting storage container,
+    and the newly created file-name being the subject, a partial URI 
+    relative to the source URI: `/data/app/alice.txt`.
+  * Customer relationship management (CRM) solution event, new customer record 
+    being the subject, with fully qualified URI: https://example.com/crm/c/2662773
 
 ### event-id
 * Type: String


### PR DESCRIPTION
See issue https://github.com/cloudevents/spec/issues/94

Restated "source-id" as "subject", which now more clearly serving to qualify the event in relation to the source, which is missing as an explicit concept. I also dropped the "source-type" in this proposal as we already have namespace/event-type as event qualifier and namespace/source/subject as context qualifiers. 