### PR TITLE
Add practical constraints exercise to 0.3 roadmap.

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -56,8 +56,15 @@ of the working group.
 
 1. Resolve all known "proposed optional attributes" issues
 1. Resolve all known "security related" issues
+1. Review spec for practical-use issues:
+    1. Consider context size limits
+    1. Consider restricting character sets of `String` properties or key names
+    1. Consider defining uniqueness constraints of `eventId`
+    1. Consider which fields will be immutable (prevents annotation or redaction)
+    1. Consider validating transport bindings with load tests
 
 *0.4*
+
 1. Complete the proposed set of protocol and serialization mappings
 1. Resolve "Process" related issues
 


### PR DESCRIPTION
In the 2018-06-15 f2f, we agreed to holistically revisit the spec
to look for issues that may arise with our spec in practice.

As a first swag, I placed this in the 0.3 milestone since it
has security-related issues. I could also see putting this in
the 0.4 milestone since it finalizes serialization and protocol mappings.