### PR TITLE
Define URIs to follow the URI-reference rule.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -259,8 +259,9 @@ The following abstract data types are available for use in attributes.
 - `Binary` - Sequence of bytes.
 - `Map` - `String`-indexed dictionary of `Object`-typed values
 - `Object` - Either a `String`, or a `Binary`, or a `Map`
-- `URI` - String expression as defined in
-  [RFC 3986](https://tools.ietf.org/html/rfc3986)
+- `URI` - String expression conforming to `URI-reference`
+  as defined in
+  [RFC 3986 §4.1](https://tools.ietf.org/html/rfc3986#section-4.1).
 - `Timestamp` - String expression as defined in
   [RFC 3339](https://tools.ietf.org/html/rfc3339)
 


### PR DESCRIPTION
URI-reference is a URI or relative-ref. This
now makes our existing examples meet the spec
as defined. Notably, this allows schemaless URIs.

Per 4/19 meeting, this will be merged as 0.1 if
it has sufficient approvals by then.

Signed-off-by: Thomas Bouldin <inlined@google.com>