### PR TITLE
clarify namespace to explicitly declare the convention used in the examples

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -110,7 +110,10 @@ that contains both context and data).
 ### namespace
 * Type: String
 * Description: Identifier that uniquely identifies the organization publishing
-  the event.
+  the event. It is important to prevent collisions and to make it possible to
+  identify the owner of a namespace. To accomplish these two goals,
+  organizations SHOULD use a prefix based on their domain name, expressed in
+  reverse order.
 * Constraints:
   * REQUIRED
   * MUST be a non-empty string


### PR DESCRIPTION
The examples of values for `namespace` both use the convention of a domain name in reverse order to identify an organization. This convention is the same as to https://tools.ietf.org/html/rfc7595 when suggesting how to namespace URI schemes.  Borrowing language from that RFC to clarify how to declare `namespace` in this spec.