### PR TITLE
Proposed clarification of "source" #82

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -149,18 +149,22 @@ that contains both context and data).
 ### source
 * Type: String
 * Description: This property identifies the source of the event as defined
-  by the publishing organization. The value SHOULD be a URI. The source property
-  value MUST uniquely identify the source within the scope set by the "namespace"
-  property. While the value MAY be a interpreted as a URL, the purpose of
-  it to logically identify the source and not to establish the location of the 
-  event source on the network.
+  by the publishing organization. The value SHOULD be a URI. The source 
+  property value MUST uniquely identify the source within the scope set by the
+  "namespace" property. While the value MAY be a interpreted as a URL, the 
+  purpose of it to logically identify the source and not to establish the 
+  location of the event source on the network.
 * Constraints:
   * REQUIRED
 * Examples:
-  * Resource path, relative URI reference: /tenant/group/type/myresource
-  * Machine component, relative URI reference: /robot/drives/3/temperature
-  * Virtual machine alerting, URI with custom scheme: alerts://mymachine.example.com/
-  * Web service notification triggers, URI/URL network resolvable: https://myservice.example.com
+  * Resource path, relative URI reference: 
+    /tenant/group/type/myresource
+  * Machine component, relative URI reference:
+    /robot/drives/3/temperature
+  * Virtual machine alerting, URI with custom scheme: 
+    alerts://mymachine.example.com/
+  * Web service notification triggers, URI/URL network resolvable: 
+    https://myservice.example.com
 
 ### source-type
 * Type: String

--- a/spec.md
+++ b/spec.md
@@ -147,12 +147,20 @@ that contains both context and data).
   * MUST be a non-empty string
 
 ### source
-* Type: Object
-* Description: This describes the software instance that emits the event at
-  runtime (i.e. the producer). It contains sub-properties (listed below)
+* Type: String
+* Description: This property identifies the source of the event as defined
+  by the publishing organization. The value SHOULD be a URI. The source property
+  value MUST uniquely identify the source within the scope set by the "namespace"
+  property. While the value MAY be a interpreted as a URL, the purpose of
+  it to logically identify the source and not to establish the location of the 
+  event source on the network.
 * Constraints:
   * REQUIRED
-  * MUST contain at least one non-empty sub-property.
+* Examples:
+  * Resource path, relative URI reference: /tenant/group/type/myresource
+  * Machine component, relative URI reference: /robot/drives/3/temperature
+  * Virtual machine alerting, URI with custom scheme: alerts://mymachine.example.com/
+  * Web service notification triggers, URI/URL network resolvable: https://myservice.example.com
 
 ### source-type
 * Type: String


### PR DESCRIPTION
Last week's discussion and issue https://github.com/cloudevents/spec/issues/82 
Supporting: https://github.com/cloudevents/spec/issues/94 

This is a proposed clarification of "source", also as a follow-up to last week's debate about the structure of the "source" property (with Matt and myself advocating for a URI). 

As discussed last week, I will support this tomorrow with a brief scenario description of event routing from within industrial automation and other contexts with segmented networking, where considering the "source" value as being a network-resolvable address from the event consumer perspective is impractical, and using hierarchical identifiers has yet proven sufficient. 