### PR TITLE
Clarify contentType

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -357,7 +357,7 @@ that contains both context and data).
   rules for how the `data` attribute content is rendered for different
   `contentType` values are defined in the event format specifications; for
   example, the JSON event format defines the relationship in
-  [section 3.1](./json-format.md#3-1-special-handling-of-the-data-attribute).
+  [section 3.1](./json-format.md#31-special-handling-of-the-data-attribute).
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in

--- a/spec.md
+++ b/spec.md
@@ -351,13 +351,13 @@ that contains both context and data).
 * Description: Content type of the `data` attribute value. This attribute
   enables the `data` attribute to carry any type of content, whereby format
   and encoding might differ from that of the chosen event format. For example,
-  an event rendered using the [JSON envelope](./json-format#3-envelope)
+  an event rendered using the [JSON envelope](./json-format.md#3-envelope)
   format might carry an XML payload in its `data` attribute, and the
   consumer is informed by this attribute being set to "application/xml". The
   rules for how the `data` attribute content is rendered for different
   `contentType` values are defined in the event format specifications; for
   example, the JSON event format defines the relationship in
-  [section 3.1](./json-format/#3-1-special-handling-of-the-data-attribute).
+  [section 3.1](./json-format.md#3-1-special-handling-of-the-data-attribute).
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in

--- a/spec.md
+++ b/spec.md
@@ -348,7 +348,7 @@ that contains both context and data).
 
 ### contentType
 * Type: `String` per [RFC 2046](https://tools.ietf.org/html/rfc2046)
-* Description: Describe the data encoding format
+* Description: Describes the format and encoding of the `data` attribute
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in

--- a/spec.md
+++ b/spec.md
@@ -359,13 +359,17 @@ that contains both context and data).
   example, the JSON event format defines the relationship in
   [section 3.1](./json-format.md#31-special-handling-of-the-data-attribute).
   
+  When this attribute is omitted, the "data" attribute simply follows the 
+  event format's encoding rules. For the JSON event format, the "data" 
+  attribute value can therefore be a JSON object, array, or value.   
+  
   For the binary mode of some of the CloudEvents transport bindings,
   where the "data" content is immediately mapped into the payload of the
   transport frame, this field is directly mapped to the respective transport
   or application protocol's content-type metadata property. Normative rules
   for the binary mode and the content-type metadata mapping can be found 
   in the respective transport mapping specifications.
-  
+    
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in

--- a/spec.md
+++ b/spec.md
@@ -358,6 +358,14 @@ that contains both context and data).
   `contentType` values are defined in the event format specifications; for
   example, the JSON event format defines the relationship in
   [section 3.1](./json-format.md#31-special-handling-of-the-data-attribute).
+  
+  For the binary mode of some of the CloudEvents transport bindings,
+  where the "data" content is immediately mapped into the payload of the
+  transport frame, this field is directly mapped to the respective transport
+  or application protocol's content-type metadata property. Normative rules
+  for the binary mode and the content-type metadata mapping can be found 
+  in the respective transport mapping specifications.
+  
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in

--- a/spec.md
+++ b/spec.md
@@ -348,7 +348,16 @@ that contains both context and data).
 
 ### contentType
 * Type: `String` per [RFC 2046](https://tools.ietf.org/html/rfc2046)
-* Description: Describes the format and encoding of the `data` attribute
+* Description: Content type of the `data` attribute value. This attribute
+  enables the `data` attribute to carry any type of content, whereby format
+  and encoding might differ from that of the chosen event format. For example,
+  an event rendered using the [JSON envelope](./json-format#3-envelope)
+  format might carry an XML payload in its `data` attribute, and the
+  consumer is informed by this attribute being set to "application/xml". The
+  rules for how the `data` attribute content is rendered for different
+  `contentType` values are defined in the event format specifications; for
+  example, the JSON event format defines the relationship in
+  [section 3.1](./json-format/#3-1-special-handling-of-the-data-attribute).
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in


### PR DESCRIPTION
There has been a good deal of confusion about the role of contentType and whether it designates the contentType of the event per-se or of the event's data attribute. This change clarifies that it is meant to designate the content type of the latter. The content type of the event encoding is defined by the respective event format. 