### PR TITLE
Add popular IDEs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.vscode/


### PR DESCRIPTION
It's very helpful to use IDEs that let us visualize the rendered markdown. It would be more helpful to not worry about local project files getting added to commits.