### PR TITLE
Add extension for Distributed Tracing spec.

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -30,13 +30,14 @@ platforms like Prometheus are built.
  
 #### traceparent
 * Type: `String`
-* Description: Contains a a trace ID, span ID, and trace options as defined in
+* Description: Contains a trace ID, span ID, and trace options as defined in
   [section 2.2.2](https://w3c.github.io/distributed-tracing/report-trace-context.html#field-value)
 * Constraints
   * REQUIRED
-  * To integrate with Distributed Tracing, this field MUST NOT use standard
-    extension encoding over HTTP(S). `distributedTracing.traceparent` MUST
-    instead be marshaled as the `traceparent` HTTP header.
+  * To integrate with Distributed Tracing, this field MUST NOT use the normal
+    [extension encoding over HTTP(S)](http-transport-binding.md).
+    `distributedTracing.traceparent` MUST instead be marshaled as 
+    the `traceparent` HTTP header.
 
 #### tracestate
 * Type: `String`
@@ -44,6 +45,7 @@ platforms like Prometheus are built.
   [section 2.3.2](https://w3c.github.io/distributed-tracing/report-trace-context.html#header-value).
 * Constraints
   * OPTIONAL
-  * To integrate with Distributed Tracing, this field MUST NOT use standard
-    extension encoding over HTTP(S). `distributedTracing.tracestate` MUST
-    instead be marshaled as the `tracestate` HTTP header.
+  * To integrate with Distributed Tracing, this field MUST NOT use the normal
+    [extension encoding over HTTP(S)](http-transport-binding.md).
+    `distributedTracing.tracestate` MUST instead be marshaled as the
+    `tracestate` HTTP header.

--- a/extensions.md
+++ b/extensions.md
@@ -1,7 +1,7 @@
 # CloudEvents Extension Attributes
 
 The [CloudEvents specification](spec.md) defines a set of metadata attributes
-than can be used when tranforming a generic event into a CloudEvent.
+than can be used when transforming a generic event into a CloudEvent.
 The list of attributes specified in that document represent the minimal set
 that the specification authors deemed most likely to be used in a majority of
 situations.
@@ -20,4 +20,30 @@ standing and might be changed, or removed, at any time.
 
 ## Extension Attributes
 
-None at this time.
+### distributedTracing
+
+This extension embeds context from 
+[Distributed Tracing](https://w3c.github.io/distributed-tracing/report-trace-context.html)
+so that distributed systems can include traces that span an event-driven system.
+This is the foundation of many other systems, such as Open Tracing, on which
+platforms like Prometheus are built.
+ 
+#### traceparent
+* Type: `String`
+* Description: Contains a a trace ID, span ID, and trace options as defined in
+  [section 2.2.2](https://w3c.github.io/distributed-tracing/report-trace-context.html#field-value)
+* Constraints
+  * REQUIRED
+  * To integrate with Distributed Tracing, this field MUST NOT use standard
+    extension encoding over HTTP(S). `distributedTracing.traceparent` MUST
+    instead be marshaled as the `traceparent` HTTP header.
+
+#### tracestate
+* Type: `String`
+* Description: a comma-delimited list of key-value pairs, defined by
+  [section 2.3.2](https://w3c.github.io/distributed-tracing/report-trace-context.html#header-value).
+* Constraints
+  * OPTIONAL
+  * To integrate with Distributed Tracing, this field MUST NOT use standard
+    extension encoding over HTTP(S). `distributedTracing.tracestate` MUST
+    instead be marshaled as the `tracestate` HTTP header.


### PR DESCRIPTION
I think this merits the initial statnce of being an extension
for a few reasons:

1. I want to adhere to the CNCF policy against kingmaking even
   though I think the world is better off with one interoperable
   tracing standard.
2. Nothing in the trace state should have an effect on
   application logic.
3. I like exercising our thoughts on extensions.