### PR TITLE
Removed eventTypeVersion

### DIFF
--- a/json-format.md
+++ b/json-format.md
@@ -81,7 +81,6 @@ The following table shows exemplary mappings:
 | CloudEvents       | Type     | Exemplary JSON Value
 |--------------------|----------|-------------------------------
 | eventType          | String   | "com.example.someevent"
-| eventTypeVersion   | String   | "1.0"
 | cloudEventsVersion | String   | "0.1"
 | source             | URI      | "/mycontext"
 | eventID            | String   | "1234-1234-1234"
@@ -138,7 +137,6 @@ Example event with `String`-valued `data`:
 {
     "cloudEventsVersion" : "0.1",
     "eventType" : "com.example.someevent",
-    "eventTypeVersion" : "1.0",
     "source" : "/mycontext",
     "eventID" : "A234-1234-1234",
     "eventTime" : "2018-04-05T17:31:00Z",
@@ -156,7 +154,6 @@ Example event with `Binary`-valued data
 {
     "cloudEventsVersion" : "0.1",
     "eventType" : "com.example.someevent",
-    "eventTypeVersion" : "1.0",
     "source" : "/mycontext",
     "eventID" : "B234-1234-1234",
     "eventTime" : "2018-04-05T17:31:00Z",
@@ -175,7 +172,6 @@ a `Map` or [JSON data](#31-special-handling-of-the-data-attribute) data:
 {
     "cloudEventsVersion" : "0.1",
     "eventType" : "com.example.someevent",
-    "eventTypeVersion" : "1.0",
     "source" : "/mycontext",
     "eventID" : "C234-1234-1234",
     "eventTime" : "2018-04-05T17:31:00Z",

--- a/spec.md
+++ b/spec.md
@@ -312,15 +312,6 @@ both appear within the same JSON object.
 * Examples
    * com.github.pull.create
 
-### eventTypeVersion
-* Type: `String`
-* Description: The version of the `eventType`. This enables the interpretation
-  of `data` by eventual consumers, requires the consumer to be knowledgeable
-  about the producer.
-* Constraints:
-  * OPTIONAL
-  * If present, MUST be a non-empty string
-
 ### cloudEventsVersion
 * Type: `String`
 * Description: The version of the CloudEvents specification which the event
@@ -360,6 +351,7 @@ both appear within the same JSON object.
 ### schemaURL
 * Type: `URI`
 * Description: A link to the schema that the `data` attribute adheres to.
+Incompatible changes to the schema SHOULD result in a new schema version.
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in

--- a/spec.md
+++ b/spec.md
@@ -351,7 +351,7 @@ both appear within the same JSON object.
 ### schemaURL
 * Type: `URI`
 * Description: A link to the schema that the `data` attribute adheres to.
-Incompatible changes to the schema SHOULD result in a new schema version.
+Incompatible changes to the schema SHOULD be reflected by a different URL.
 * Constraints:
   * OPTIONAL
   * If present, MUST adhere to the format specified in
@@ -409,8 +409,8 @@ encapsulated within the `data` attribute.
 
 ### data
 * Type: `Object`
-* Description: The event payload. The payload depends on the eventType,
-  schemaURL and eventTypeVersion, the payload is encoded into a media format
+* Description: The event payload. The payload depends on the eventType and
+  the schemaURL. It is encoded into a media format
   which is specified by the contentType attribute (e.g. application/json).
 * Constraints:
   * OPTIONAL
@@ -423,7 +423,6 @@ The following example shows a CloudEvent serialized as JSON:
 {
     "cloudEventsVersion" : "0.1",
     "eventType" : "com.example.someevent",
-    "eventTypeVersion" : "1.0",
     "source" : "/mycontext",
     "eventID" : "A234-1234-1234",
     "eventTime" : "2018-04-05T17:31:00Z",


### PR DESCRIPTION
This solves https://github.com/cloudevents/spec/issues/142
I added a sentence to the definition of schemaURL claiming that incompatible changes to the schema SHOULD result in a new schema version. Please let me know, if you are fine with this. 