### PR TITLE
First pass at an 'extension attributes' doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ verify:
 	@# Use "-x" if you want to skip exernal links
 	@tools/verify-links.sh -v .
 	@echo Running the RFC2119 keyword checker:
-	@tools/verify-phrases.sh -v spec.md
+	@tools/verify-phrases.sh -v spec.md extensions.md

--- a/extensions.md
+++ b/extensions.md
@@ -1,0 +1,23 @@
+# CloudEvents Extension Attributes
+
+The [CloudEvents specification](spec.md) defines a set of metadata attributes
+than can be used when tranforming a generic event into a CloudEvent.
+The list of attributes specified in that document represent the minimal set
+that the specification authors deemed most likely to be used in a majority of
+situations.
+
+This document defines some addition attributes that, while not as commonly
+used as the ones specified in the [CloudEvents specification](spec.md),
+could still benefit from being formally specified in the hopes of providing
+some degree of interoperabilty. This also allows for attributes to be
+defined in an experimental manner and tested prior to being considered for
+inclusion in the [CloudEvents specification](spec.md).
+
+Implementations of the [CloudEvents specification](spec.md) are not mandated
+to limit their use of extension attributes to just the ones specified in
+this document. The attributes defined in this document have no official
+standing and might be changed, or removed, at any time.
+
+## Extension Attributes
+
+None at this time.

--- a/spec.md
+++ b/spec.md
@@ -216,6 +216,8 @@ that contains both context and data).
   middleware might want to include and provides a place to test metadata before
   adding them to the CloudEvents specification. TBD - Determine a shorter
   prefix for this (e.g. OpenAPI uses “x-”)
+  See the [Extensions](extensions.md) document for a list of possible
+  properties.
 * Constraints:
   * OPTIONAL
   * If present, MUST contain at least one entry


### PR DESCRIPTION
There is a strong desire by the WG to keep the list of attributes we include in the specification down to the minimum necessary to achieve our goals. However, there have been some attributes proposed that seem to be popular in some usecases, but just not enough usecases to cross the threshold of being included in the spec as formal attributes. We've talked about possibly having a spot to put those attributes so they can be used as extensions - then at least there's the possibility of some amount of interop around them even if they have no official standing from our WG.

To that end, this PR proposes a starting doc to host some extensions that people can use.

Signed-off-by: Doug Davis <dug@us.ibm.com>