### PR TITLE
Add clarification for "implied" JSON content type to handle data attribute

### DIFF
--- a/community/open-source.md
+++ b/community/open-source.md
@@ -5,3 +5,14 @@ Example:
 * [AwesomeLibrary](): descriptive text, consider additional links to docs or
   specific files, especially if the CloudEvents integration is deep in the repo
 
+---
+
+* [CloudEvents.NET](https://github.com/aliencube/CloudEvents.NET): is a .NET
+  implementation of the CloudEvents [spec](spec.md) and
+  [HTTP transport binding](http-transport-binding.md). It has been released to
+  [nuget.org](https://www.nuget.org/packages?q=Aliencube.CloudEventsNet).
+  It also contains some app
+  [samples](https://github.com/aliencube/CloudEvents.NET/tree/master/sample)
+  of 1) console app to Web API, and 2) Web API to Azure Event Grid, which
+  demonstrates how a CloudEvent message is generated and sent to Web API over
+  HTTP, and to Azure Event Grid.

--- a/community/open-source.md
+++ b/community/open-source.md
@@ -8,8 +8,8 @@ Example:
 ---
 
 * [CloudEvents.NET](https://github.com/aliencube/CloudEvents.NET): is a .NET
-  implementation of the CloudEvents [spec](spec.md) and
-  [HTTP transport binding](http-transport-binding.md). It has been released to
+  implementation of the CloudEvents [spec](../spec.md) and
+  [HTTP transport binding](../http-transport-binding.md). It has been released to
   [nuget.org](https://www.nuget.org/packages?q=Aliencube.CloudEventsNet).
   It also contains some app
   [samples](https://github.com/aliencube/CloudEvents.NET/tree/master/sample)

--- a/community/open-source.md
+++ b/community/open-source.md
@@ -1,12 +1,6 @@
 If you have created (or know of) an open source library or product that
 uses CloudEvents, please include in the list below.
 
-Example:
-* [AwesomeLibrary](): descriptive text, consider additional links to docs or
-  specific files, especially if the CloudEvents integration is deep in the repo
-
----
-
 * [CloudEvents.NET](https://github.com/aliencube/CloudEvents.NET): is a .NET
   implementation of the CloudEvents [spec](../spec.md) and
   [HTTP transport binding](../http-transport-binding.md). It has been released to
@@ -14,5 +8,5 @@ Example:
   It also contains some app
   [samples](https://github.com/aliencube/CloudEvents.NET/tree/master/sample)
   of 1) console app to Web API, and 2) Web API to Azure Event Grid, which
-  demonstrates how a CloudEvent message is generated and sent to Web API over
-  HTTP, and to Azure Event Grid.
+  demonstrates how CloudEvent messages are generated and sent to Web API and
+  Azure Event Grid over HTTP.

--- a/spec.md
+++ b/spec.md
@@ -323,7 +323,7 @@ that contains both context and data).
 * Type: `URI`
 * Description: This describes the event producer. Often this will include
   information such as the type of the event source, the organization
-  publishing the event, and some unique idenfitiers. The exact syntax and
+  publishing the event, and some unique identifiers. The exact syntax and
   semantics behind the data encoded in the URI is event producer defined.
 * Constraints:
   * REQUIRED


### PR DESCRIPTION
As discussed in #208 , in order to avoid the `data` attribute from being inappropriately handled, I have added a paragraph for content types that imply JSON media type, which helps implement the [spec.md](../blob/master/spec.md).