### PR TITLE
Add an example to the spec and clean-up a little

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The following specifications are available:
 There is also the [CloudEvents Extension Attributes](https://github.com/cloudevents/spec/blob/master/extensions.md)
 document.
 
+Included within this repository are some documents that helped guide the
+working group's design decisions. They include:
+- [Use-Cases](about/use-cases.md) from the community
+- [Existing events](about/references.md) from some popular implementations
+  in the community
+
 ## Community
 
 Learn more about the people and organizations who are creating a dynamic

--- a/spec.md
+++ b/spec.md
@@ -12,11 +12,13 @@ This document is a working draft.
 ## Table of Contents
 - [Overview](#overview)
 - [Design Goals](#design-goals)
+- [Non-Goals](#non-goals)
+- [Usage Scenarios](#usage-scenarios)
 - [Notations and Terminology](#notations-and-terminology)
+- [Type System](#type-system)
 - [Context Attributes](#context-attributes)
 - [Data Attribute](#data-attribute)
-- [Use-Cases](about/use-cases.md)
-- [References](about/references.md)
+- [Example](#example)
 
 ## Overview
 Events are everywhere. However, event publishers tend to describe events
@@ -400,3 +402,22 @@ encapsulated within the `data` attribute.
 * Constraints:
   * OPTIONAL
 
+# Example
+
+The following example shows a CloudEvent serialized as JSON:
+
+``` JSON
+{
+    "cloudEventsVersion" : "0.1",
+    "eventType" : "com.example.someevent",
+    "eventTypeVersion" : "1.0",
+    "source" : "/mycontext",
+    "eventID" : "A234-1234-1234",
+    "eventTime" : "2018-04-05T17:31:00Z",
+    "extensions" : {
+        "comExampleExtension" : "value"
+    },
+    "contentType" : "text/xml",
+    "data" : "<much wow=\"xml\"/>"
+}
+```


### PR DESCRIPTION
I found it a bit odd that the spec never included an example CloudEvent.
People would have to go to one of the other docs to actually see what
one looked like. For me, its sometimes easier to full understand something
when I can see a real example of what is being defined. Having people leave
our doc to see one felt odd so I just copied one from the JSON mapping spec.

While in there I noticed that our TOC wasn't consistent w.r.t. what we
included so I put all 1st and 2nd level headings in there (excluding the
ones before the TOC).

Also, the TOC included references to two docs w/o any explanation around
them - the usecases and example events from some popular eventing systems.
None of these are normative so they felt really odd to be in our spec's
TOC. However, since they are useful bits of information, I added a pointer
to them from our README instead. This also provides a bit of explanation
about why they exist in our repo at all.

Signed-off-by: Doug Davis <dug@us.ibm.com>