### PR TITLE
Fix some simple typos in docs

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -50,7 +50,7 @@ If a vote is taken during a WG meeting, the follow rules will be followed:
 * A vote passes if more than 50% of the votes cast approve the motion.
 * Only "yes" or "no" votes count, "abstain" votes do not count towards the
   total.
-* Meeting attendence will be formally tracked
+* Meeting attendance will be formally tracked
   [here](https://docs.google.com/spreadsheets/d/1bw5s9sC2ggYyAiGJHEk7xm-q2KG6jyrfBy69ifkdmt0/edit#gid=0).
   Members must acknowledge their presence verbally, meaning, adding yourself
   to the "Attendees" section of the Agenda document is not sufficient.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ document.
 ## Community
 
 Learn more about the people and organizations who are creating a dynamic
-cloud native ecosystem by making our systems interopable with CloudEvents.
+cloud native ecosystem by making our systems interoperable with CloudEvents.
 
 * [Contributors](community/contributors.md): people and organizations who helped
 us get started or are actively working on the CloudEvents specification.

--- a/community/contributors.md
+++ b/community/contributors.md
@@ -1,6 +1,6 @@
 ## CloudEvents contributors
 
-We welcome you to join us! This list acknowleges those who contribute whether
+We welcome you to join us! This list acknowledges those who contribute whether
 it be via GitHub pull request or in real life in the working group, as well as
 those who contributed before this became a CNCF Serverless WG project. If you
 are participating in some way, please add your information via pull request.

--- a/extensions.md
+++ b/extensions.md
@@ -1,7 +1,7 @@
 # CloudEvents Extension Attributes
 
 The [CloudEvents specification](spec.md) defines a set of metadata attributes
-than can be used when tranforming a generic event into a CloudEvent.
+than can be used when transforming a generic event into a CloudEvent.
 The list of attributes specified in that document represent the minimal set
 that the specification authors deemed most likely to be used in a majority of
 situations.
@@ -9,7 +9,7 @@ situations.
 This document defines some addition attributes that, while not as commonly
 used as the ones specified in the [CloudEvents specification](spec.md),
 could still benefit from being formally specified in the hopes of providing
-some degree of interoperabilty. This also allows for attributes to be
+some degree of interoperability. This also allows for attributes to be
 defined in an experimental manner and tested prior to being considered for
 inclusion in the [CloudEvents specification](spec.md).
 

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -73,7 +73,7 @@ headers.
 
 ### 1.4. Event Formats
 
-Event formats, used with the *stuctured* content mode, define how an event is
+Event formats, used with the *structured* content mode, define how an event is
 expressed in a particular data format. All implementations of this
 specification MUST support the [JSON event format][JSON-format], but MAY
 support any additional, including proprietary, formats.
@@ -305,7 +305,7 @@ Content-Length: nnnn
 
 ```
 
-This example shows a JSON encoded event retuned in a response:
+This example shows a JSON encoded event returned in a response:
 
 ``` text
 

--- a/http-webhook.md
+++ b/http-webhook.md
@@ -173,7 +173,7 @@ field or the HTTP request entity-body. All further caveats cited in
 ## 4. Abuse Protection
 
 Any system that allows registration of and delivery of notifications to
-arbitary HTTP endpoints can potentially be abused such that someone maliciously
+arbitrary HTTP endpoints can potentially be abused such that someone maliciously
 or inadvertently registers the address of a system that does not expect such
 requests and for which the registering party is not authorized to perform such
 a registration. In extreme cases, a notification infrastructure could be abused

--- a/mqtt-transport-binding.md
+++ b/mqtt-transport-binding.md
@@ -65,7 +65,7 @@ attributes are mapped to the MQTT PUBLISH message's
 
 ### 1.4. Event Formats
 
-Event formats, used with the *stuctured* content mode, define how an event is
+Event formats, used with the *structured* content mode, define how an event is
 expressed in a particular data format. All implementations of this
 specification MUST support the [JSON event format][JSON-format].
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -36,7 +36,7 @@ of the working group.
     1.  At least one open source implementation of sending and receiving
 	    events, see
 		[community open source](https://github.com/cloudevents/spec/blob/master/community/open-source.md).
-    1. Events are sent by code written by Developer1 and recieved by code
+    1. Events are sent by code written by Developer1 and received by code
 	   written by Developer2, where Developer1 has no knowledge of Developer2.
 
 *0.2*

--- a/spec.md
+++ b/spec.md
@@ -238,8 +238,8 @@ are routed from the emitting source to interested parties for the purpose of
 notifying them about the source occurrence. The routing can be performed based
 on information contained in the event, but an event will not identify
 a specific routing destination. Events will contain two pieces of information:
-the [Data](#data) representing the Occurance and extra [Context](#context)
-metadata providing additional information about the Occurance.
+the [Data](#data) representing the Occurrence and extra [Context](#context)
+metadata providing additional information about the Occurrence.
 
 #### Context
 As described in the Event definition, an Event contains two parts, the


### PR DESCRIPTION
Commented on a typo elsewhere, so went ahead and fixed a number of minor documentation typos across the entire repo.