### PR TITLE
Roadmap - Add deliverables to 0.1

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -14,23 +14,22 @@ _Note: The ordered lists for each milestone provide a way to reference each item
 *0.1*
 
 1. Draft specification that WG members agree *could* provide interoperability.
+1. Include an initial set of use-cases for CloudEvents.
+1. Define a type system for CloudEvents values.
 1. Document at least 3 sample events that conform to the specification.
 1. Github repo is organized to be approachable to a engineers who might want to
 implement the spec.
-1. Use-cases.
-1. Placeholder for protocol specification, folder and brief starter doc for
-  HTTP.
 1. Finalize logo.
 1. Create and deploy a website that features a simple overview, email list and directs visitors to Github.
 1. Store all website assets in the CloudEvents repository, under the governance
 of the working group.
 
-
 *0.2*
 
 1. Have at least 2 implementations of the specification that can demonstrate interoperability.
+1. Include a specification for mapping the CloudEvents specification to HTTP.
+1. Include a specification for mapping the CloudEvents specification to JSON.
 1. Changes to the spec to facilitate adoption.
-1. HTTP protocol specification.
 1. Draft documentation and developer guide.
 1. Publicize at conferences ([CloudNativeCon Europe](https://events.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2018/)).
 


### PR DESCRIPTION
**Note:** This is a clone of #156 that was created to get around DCO issues.

This PR adds deliverables to 0.1:

Include a specification for mapping the CloudEvents specification to HTTP.
Include a specification for mapping the CloudEvents specification to JSON.
Define a type system for CloudEvents values.
This PR also does minor clean-ups (that don't intend to change our intentions).

Signed-off-by: Austen Collins austen@serverless.com