### PR TITLE
Remove "TBD" comment about extensions

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -340,8 +340,7 @@ that contains both context and data).
 * Description: This is for additional metadata and this does not have a
   mandated structure. This enables a place for custom fields a producer or
   middleware might want to include and provides a place to test metadata before
-  adding them to the CloudEvents specification. TBD - Determine a shorter
-  prefix for this (e.g. OpenAPI uses “x-”)
+  adding them to the CloudEvents specification.
   See the [Extensions](extensions.md) document for a list of possible
   properties.
 * Constraints:


### PR DESCRIPTION
We don't need the TBD since each mapping/serialization doc we produce
should state how extensions should appear. E.g. https://github.com/cloudevents/spec/pull/148

Closes: #125

Signed-off-by: Doug Davis <dug@us.ibm.com>