### PR TITLE
Roadmap - Add deliverables to 0.1

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -12,18 +12,17 @@ The CloudEvents Roadmap.
 *0.1*
 
 * Draft specification that WG members agree *could* provide interoperability.
+* Include an initial set of use-cases for CloudEvents.
+* Include a specification for mapping the CloudEvents specification to HTTP.
+* Include a specification for mapping the CloudEvents specification to JSON.
+* Define a type system for CloudEvents values.
 * Document at least 3 sample events that conform to the specification.
 * Github repo is organized to be approachable to a engineers who might want to
 implement the spec.
-* Additional materials:
-  * Use-cases.
-  * Placeholder for protocol specification, folder and brief starter doc for
-  HTTP.
 * Finalize logo.
 * Create and deploy a website that features a simple overview, email list and directs visitors to Github.
 * Store all website assets in the CloudEvents repository, under the governance
 of the working group.
-
 
 *0.2*
 


### PR DESCRIPTION
This PR adds deliverables to 0.1:

* Include a specification for mapping the CloudEvents specification to HTTP.
* Include a specification for mapping the CloudEvents specification to JSON.
* Define a type system for CloudEvents values.

This PR also does minor clean-ups (that don't intend to change our intentions).