### PR TITLE
Add namespacing to event-type

### DIFF
--- a/serialization.md
+++ b/serialization.md
@@ -53,7 +53,7 @@ Example:
   "cloudEventsVersion": "0.1",
   "eventID": "6480da1a-5028-4301-acc3-fbae628207b3",
   "source": "http://example.com/repomanager",
-  "eventType": "created",
+  "eventType": "com.example.repro.create",
   "eventTypeVersion": "v1.5",
   "eventTime": "2018-04-01T23:12:34Z",
   "schemaURL": "https://product.example.com/schema/repo-create",

--- a/spec.md
+++ b/spec.md
@@ -269,8 +269,8 @@ that contains both context and data).
 * Constraints:
    * REQUIRED
    * MUST be a non-empty string
-   * SHOULD be prefixed with a reverse-DNS name associated with the software
-          that produces the event
+   * SHOULD be prefixed with a reverse-DNS name. The prefixed domain dictates
+            the organization which defines the semantics of this event type.
 * Examples
    * com.github.pull.create
 

--- a/spec.md
+++ b/spec.md
@@ -264,15 +264,13 @@ that contains both context and data).
 
 ### eventType
 * Type: String
-* Description: Type of occurrence which has happened. The event type MUST be
-  namespaced with a package based on the reverse-DNS of a domain associated
-  with the software that produced the event. This MAY be used for routing,
-  observability, policy enforcement, etc.
+* Description: Type of occurrence which has happened. Often this
+  property is used for routing, observability, policy enforcement, etc.
 * Constraints:
    * REQUIRED
    * MUST be a non-empty string
-   * MUST be prefixed with a reverse-DNS name associated with the software that
-          produces the event
+   * SHOULD be prefixed with a reverse-DNS name associated with the software
+          that produces the event
 * Examples
    * com.github.pull.create
 

--- a/spec.md
+++ b/spec.md
@@ -264,14 +264,17 @@ that contains both context and data).
 
 ### eventType
 * Type: String
-* Description: Type of the event `data`. Producers can specify the format of
-  this, depending on their service. This enables the interpretation of `data`,
-  and can be used for routing, policy and more.
+* Description: Type of occurrence which has happened. The event type MUST be
+  namespaced with a package based on the reverse-DNS of a domain associated
+  with the software that produced the event. This MAY be used for routing,
+  observability, policy enforcement, etc.
 * Constraints:
-  * REQUIRED
-  * MUST be a non-empty string
-* Examples:
-  * customer.created
+   * REQUIRED
+   * MUST be a non-empty string
+   * MUST be prefixed with a reverse-DNS name associated with the software that
+          produces the event
+* Examples
+   * com.github.pull.create
 
 ### eventTypeVersion
 * Type: String


### PR DESCRIPTION
## Overview ##
Add reverse-DNS namespacing to `event-type`.  This commit has been spliced off of https://github.com/cloudevents/spec/pull/129.

I agree that removing `namespace` from the spec was a step in the right direction because it was ambiguous what is being namespaced. This change proposes that event types are themselves namespaced. This can be important for any proxy or action that chooses to group related streams of events. As I've said before, there's a very big difference between "document.create" events when you're referring to a Word document or a Mongo document.

Updated seralization.md, including removing the "namespace" parameters that were already removed from spec.md.

## Usage Scenarios ##

### Hosted Software ###

A GitHub pull request event from github.com

```json
{
  "source-authority": "github.com",
  "source-path": "cloudevents/spec/pull/129",
  "event-type": "com.github.pull.create"
}
```

### Self-managed software ###

The same event on enterprise GitHub. Because the event is from the same software running in a new location, the source path and event type stay the same; only the source-authority changes.

```json
{
  "source-authority": "git.internal.mycompany.com",
  "source-path": "cloudevents/spec/pull/129",
  "event-type": "com.github.pull.create"
}
```

Closes: #32