### PR TITLE
OpenMessaging event format and transport binding 

### DIFF
--- a/openmessaging-format.md
+++ b/openmessaging-format.md
@@ -2,8 +2,8 @@
 
 ## Abstract
 
-The OpenMessaging Event Format for CloudEvents defines how events are expressed in
-[OpenMessaging][OpenMessaging].
+The OpenMessaging Event Format for CloudEvents defines how events are expressed 
+in [OpenMessaging][OpenMessaging].
 
 ## Status of this document
 
@@ -16,11 +16,16 @@ This document is a working draft.
 3. [References](#3-references)
 
 ## 1. Introduction
-The [OpenMessaging][OpenMessaging] Format for CloudEvents defines how event attributes are expressed in the [OpenMessaging Type System](https://github.com/openmessaging/specification/blob/master/specification-schema.md).
+The [OpenMessaging][OpenMessaging] Format for CloudEvents defines how event 
+attributes are expressed in the [OpenMessaging Type System][OpenMessaging-Spec].
 
-The [Attributes](#2-attributes) section describes the naming conventions and data type mappings for CloudEvents attributes for use as OpenMessaging message properties.
+The [Attributes](#2-attributes) section describes the naming conventions and 
+data type mappings for CloudEvents attributes for use as OpenMessaging message 
+properties.
 
-This specification does not define an envelope format. The OpenMessaging type system's intent is primarily to provide a consistent type system for OpenMessaging itself and not for message payloads.
+This specification does not define an envelope format. The OpenMessaging type 
+system's intent is primarily to provide a consistent type system for 
+OpenMessaging itself and not for message payloads.
 
 
 ### 1.1. Conformance
@@ -31,9 +36,10 @@ interpreted as described in [RFC2119][RFC2119].
 
 ## 2. Attributes
 
-This section defines how CloudEvents attributes are mapped to OpenMessaging type-system . This
-specification does not explicitly map each attribute, but provides a generic
-mapping model that applies to all current and future CloudEvents attributes, including extensions.
+This section defines how CloudEvents attributes are mapped to OpenMessaging 
+type-system . This specification does not explicitly map each attribute, but 
+provides a generic mapping model that applies to all current and future 
+CloudEvents attributes, including extensions.
 
 ### 2.1. Base Type System
 
@@ -45,16 +51,19 @@ The CloudEvents type system is mapped to OpenMessaging types as follows:
 
 | CloudEvents | OpenMessaging
 |--------------|-------------------------------------------------------------
-| String       | [String](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
-| Binary       | [Binary](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
-| URI          | [URI](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
-| Timestamp    | [String](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
-| Map          | [Key-Value](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
-| Object       | [Object](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
+| String       | [String][OpenMessaging-Spec]
+| Binary       | [Binary][OpenMessaging-Spec]
+| URI          | [URI][OpenMessaging-Spec]
+| Timestamp    | [String][OpenMessaging-Spec]
+| Map          | [Key-Value][OpenMessaging-Spec]
+| Object       | [Object][OpenMessaging-Spec]
 
 ## 3. References
 
-- [OpenMessaging][OpenMessaging] The OpenMessaging Specification
+- [OpenMessaging][OpenMessaging] The OpenMessaging repository
+- [OpenMessaging Type System][OpenMessaging-Spec] The type system in 
+OpenMessaging specification
 
 [CE]: ./spec.md
 [OpenMessaging]: https://github.com/openmessaging
+[OpenMessaging-Spec]: https://github.com/openmessaging/specification/blob/master/specification-schema.md

--- a/openmessaging-format.md
+++ b/openmessaging-format.md
@@ -1,0 +1,130 @@
+# OpenMessaging Event Format for CloudEvents - Version 0.1
+
+## Abstract
+
+The OpenMessaging Format for CloudEvents defines how events are expressed in
+Open Messaging.
+
+## Status of this document
+
+This document is a working draft.
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Attributes](#2-attributes)
+3. [Envelope](#3-envelope)
+4. [References](#4-references)
+
+## 1. Introduction
+
+[CloudEvents][CE] is a standardized and transport-neutral definition of the
+structure and metadata description of events. This specification defines how
+the elements defined in the CloudEvents specification are to be represented in
+the [OpenMessaging][OpenMessaging].
+
+The [Attributes](#2-attributes) section describes the naming conventions and
+data type mappings for CloudEvents attributes.
+
+The [Envelope](#3-envelope) section defines a OpenMessaging container for CloudEvents
+attributes and an associated media type.
+
+### 1.1. Conformance
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC2119][RFC2119].
+
+## 2. Attributes
+
+This section defines how CloudEvents attributes are mapped to OpenMessaging. This
+specification does not explicitly map each attribute, but provides a generic
+mapping model that applies to all current and future CloudEvents attributes.
+
+### 2.1. Base Type System
+
+The core [CloudEvents specification][CE] defines a minimal abstract type
+system, which this mapping leans on.
+
+### 2.2. Type System Mapping
+
+The CloudEvents type system is mapped to JSON types as follows:
+
+| CloudEvents | JSON
+|--------------|-------------------------------------------------------------
+| String       | [String][String]
+| Binary       | [Binary][binary], unicode binary
+| URI          | [String][String]
+| Timestamp    | [String][String]
+| Map          | [Map][map]
+| Object       | see2.3
+
+### 2.3. Mapping Object-typed Attributes
+
+`Object`-typed CloudEvents values can either hold a `String`, or a `Binary`
+value, or a `Map`. `Map` entry values are also `Object` typed. OpenMessaging's type
+system natively represents dynamic typing in its [type system
+encoding][type-system-encoding], and therefore immediately allows for the required
+variant type representation.
+
+### 2.4. Examples
+
+The following table shows exemplary mappings:
+
+| CloudEvents       | Type     | Exemplary OpenMessaging Value
+|--------------------|----------|-------------------------------
+| eventType          | String   | "openMessaging"
+| eventTypeVersion   | String   | "1.0"
+| cloudEventsVersion | String   | "0.1"
+| source             | URI      | "openMessaging.io.event"
+| eventID            | String   | "1234-1234-1234"
+| eventTime          | Timestamp| "2018-04-05T17:31:00Z"
+| contentType        | String   | "text/json"
+| extensions         | Map      | { "extA" : "vA", "extB", "vB" }
+| data               | String   | "test openMessaging"
+| data               | Binary   | "156,134,111"
+| data               | Map      | { "objA" : "vA", "objB", "vB" }
+
+## 3. Envelope
+Each CloudEvents event can be wholly represented as a OpenMessaging object.
+
+Such a representation uses the *userHeader* in the OpenMessaging,
+If the property "cloudEvent" existed, it represented it's a cloud event message.
+All REQUIRED and all not omitted OPTIONAL attributes in the given event MUST
+become members of the OpenMessaging object, with the respective OpenMessaging object member name
+matching the attribute name, and the member's type and value being mapped using
+the [type system mapping](#22-type-system-mapping).
+
+### 3.1. Special Handling of the "data" Attribute
+
+The mapping of the `Object`-typed `data` attribute follows the rules laid out
+in [Section 2.3.](#23-mapping-object-typed-attributes), with one additional
+rule:
+
+If an implementation determines that the type of the `data` attribute is
+`Binary` or `String`, it MUST inspect the `contentType` attribute to determine
+whether it is indicated that the data value contains JSON data.
+
+If the `contentType` value is either ["application/json"][RFC4627] or any media type
+with a [structured +json suffix][RFC6839], the implementation MUST translate
+the `data` attribute value into a [JSON value][JSON-Value], and set the `data`
+attribute of the envelope JSON object to this JSON value.
+
+Unlike all other attributes, for which value types are restricted to strings
+per the [type-system mapping](#22-type-system-mapping), the resulting `data`
+member [JSON value][JSON-Value] is unrestricted, and if `contentType` value is either "binary/thrift",it represented
+that the data should be interpreted by the thrift protocol. so for the binary, users can customize 
+the serialization protocol. 
+
+
+## 4. References
+
+- [OpenMessaging][OpenMessaging] The NATS Messaging System
+- [RFC4627][RFC4627] The application/json Media Type for JavaScript Object Notation (JSON)
+- [RFC6839][RFC6839] additional Media Type Structured Syntax Suffixes
+
+[base64]: https://tools.ietf.org/html/rfc4648#section-4
+[CE]: ./spec.md
+[OpenMessaging]: https://github.com/openmessaging
+[RFC4627]: https://tools.ietf.org/html/rfc4627
+[RFC6839]: https://tools.ietf.org/html/rfc6839#section-3.1

--- a/openmessaging-format.md
+++ b/openmessaging-format.md
@@ -2,8 +2,8 @@
 
 ## Abstract
 
-The OpenMessaging Format for CloudEvents defines how events are expressed in
-Open Messaging.
+The OpenMessaging Event Format for CloudEvents defines how events are expressed in
+[OpenMessaging][OpenMessaging].
 
 ## Status of this document
 
@@ -13,21 +13,15 @@ This document is a working draft.
 
 1. [Introduction](#1-introduction)
 2. [Attributes](#2-attributes)
-3. [Envelope](#3-envelope)
-4. [References](#4-references)
+3. [References](#3-references)
 
 ## 1. Introduction
+The [OpenMessaging][OpenMessaging] Format for CloudEvents defines how event attributes are expressed in the [OpenMessaging Type System](https://github.com/openmessaging/specification/blob/master/specification-schema.md).
 
-[CloudEvents][CE] is a standardized and transport-neutral definition of the
-structure and metadata description of events. This specification defines how
-the elements defined in the CloudEvents specification are to be represented in
-the [OpenMessaging][OpenMessaging].
+The [Attributes](#2-attributes) section describes the naming conventions and data type mappings for CloudEvents attributes for use as OpenMessaging message properties.
 
-The [Attributes](#2-attributes) section describes the naming conventions and
-data type mappings for CloudEvents attributes.
+This specification does not define an envelope format. The OpenMessaging type system's intent is primarily to provide a consistent type system for OpenMessaging itself and not for message payloads.
 
-The [Envelope](#3-envelope) section defines a OpenMessaging container for CloudEvents
-attributes and an associated media type.
 
 ### 1.1. Conformance
 
@@ -37,94 +31,30 @@ interpreted as described in [RFC2119][RFC2119].
 
 ## 2. Attributes
 
-This section defines how CloudEvents attributes are mapped to OpenMessaging. This
+This section defines how CloudEvents attributes are mapped to OpenMessaging type-system . This
 specification does not explicitly map each attribute, but provides a generic
-mapping model that applies to all current and future CloudEvents attributes.
+mapping model that applies to all current and future CloudEvents attributes, including extensions.
 
 ### 2.1. Base Type System
 
-The core [CloudEvents specification][CE] defines a minimal abstract type
-system, which this mapping leans on.
+This mapping leans on [CloudEvents specification][CE].
 
 ### 2.2. Type System Mapping
 
-The CloudEvents type system is mapped to JSON types as follows:
+The CloudEvents type system is mapped to OpenMessaging types as follows:
 
-| CloudEvents | JSON
+| CloudEvents | OpenMessaging
 |--------------|-------------------------------------------------------------
-| String       | [String][String]
-| Binary       | [Binary][binary], unicode binary
-| URI          | [String][String]
-| Timestamp    | [String][String]
-| Map          | [Map][map]
-| Object       | see2.3
+| String       | [String](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
+| Binary       | [Binary](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
+| URI          | [URI](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
+| Timestamp    | [String](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
+| Map          | [Key-Value](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
+| Object       | [Object](https://github.com/openmessaging/specification/blob/master/specification-schema.md)
 
-### 2.3. Mapping Object-typed Attributes
+## 3. References
 
-`Object`-typed CloudEvents values can either hold a `String`, or a `Binary`
-value, or a `Map`. `Map` entry values are also `Object` typed. OpenMessaging's type
-system natively represents dynamic typing in its [type system
-encoding][type-system-encoding], and therefore immediately allows for the required
-variant type representation.
+- [OpenMessaging][OpenMessaging] The OpenMessaging Specification
 
-### 2.4. Examples
-
-The following table shows exemplary mappings:
-
-| CloudEvents       | Type     | Exemplary OpenMessaging Value
-|--------------------|----------|-------------------------------
-| eventType          | String   | "openMessaging"
-| eventTypeVersion   | String   | "1.0"
-| cloudEventsVersion | String   | "0.1"
-| source             | URI      | "openMessaging.io.event"
-| eventID            | String   | "1234-1234-1234"
-| eventTime          | Timestamp| "2018-04-05T17:31:00Z"
-| contentType        | String   | "text/json"
-| extensions         | Map      | { "extA" : "vA", "extB", "vB" }
-| data               | String   | "test openMessaging"
-| data               | Binary   | "156,134,111"
-| data               | Map      | { "objA" : "vA", "objB", "vB" }
-
-## 3. Envelope
-Each CloudEvents event can be wholly represented as a OpenMessaging object.
-
-Such a representation uses the *userHeader* in the OpenMessaging,
-If the property "cloudEvent" existed, it represented it's a cloud event message.
-All REQUIRED and all not omitted OPTIONAL attributes in the given event MUST
-become members of the OpenMessaging object, with the respective OpenMessaging object member name
-matching the attribute name, and the member's type and value being mapped using
-the [type system mapping](#22-type-system-mapping).
-
-### 3.1. Special Handling of the "data" Attribute
-
-The mapping of the `Object`-typed `data` attribute follows the rules laid out
-in [Section 2.3.](#23-mapping-object-typed-attributes), with one additional
-rule:
-
-If an implementation determines that the type of the `data` attribute is
-`Binary` or `String`, it MUST inspect the `contentType` attribute to determine
-whether it is indicated that the data value contains JSON data.
-
-If the `contentType` value is either ["application/json"][RFC4627] or any media type
-with a [structured +json suffix][RFC6839], the implementation MUST translate
-the `data` attribute value into a [JSON value][JSON-Value], and set the `data`
-attribute of the envelope JSON object to this JSON value.
-
-Unlike all other attributes, for which value types are restricted to strings
-per the [type-system mapping](#22-type-system-mapping), the resulting `data`
-member [JSON value][JSON-Value] is unrestricted, and if `contentType` value is either "binary/thrift",it represented
-that the data should be interpreted by the thrift protocol. so for the binary, users can customize 
-the serialization protocol. 
-
-
-## 4. References
-
-- [OpenMessaging][OpenMessaging] The NATS Messaging System
-- [RFC4627][RFC4627] The application/json Media Type for JavaScript Object Notation (JSON)
-- [RFC6839][RFC6839] additional Media Type Structured Syntax Suffixes
-
-[base64]: https://tools.ietf.org/html/rfc4648#section-4
 [CE]: ./spec.md
 [OpenMessaging]: https://github.com/openmessaging
-[RFC4627]: https://tools.ietf.org/html/rfc4627
-[RFC6839]: https://tools.ietf.org/html/rfc6839#section-3.1

--- a/openmessaging-transport-binding.md
+++ b/openmessaging-transport-binding.md
@@ -2,7 +2,8 @@
 
 ## Abstract
 
-The [OpenMessaging][OpenMessaging] Transport Binding for CloudEvents defines how events are mapped to [OpenMessaging Specification](https://github.com/openmessaging/specification/blob/master/specification-schema.md).
+The [OpenMessaging][OpenMessaging] Transport Binding for CloudEvents defines how
+events are mapped to [OpenMessaging Specification][OpenMessaging-Spec].
 
 
 ## Status of this document
@@ -40,13 +41,17 @@ interpreted as described in [RFC2119][RFC2119].
 ### 1.2. Relation to OpenMessaging
 
 This specification does not prescribe rules constraining transfer or settlement
-of event messages with [OpenMessaging][OpenMessaging]; it solely defines how CloudEvents are expressed
-with [OpenMessaging Specification][OpenMessaging-Spec].    
+of event messages with [OpenMessaging][OpenMessaging]; it solely defines how 
+CloudEvents are expressed with [OpenMessaging 
+Specification][OpenMessaging-Spec].    
 
-OpenMessaging-based messaging and eventing infrastructures may provide higher-level programming-level
-abstractions although OpenMessaging provides optional core APIs, but they all follow the schema of the messages
-provided by OpenMessaging Specification. This specification uses OpenMessaging terminology, and implementers can refer the respective
-infrastructure's OpenMessaging documentation to determine the mapping into a programming-level abstraction.
+OpenMessaging-based messaging and eventing infrastructures may provide
+higher-level programming-level abstractions although OpenMessaging provides 
+optional core APIs, but they all follow the schema of the messages
+provided by OpenMessaging Specification. This specification uses OpenMessaging
+terminology, and implementers can refer the respective infrastructure's 
+OpenMessaging documentation to determine the mapping into a programming-level 
+abstraction.
 
 
 ### 1.3. Content Modes
@@ -55,27 +60,29 @@ This specification defines two content modes for transferring events:
 *structured* and *binary*. Every compliant implementation SHOULD support both
 modes.
 
-In the *structured* content mode, event metadata attributes and event data are placed
-into the OpenMessaging message's application data section using an [event format](#14-event-formats).
+In the *structured* content mode, event metadata attributes and event data are
+placed into the OpenMessaging message's application data section using an 
+[event format](#14-event-formats).
 
 In the *binary* content mode, the value of the event `data` attribute is placed
 into message body, with the `contentType` attribute
-value declaring its media type; all other event attributes are mapped [OpenMessaging
-properties][OpenMessaging-Spec]
+value declaring its media type; all other event attributes are 
+mapped [OpenMessaging properties][OpenMessaging-Spec]
 
 ### 1.4. Event Formats
 
 Event formats, used with the *stuctured* content mode, define how an event is
 expressed in a particular data format. All implementations of this
-specification MUST support the [JSON event format][JSON-format], as well as the [OpenMessaging event format][OpenMessaging-format]
-for the [properties][OpenMessaging-Spec]
+specification MUST support the [JSON event format][JSON-format], as well as 
+the [OpenMessaging event format][OpenMessaging-format] for the 
+[properties][OpenMessaging-Spec]
 section, but MAY support any additional, including proprietary, formats.
 
 ### 1.5. Security
 
-This specification does not introduce any new security features for OpenMessaging, or
-mandate specific existing features to be used. This specification applies
-identically to [SSL]([RFC6101][RFC6101]).
+This specification does not introduce any new security features for 
+OpenMessaging, or mandate specific existing features to be used. This 
+specification applies identically to [SSL]([RFC6101][RFC6101]).
 
 ## 2. Use of CloudEvents Attributes
 
@@ -83,12 +90,13 @@ This specification does not further define any of the [CloudEvents][CE] event
 attributes.
 
 Two of the event attributes, `contentType` and `data` are handled specially
-and mapped onto OpenMessaging constructs, all other attributes are transferred as
-metadata without further interpretation.
+and mapped onto OpenMessaging constructs, all other attributes are transferred
+as metadata without further interpretation.
 
-This mapping is intentionally robust against changes, including the addition and 
-removal of event attributes, and also accommodates vendor extensions to the event 
-metadata. Any mention of event attributes other than contentType and data is exemplary.
+This mapping is intentionally robust against changes, including the addition 
+and removal of event attributes, and also accommodates vendor extensions to the 
+event metadata. Any mention of event attributes other than contentType and data 
+is exemplary.
 
 
 ### 2.1. contentType Attribute
@@ -102,8 +110,8 @@ The `data` attribute is assumed to contain opaque application data that is
 encoded as declared by the `contentType` attribute.
 
 An application is free to hold the information in any in-memory representation
-of its choosing, but as the value is transposed into OpenMessaging as defined in this
-specification, the assumption is that the `data` attribute value is made
+of its choosing, but as the value is transposed into OpenMessaging as defined 
+in this specification, the assumption is that the `data` attribute value is made
 available as a sequence of bytes.
 
 For instance, if the declared `contentType` is
@@ -114,19 +122,21 @@ OpenMessaging.
 
 ## 3. OpenMessaging Message Mapping
 
-With OpenMessaging, the content mode is chosen by the sender of the event. Protocol
-usage patterns that might allow solicitation of events using a particular
-content mode might be defined by an application, but are not defined here.
+With OpenMessaging, the content mode is chosen by the sender of the event. 
+Protocol usage patterns that might allow solicitation of events using a 
+particular content mode might be defined by an application, but are not 
+defined here.
 
 The receiver of the event can distinguish between the two content modes by
-inspecting the`contentType` property  in the *properties* of the OpenMessaging message.
-If the value is prefixed with the CloudEvents media type application/cloudevents, 
+inspecting the`contentType` property  in the *properties* of the OpenMessaging 
+message. If the value is prefixed with the CloudEvents media type 
+application/cloudevents, 
 indicating the use of a known event format, the receiver uses structured mode, 
 otherwise it defaults to binary mode.
 
-If a receiver detects the CloudEvents media type, but with an event format that it cannot handle, 
-for instance application/cloudevents+avro, it MAY still treat the event as binary and forward it 
-to another party as-is.
+If a receiver detects the CloudEvents media type, but with an event format that 
+it cannot handle, for instance application/cloudevents+avro, it MAY still treat 
+the event as binary and forward it to another party as-is.
 
 
 ### 3.1. Binary Content Mode
@@ -136,8 +146,8 @@ efficient transfer and without transcoding effort.
 
 #### 3.1.1. OpenMessaging contentType
 
-For the *binary* mode, the  `contentType`  property field value maps directly to the
-CloudEvents `contentType` attribute.
+For the *binary* mode, the  `contentType`  property field value maps directly to
+the CloudEvents `contentType` attribute.
 
 #### 3.1.2. Event Data Encoding
 
@@ -152,7 +162,8 @@ MUST be individually mapped to and from the *properties* section.
 ##### 3.1.3.1 OpenMessaging Properties Names
 
 
-Cloud Event attributes are prefixed with "cloudEvents:" for use in the [properties][OpenMessaging-Spec]  section.
+Cloud Event attributes are prefixed with "cloudEvents:" for use in the
+[properties][OpenMessaging-Spec] section.
 
 Examples:
 
@@ -162,15 +173,16 @@ Examples:
 
 ##### 3.1.3.2 OpenMessaging Properties Values
 
-The value for each OpenMessaging *properties* is constructed from the respective attribute's OpenMessaging type representation,
-compliant with the [OpenMessaging event format][OpenMessaging-format] specification.
+The value for each OpenMessaging *properties* is constructed from the 
+respective attribute's OpenMessaging type representation, compliant with the
+[OpenMessaging event format][OpenMessaging-format] specification.
 
 #### 3.1.4 Examples
 
 This example shows the *binary* mode mapping of an event into the
-OpenMessaging message. All CloudEvents attributes are mapped to OpenMessaging *properties* section fields.
-Mind that `contentType` here does refer to the event `data`
-content carried in the payload.
+OpenMessaging message. All CloudEvents attributes are mapped to OpenMessaging
+*properties* section fields. Mind that `contentType` here does refer to the 
+event `data` content carried in the payload.
 
 ``` text
 ------------- headers -------------------
@@ -202,7 +214,8 @@ hops, and across multiple transports.
 
 #### 3.2.1. OpenMessaging Content Type
 
-The OpenMessaging `contentType` field in *properties* section is set to the media type of an [event format](#14-event-formats).
+The OpenMessaging `contentType` field in *properties* section is set to the 
+media type of an [event format](#14-event-formats).
 
 
 Example for the [JSON format][JSON-format]:

--- a/openmessaging-transport-binding.md
+++ b/openmessaging-transport-binding.md
@@ -1,0 +1,254 @@
+# OpenMessaging Transport Binding for CloudEvents
+
+## Abstract
+
+The [OpenMessaging][OpenMessaging] Transport Binding for CloudEvents defines how events are mapped to [NATS messages][NATS-MSG-PROTO].
+
+## Status of this document
+
+This document is a working draft.
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+- 1.1. [Conformance](#11-conformance)
+- 1.2. [Relation to OpenMessaging](#12-relation-to-nats)
+- 1.3. [Content Modes](#13-content-modes)
+- 1.4. [Event Formats](#14-event-formats)
+- 1.5. [Security](#15-security)
+2. [Use of CloudEvents Attributes](#2-use-of-cloudevents-attributes)
+- 2.1. [contentType Attribute](#21-contenttype-attribute)
+- 2.2. [data Attribute](#22-data-attribute)
+3. [OpenMessaging Message Mapping](#3-mqtt-publish-message-mapping)
+- 3.2. [Binary Content Mode](#31-binary-content-mode)
+- 3.1. [Structured Content Mode](#32-structured-content-mode)
+4. [References](#4-references)
+
+## 1. Introduction
+
+[CloudEvents][CE] is a standardized and transport-neutral definition of the
+structure and metadata description of events. This specification defines how
+the elements defined in the CloudEvents specification are to be used in
+[OpenMessaging][OpenMessaging]. 
+### 1.1. Conformance
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC2119][RFC2119].
+
+### 1.2. Relation to OpenMessaging
+
+This specification does not prescribe rules constraining transfer or settlement
+of event messages with OpenMessaging; it solely defines how CloudEvents are expressed
+in the OpenMessaging protocol as client messages that are produced
+and consumed.
+
+### 1.3. Content Modes
+
+This specification defines two content modes for transferring events:
+*structured* and *binary*. Every compliant implementation SHOULD support both
+modes.
+
+In the *structured* content mode, event metadata attributes and event data are
+placed into producer send message body.
+
+In the *binary* content mode, the value of the event `data` attribute is placed
+into message body, with the `contentType` attribute
+value declaring its media type; all other event attributes are mapped OpenMessaging
+sys headers.
+
+### 1.4. Event Formats
+
+Event formats, used with the *stuctured* content mode, define how an event is
+expressed in a particular data format. All implementations of this
+specification MUST support the [JSON event format][JSON-format].
+
+### 1.5. Security
+
+This specification does not introduce any new security features for OpenMessaging, or
+mandate specific existing features to be used. This specification applies
+identically to [SSL]([RFC6101][RFC6101]).
+
+## 2. Use of CloudEvents Attributes
+
+This specification does not further define any of the [CloudEvents][CE] event
+attributes.
+
+Two of the event attributes, `contentType` and `data` are handled specially
+and mapped onto OpenMessaging constructs, all other attributes are transferred as
+metadata without further interpretation.
+
+### 2.1. contentType Attribute
+
+The `contentType` attribute is assumed to contain a media-type expression
+compliant with [RFC2046][RFC2046].
+
+### 2.2. data Attribute
+
+The `data` attribute is assumed to contain opaque application data that is
+encoded as declared by the `contentType` attribute.
+
+An application is free to hold the information in any in-memory representation
+of its choosing, but as the value is transposed into OpenMessaging as defined in this
+specification, the assumption is that the `data` attribute value is made
+available as a sequence of bytes.
+
+For instance, if the declared `contentType` is
+`application/json;charset=utf-8`, the expectation is that the `data` attribute
+value is made available as [UTF-8][RFC3629] encoded JSON text for use in
+OpenMessaging
+
+
+## 3. OpenMessaging Message Mapping
+
+With OpenMessaging, the content mode is chosen by the sender of the event. Protocol
+usage patterns that might allow solicitation of events using a particular
+content mode might be defined by an application, but are not defined here.
+
+The receiver of the event can distinguish between the two content modes by
+inspecting the`Content Type` property  in the *userHeader* of the OpenMessaging PUBLISH message.
+If the value of the `Content Type` property is `application/json;charset=utf-8`, 
+indicating the use of a known [event format](#14-event-formats), the receiver uses *structured* mode, otherwise it
+defaults to *binary* mode.
+
+If a receiver finds a CloudEvents media type as per the above rule, but with an
+event format that it cannot handle, for instance
+`application/cloudevents+thrift`, it MAY still treat the event as binary and
+forward it to another party as-is.
+
+
+### 3.1. Binary Content Mode
+
+The *binary* content mode accommodates any shape of event data, and allows for
+efficient transfer and without transcoding effort.
+
+#### 3.1.1. OpenMessaging Content-Type
+
+For the *binary* mode, the  `contentType` value in *userHeaders* maps directly to the
+CloudEvents `contentType` attribute.
+
+#### 3.1.2. Event Data Encoding
+
+The [`data` attribute](#22-data-attribute) byte-sequence is used as the OpenMessaging body
+
+#### 3.1.3. Metadata Headers
+
+All [CloudEvents][CE] attributes with exception of `contentType` and `data`
+MUST be individually mapped to and from the *userHeader* Property fields in the OpenMessaging
+message.
+
+##### 3.1.3.1 User Property Names
+
+CloudEvents attribute names MUST be used unchanged in each mapped User Property
+in the MQTT PUBLISH message.
+
+##### 3.1.3.2 User Property Values
+
+The value for each OpenMessaging PUBLISH *userHeader* MUST be constructed from the
+respective CloudEvents attribute's JSON type representation, compliant with the
+[JSON event format][JSON-format] specification.
+
+#### 3.1.4 Examples
+
+This example shows the *binary* mode mapping of an event into the
+OpenMessaging produce message.All 
+CloudEvents attributes are mapped to OpenMessaging produce *userHeaders* Property
+fields. The `Topic name` is chosen by the OpenMessaging client and not derived
+from the CloudEvents event data.
+
+Mind that `Content Type` here does refer to the event `data`
+content carried in the payload.
+
+``` text
+------------------ PRODUCE -------------------
+
+Topic Name: mytopic
+
+------------- User Headers ----------------
+contentYype: application/json; charset=utf-8
+cloudEventsVersion: "0.1"
+eventType: "com.example.someevent"
+eventTime: "2018-04-16T08:56:24Z"
+eventId: "openMessaging.io.event"
+source: "io.penMessaging"
+       .... further attributes ...
+
+------------------ payload -------------------
+
+{
+    ... application data ...
+}
+
+-----------------------------------------------
+```
+
+### 3.2. Structured Content Mode
+
+The *structured* content mode keeps event metadata and data together in the
+payload, allowing simple forwarding of the same event across multiple routing
+hops, and across multiple transports.
+
+#### 3.2.1. OpenMessaging Content Type
+
+For OpenMessaging, the  `contentType` value in *userHeaders* maps directly to the
+CloudEvents `contentType` attribute.
+
+#### 3.2.2. Event Data Encoding
+
+The chosen [event format](#14-event-formats) defines how all attributes,
+including the `data` attribute, are represented.
+
+The event metadata and data MUST then be rendered in accordance with the event
+format specification and the resulting data becomes the OpenMessaging payload.
+
+#### 3.2.3. Metadata Headers
+
+For OpenMessaging, implementations MAY include the same *userHeader* Properties
+as defined for the [binary mode](#313-metadata-headers).
+
+#### 3.2.4. Examples
+
+The first example shows a JSON event format encoded event with OpenMessaging:
+
+``` text
+------------------ PRODUCE -------------------
+
+Topic Name: mytopic
+Content Type: application/cloudevents+json; charset=utf-8
+
+------------------ payload -------------------
+
+{
+    "cloudEventsVersion" : "0.1",
+    "eventType" : "com.example.someevent",
+
+    ... further attributes omitted ...
+
+    "data" : {
+        ... application data ...
+    }
+}
+
+-----------------------------------------------
+```
+
+
+## 4. References
+
+- [OpenMessaging][OpenMessaging] The NATS Messaging System
+- [RFC2046][RFC2046] Multipurpose Internet Mail Extensions (MIME) Part Two: 
+  Media Types
+- [RFC2119][RFC2119] Key words for use in RFCs to Indicate Requirement Levels
+- [RFC3629][RFC3629] UTF-8, a transformation format of ISO 10646
+- [RFC6101][RFC6101] HTTP over TLS
+- [RFC7159][RFC7159] The JavaScript Object Notation (JSON) Data Interchange Format
+
+[CE]: ./spec.md
+[JSON-format]: ./json-format.md
+[OpenMessaging]: https://github.com/openmessaging
+[JSON-Value]: https://tools.ietf.org/html/rfc7159#section-3
+[RFC2046]: https://tools.ietf.org/html/rfc2046
+[RFC2119]: https://tools.ietf.org/html/rfc2119
+[RFC3629]: https://tools.ietf.org/html/rfc3629
+[RFC6101]: https://tools.ietf.org/html/rfc6101
+[RFC7159]: https://tools.ietf.org/html/rfc7159


### PR DESCRIPTION
OpenMessaging is a Cloud-oriented, simple, flexible, vendor-neutral and language-independent standards for messaging. It would be great to define a transport binding for CloudEvents and 
define a map between OpenMessaging and CloudEvents.

[OpenMessaging](http://openmessaging.cloud/) has been implemented in the [Apache RocketMQ 4.2.0](https://github.com/apache/rocketmq/tree/master/example/src/main/java/org/apache/rocketmq/example/openmessaging
) release. In the future, there will be more other vendors joining to support OpenMessaging，and [Apache Pulsar](http://pulsar.apache.org/en/) has announced support for OpenMessaging. In addition, cloud vendors such as Aliyun will also support OpenMessaging soon, and also OpenMessaging will bring huge commercial value to cloud vendors, and more and more companies such as Alibaba, Yahoo, Didi, Streamlio, DataPipeline, Webank etc. have announced their participation in OpenMessaging. So we have enough confidence to make OpenMessaging to be a de facto standard.

Relevant resources:
Alibaba&Ali_Cloud: [official Tweet](https://twitter.com/alibaba_cloud/status/919085011013287937):
CNCF TOC presentation proposal: [open Github issue](https://github.com/cncf/toc/issues/103) 
Linux Foundation: [blog post](https://www.linuxfoundation.org/blog/2017/10/building-open-standard-distributed-messaging-introducing-openmessaging/), includes quotes from multiple companies
Yahoo/Oath: [Linux Foundation blog](http://www.enterprisenetworkingplanet.com/unified_communications/linux-foundation-launches-openmessaging-project.html)
Didi:  [quoted in the Linux Foundation post](https://www.linuxfoundation.org/blog/2017/10/building-open-standard-distributed-messaging-introducing-openmessaging/)
Streamlio(Apache Pulsar): [blog post](https://streaml.io/blog/open-messaging)
DataPipeline and Webank:[ Linux Foundation blogpost announcing their participation](https://www.linuxfoundation.org/blog/2018/09/webank-and-datapipeline-join-openmessaging-to-build-an-open-standard-for-distributed-messaging/)
Apache RocketMQ: [code implementation](https://github.com/apache/rocketmq/tree/master/example/src/main/java/org/apache/rocketmq/example/openmessaging)





Changes

This PR proposes an OpenMessaging
transport binding for CloudEvents, similar to other existing transport bindings.


