### PR TITLE
Add event 'ordinal' field

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -318,6 +318,14 @@ that contains both context and data).
 * Constraints:
   * REQUIRED
   * MUST be a non-empty string
+  
+### ordinal
+* Type: `String`
+* Description: Value expressing the relative order of the event. This enables
+  interpretation of data supercedence.
+* Constraints:
+  * REQUIRED
+  * MUST be a non-empty lexicographically-orderable string
 
 ### source
 * Type: `URI`


### PR DESCRIPTION
Events are inherently ordered - and without such cannot be interpreted by their consumers. This change makes the order explicit, rather than a requirement of the transport. 

The ordinal should be *per aggregate instance*, and so I'd assume a `source` structured as `AggregateType/AggregateId#CorrelationId`, where `AggregateType/AggregateId/Ordinal` is essentially the address for an individual event. It might be worth calling out these values into separate fields, but that should be a separate PR.

Including the ordinal also allows simpler deduplication (valid are >= last processed ordinal, rather than a growing list of processed ids), as well as a simple mechanism to check for gaps (eg. if you've received event ordinals 1,2,3,6,7, it's easy to know you still need to wait for 4 & 5)