### PR TITLE
Factor Distributed Tracing extension into new doc.

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -33,6 +33,6 @@ default placement for extensions, but an extension MAY require special
 representation when transported (e.g. tracing standards that require
 specific headers).
 
-## Known Extensions
+## Documented Extensions
 
 * [Distributed Tracing](extensions/distributed-tracing.md)

--- a/extensions.md
+++ b/extensions.md
@@ -18,34 +18,21 @@ to limit their use of extension attributes to just the ones specified in
 this document. The attributes defined in this document have no official
 standing and might be changed, or removed, at any time.
 
-## Extension Attributes
+## Usage
 
-### distributedTracing
+Support for any extension is OPTIONAL. When an extension definition uses 
+[RFC 2199](https://www.ietf.org/rfc/rfc2119.txt) keywords (e.g. MUST,
+SHOULD, MAY), this usage only applies to events that use the extension.
 
-This extension embeds context from 
-[Distributed Tracing](https://w3c.github.io/distributed-tracing/report-trace-context.html)
-so that distributed systems can include traces that span an event-driven system.
-This is the foundation of many other systems, such as Open Tracing, on which
-platforms like Prometheus are built.
- 
-#### traceparent
-* Type: `String`
-* Description: Contains a trace ID, span ID, and trace options as defined in
-  [section 2.2.2](https://w3c.github.io/distributed-tracing/report-trace-context.html#field-value)
-* Constraints
-  * REQUIRED
-  * To integrate with Distributed Tracing, this field MUST NOT use the normal
-    [extension encoding over HTTP(S)](http-transport-binding.md).
-    `distributedTracing.traceparent` MUST instead be marshaled as 
-    the `traceparent` HTTP header.
+Extensions always follow a common placement strategy for in-memory
+formats (e.g. [JSON](json-format.md), XML, Protobuffer) that are
+decided by those representations. Transport bindings (e.g.
+[HTTP](http-transport-binding.md), [MQTT](mqtt-transport-binding.md),
+[AMPQ](amqp-transport-binding.md), [NATS](nats-transport-binding.md)) provide
+default placement for extensions, but an extension MAY require special
+representation when transported (e.g. tracing standards that require
+specific headers).
 
-#### tracestate
-* Type: `String`
-* Description: a comma-delimited list of key-value pairs, defined by
-  [section 2.3.2](https://w3c.github.io/distributed-tracing/report-trace-context.html#header-value).
-* Constraints
-  * OPTIONAL
-  * To integrate with Distributed Tracing, this field MUST NOT use the normal
-    [extension encoding over HTTP(S)](http-transport-binding.md).
-    `distributedTracing.tracestate` MUST instead be marshaled as the
-    `tracestate` HTTP header.
+## Known Extensions
+
+* [Distributed Tracing](extensions/distributed-tracing.md)

--- a/extensions/distributed-tracing.md
+++ b/extensions/distributed-tracing.md
@@ -1,0 +1,40 @@
+# Distributed Tracing extension
+
+This extension embeds context from 
+[Distributed Tracing](https://w3c.github.io/distributed-tracing/report-trace-context.html)
+so that distributed systems can include traces that span an event-driven system.
+This is the foundation of many other systems, such as Open Tracing, on which
+platforms like Prometheus are built.
+
+## Attributes
+#### traceparent
+* Type: `String`
+* Description: Contains a version, trace ID, span ID, and trace options as defined in
+  [section 2.2.2](https://w3c.github.io/distributed-tracing/report-trace-context.html#field-value)
+* Constraints
+  * REQUIRED
+
+#### tracestate
+* Type: `String`
+* Description: a comma-delimited list of key-value pairs, defined by
+  [section 2.3.2](https://w3c.github.io/distributed-tracing/report-trace-context.html#header-value).
+* Constraints
+  * OPTIONAL
+    
+## Encoding
+
+### In-memory formats
+The Distributed Tracing extension uses the key `distributedTracing` for in-memory formats
+
+### HTTP
+
+To integrate with existing tracing libraries, the Distributed Tracing attributes MUST
+be encoded over HTTP(S) as headers. E.g.
+
+```bash
+CURL -X POST example/webhook.json \
+-H 'traceparent:  00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01' \
+-H 'tracestate: rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4=` \
+-H 'content-type: application/cloudevents+json' \
+-d '@sample-event.json'
+```


### PR DESCRIPTION
* Extends extensions.md to clarify that RFC 2119 keywords
  are only for those who implement an extension.
* Notes our resolved rules that each memory format defines
  extensions' placement and each transport binding defines
  a default placement which an extension may override.
* Refactor the contents now in extensions/distributed-tracing.md
  as a first SWAG at a reusable template.