### PR TITLE
Propose holistic simplification of source- attributes

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -162,9 +162,9 @@ that contains both context and data).
   * myorg/myrepo
   * my/long/ftp/path.jpg
 
-### source-attributes
+### source-labels
 * Type: Map <String, String>
-* Description: Attributes associated with the resource that emitted the event.
+* Description: Labels associated with the resource that emitted the event.
   This allows filtering or routing based on non-hierarchical source metadata.
   This is intended to include (but is not limited to) "labels" in cloud
   platforms like AWS or Kubernetes.

--- a/spec.md
+++ b/spec.md
@@ -107,27 +107,19 @@ the event data. The context might also need to be serialized with the event
 data for some use cases (e.g. a JSON implementation might use one JSON object
 that contains both context and data).
 
-### namespace
-* Type: String
-* Description: Identifier that uniquely identifies the organization publishing
-  the event.
-* Constraints:
-  * REQUIRED
-  * MUST be a non-empty string
-* Examples:
-  * kafka.apache.org
-  * com.microsoft.azure
-
 ### event-type
 * Type: String
-* Description: Type of the event `data`. Producers can specify the format of
-  this, depending on their service. This enables the interpretation of `data`,
-  and can be used for routing, policy and more.
+* Description: Type of occurrence which has happened. The event type MUST be
+  namespaced with a package based on the reverse-DNS of a domain associated
+  with the software that produced the event. This MAY be used for routing,
+  observability, policy enforcement, etc.
 * Constraints:
   * REQUIRED
   * MUST be a non-empty string
+  * MUST be prefixed with a reverse-DNS name associated with the software that
+         produces the event
 * Examples:
-  * customer.created
+  * com.github.pull.create
 
 ### event-type-version
 * Type: String
@@ -146,32 +138,46 @@ that contains both context and data).
   * REQUIRED
   * MUST be a non-empty string
 
-### source
-* Type: Object
-* Description: This describes the software instance that emits the event at
-  runtime (i.e. the producer). It contains sub-properties (listed below)
-* Constraints:
-  * REQUIRED
-  * MUST contain at least one non-empty sub-property.
-
-### source-type
+### source-authority
 * Type: String
-* Description: Type of the event source. Providers define list of event
-  sources.
+* Description: The URI authority component of the source software.
 * Constraints:
   * REQUIRED
   * MUST be a non-empty string
+  * MUST conform to the
+   ["authority" component](https://tools.ietf.org/html/rfc3986#section-3.2)
+    of the URI spec
 * Examples:
-  * s3
+  * github.com
+  * myenterpriseGitHubInstall.company.com
 
-### source-id
-* Type: String
-* Description: ID of the event source.
+### source-path
+* Type: string
+* Description: The URI path component of the resource that emitted an event.
 * Constraints:
-  * REQUIRED
-  * MUST be a non-empty string
+  * OPTIONAL
+  * If present, MUST conform to the "path-rootless" grammar of the 
+    [URI spec](https://tools.ietf.org/html/rfc3986#section-3.3)
 * Examples:
-  * my.s3.bucket
+  * myorg/myrepo
+  * my/long/ftp/path.jpg
+
+### source-attributes
+* Type: Map <String, String>
+* Description: Attributes associated with the resource that emitted the event.
+  This allows filtering or routing based on non-hierarchical source metadata.
+  This is intended to include (but is not limited to) "labels" in cloud
+  platforms like AWS or Kubernetes.
+* Constraints:
+  * OPTIONAL
+  * Keys MUST match the regular expression `[_.a-z0-9]+`
+  * Keys SHOULD use the character "." is as namespace separator
+  * Values MUST use URI-safe characters
+* Examples:
+  * {
+      "sensor.configuration": "WINDOW"
+      "sensor.location": "deployments/house1/window3"
+    }
 
 ### event-id
 * Type: String

--- a/spec.md
+++ b/spec.md
@@ -171,7 +171,7 @@ that contains both context and data).
 * Constraints:
   * OPTIONAL
   * Keys MUST match the regular expression `[_.a-z0-9]+`
-  * Keys SHOULD use the character "." is as namespace separator
+  * Keys SHOULD use the character "." as a namespace separator
   * Values MUST use URI-safe characters
 * Examples:
   * {


### PR DESCRIPTION
## Overview ##

This PR drops source-types, applies namespacing to event-type and source, and clarifies that source path need not include the source-authority.

My goal is to build on Clemens' [Usage Scenarios](https://github.com/cloudevents/spec/pull/117) and revisit our attributes in related groups. This PR looks at event-type, namespace, and source, which are attributes that describe common metadata for the individual occurrence. I would like to cover the fields related to parsing data (event-type-version, schema-url, content-type) in a future PR.

## Changes ##
* Drops source-type; there is no clear use according to the usage
scenarios.
* Consolidates namespace and the source-authority
* Clarifies that source-path should not be redundant with
source-authority/namespace
* Adds namespacing to event-type
* Drops documentation for "source" that was redundant with each
  of its subfields. Opts for a name prefix instead.
* Leans on the URI spec to name parts of source (e.g. source-id is now source-path)

## Usage Scenarios ##
### IoT Case ###
This case demonstrates an IoT vendor who may use UUIDs for the sensors they sell and use non-hierarchical attributes for filtering/routing events in an event-connected system. Note that the IoT device's source may not be addressable from the Action which receives the event data.

```json
{
  "source-authority": "iotvendor.net",
  "source-path": "12345678901234-1234-1234-1234-12345678",
  "source-labels": {
    "sensor-type": "vibration",
    "sensor-deployment": "house1234",
    "sensor-location": "window",
  },
  "event-type": "net.iotvendor.window.break"
}
```

### Hosted service ###

This use case focuses on a developer who extends their application by receiving events from a managed cloud service.

```json
{
  "source-authority": "storage.googleapis.com",
  "source-path": "projects/_/buckets/myBucket/objects/foo/bar.jpg",
  "source-labels": {
    "tier": "preprod"
  },
  "event-type": "google.storage.object.archive"
}
```

### Deployed software ###

This case demonstrates the value of splitting the concept of "namespace" to both the event-type and the source. Here "bigcompany.com" has deployed GitHub enterprise inside their corporate network. The event-type is still associated with GitHub (the software author) and the source is associated with "bigcompany.com". This example shows a pull request creation event for the "project88/backend" repo.

```json
{
  "source-authority": "code.corp.bigcompany.com",
  "source-path": "project88/backend",
  "event-type": "com.github.pull.create"
}
```

I'd really like feedback related to:
* Whether routing software (one of the official use cases) have any requirements related to this pull request.
*  Do we need a maximum number of `source-labels`? If so, what is a reasonable upper bound?
* Should we specify that software MUST treat a missing `source-labels` the same as an empty `source-labels`?
* Should we specify rules for how event-type must be interpreted (e.g. using DNS rules: names are matched regardless of case, but SHOULD be returned in their original case)?