### PR TITLE
Added a bullet point in open-source.md for microBean CloudEvents

### DIFF
--- a/community/open-source.md
+++ b/community/open-source.md
@@ -2,6 +2,12 @@ If you have created (or know of) an open source library or product that
 uses CloudEvents, please include in the list below.
 
 Example:
+
 * [AwesomeLibrary](): descriptive text, consider additional links to docs or
   specific files, especially if the CloudEvents integration is deep in the repo
+* [microBean CloudEvents][microbean-cloudevents]: CloudEvents represented as
+  plain Java objects. Satellite projects add
+  [Jackson and CDI event integration][microbean-cloudevents-jackson-cdi].
 
+[microbean-cloudevents]: https://microbean.github.io/microbean-cloudevents/
+[microbean-cloudevents-jackson-cdi]: https://microbean.github.io/microbean-cloudevents-jackson-cdi


### PR DESCRIPTION
Hello; I've added a line in `community/open-source.md` pointing to my initial (tiny) CloudEvents-in-Java projects.  See [microBean CloudEvents][microbean-cloudevents] and [microBean CloudEvents Jackson/CDI integration][microbean-cloudevents-jackson-cdi] as initial sketches.

[microbean-cloudevents]: https://microbean.github.io/microbean-cloudevents
[microbean-cloudevents-jackson-cdi]: https://microbean.github.io/microbean-cloudevents-jackson-cdi