### PR TITLE
idea for more async process to improve WG meetings

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -3,16 +3,31 @@
 This document describes the governance process under which the Serverless
 Working Group (WG) will manage this repository.
 
-## Working Group Meetings
+## Working Group Process
 
 In order to provide equitable rights to all Working Group members,
 the following process will be followed:
 
 * Official WG meetings will be announced at least a week in advance.
-* Proposed changes to any document will be done via a Pull Request (PR).
-* PRs will be reviewed during official WG meetings.
-* During meetings, priority will be given to PRs that appear to be ready for
-  a vote over those that appear to require discussions.
+* Proposed changes to any document will be done via a Pull Request (PR)
+* PRs will be reviewed in advance of WG meetings
+* Active members will vote on PRs in advance of Working Group meetings to
+  promote them to active consideration
+* Changes to the [spec.md](spec.md) require active member participation:
+  * if there are no negative votes, then any PR with 3 affirmative votes can be
+    raised for consideration
+  * if there are negative votes, then 5 affirmative votes and a code sample
+  illustrating the benefit of the change or drawback of current spec which would
+  be addressed by the change
+* Changes outside of the spec require only a single affirmative vote from
+  another active member for consideration
+* Working Group will discuss PRs under consideration at Working Group meetings
+  in advance of merging any PR (see details below)
+
+
+## Working Group Meetings
+* During meetings, priority will be given to PRs with the most votes from
+  active members
 * PRs should not be merged if they have had substantial changes made within
   two days of the meeting.
   Rebases, typo fixes, etc. do not count as substantial.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -11,8 +11,8 @@ the following process will be followed:
 * Official WG meetings will be announced at least a week in advance.
 * Proposed changes to any document will be done via a Pull Request (PR)
 * PRs will be reviewed in advance of WG meetings
-* Active members will vote on PRs in advance of Working Group meetings to
-  promote them to active consideration
+* [Active Members](#active-members) will vote on PRs in advance of Working Group
+  meetings to promote them to active consideration
 * Changes to the [spec.md](spec.md) require active member participation:
   * if there are no negative votes, then any PR with 3 affirmative votes can be
     raised for consideration
@@ -52,21 +52,27 @@ merged:
 * PRs that have objections/concerns will be discussed off-line by interested
   parties. A resolution, updated PR, will be expected from those talks.
 
-## Voting
+## Active Members
 
-If a vote is taken during a WG meeting, the follow rules will be followed:
+Membership in the Serverless WG is based on a paricipating company,
+organization or nonaffiliated individual.
 
-* There is only 1 vote per participating company, or nonaffiliated individual.
-* Each participating company can assign a primary and secondary representative.
-* A participating company, or nonaffiliated individual, attains voting rights
-  by having any of their assigned representative(s) attend 3 out of the last
-  4 meetings. They obtain voting rights after the 3rd meeting, not during.
-* Only WG members with voting rights will be allowed to vote.
-* A vote passes if more than 50% of the votes cast approve the motion.
-* Only "yes" or "no" votes count, "abstain" votes do not count towards the
-  total.
+* Each participating company or organization may assign a primary and secondary
+  representative.
+* A participating company, or nonaffiliated individual, is considered an
+  **Active Member** by having any of their assigned representative(s) attend
+  3 out of the last 4 meetings. They obtain voting rights after the 3rd meeting,
+  not during.
 * Meeting attendence will be formally tracked
   [here](https://docs.google.com/spreadsheets/d/1bw5s9sC2ggYyAiGJHEk7xm-q2KG6jyrfBy69ifkdmt0/edit#gid=0).
   Members must acknowledge their presence verbally, meaning, adding yourself
   to the "Attendees" section of the Agenda document is not sufficient.
 
+## Voting
+
+If a vote is taken during a WG meeting, the follow rules will be followed:
+
+* Only [Active Members](#active-members) will be allowed to vote.
+* A vote passes if more than 50% of the votes cast approve the motion.
+* Only "yes" or "no" votes count, "abstain" votes do not count towards the
+  total.


### PR DESCRIPTION
factoring out the key point from https://github.com/cloudevents/spec/pull/16/files 
with the goal of fostering more async communication by:
1. prioritizing PRs with most support by active members (which I hope/expect will lead to more active review and commenting in advance of meetings)
2. require more evidence (via code sample) that a change is required if there are minority voices who disagree with a change