### PR TITLE
Add SHOULD constraint that source has an authority.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -287,6 +287,8 @@ that contains both context and data).
   semantics behind the data encoded in the URI is event producer defined.
 * Constraints:
   * REQUIRED
+  * SHOULD include an [authority
+    component](https://tools.ietf.org/html/rfc3986#section-3.2)
 
 ### event-id
 * Type: String


### PR DESCRIPTION
Events which contain an authority will be easier to route
(authority-specific subscriptions) or process.

It is intentionally undefined what the authority would contain.
It is possible that the authority references an private or public IP
addres, a gateway host, etc.