### PR TITLE
Fix some syntax issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,8 @@ Each PR must be signed per the following section.
 
 ### Assigning and Owning work
 
-If you want to own and work on an issue, add a comment or “#dibs” it asking 
-about ownership. A maintainer will then add the Assigned label and modify 
+If you want to own and work on an issue, add a comment or “#dibs” it asking
+about ownership. A maintainer will then add the Assigned label and modify
 the first comment in the issue to include `Assigned to: @person`
 
 

--- a/references.md
+++ b/references.md
@@ -5,7 +5,8 @@ Examples of current event formats that exist today.
 ### Microsoft - Event Grid
 ```
 {
-    "topic":"/subscriptions/{subscription-id}",        "subject":"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501",
+    "topic":"/subscriptions/{subscription-id}",
+    "subject":"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501",
     "eventType":"Microsoft.Resources.ResourceWriteSuccess",
     "eventTime":"2017-08-16T03:54:38.2696833Z",
     "id":"25b3b0d0-d79b-44d5-9963-440d4e6a9bba",

--- a/spec.md
+++ b/spec.md
@@ -75,7 +75,8 @@ Data representing an occurrence, a change in state, that something happened
 uniquely identified with data in the event. Events ought not to be confused
 with messages which are used to transport or distribute data without assumptions
 regarding its semantic. Events are considered to be facts that have no given
-destination. Events are used to notify other systems that something has happened.
+destination. Events are used to notify other systems that something has
+happened.
 
 #### Context
 A set of consistent metadata attributes included with the event about the
@@ -225,7 +226,7 @@ that contains both context and data).
 ### data
 * Type: Arbitrary payload
 * Description: The event payload. The payload depends on the event-type,
-  schema-url and event-type-version, the pyload is encoded into a media format 
+  schema-url and event-type-version, the payload is encoded into a media format 
   which is specified by the content-type attribute (e.g. application/json).
 * Constraints:
   * OPTIONAL


### PR DESCRIPTION
- spelling mistake
- wrap at 80 chars
- remove trailing spaces
- put json properties on their own lines

Signed-off-by: Doug Davis <dug@us.ibm.com>