### PR TITLE
Add JSONSchema Validation

### DIFF
--- a/json-format.md
+++ b/json-format.md
@@ -91,6 +91,12 @@ The following table shows exemplary mappings:
 | data               | Binary   | "Q2xvdWRFdmVudHM="
 | data               | Map      | { "objA" : "vA", "objB", "vB" }
 
+## 2.5. JSONSchema Validation
+
+The CloudEvents [JSONSchema](http://json-schema.org) for the spec is located
+[here](spec.json) and contains the definitions for validating events in JSON.
+
+
 ## 3. Envelope
 
 Each CloudEvents event can be wholly represented as a JSON object.

--- a/spec.json
+++ b/spec.json
@@ -1,0 +1,74 @@
+{
+  "$ref": "#/definitions/event",
+  "definitions": {
+    "cloudEventsVersion": {
+      "type": "string"
+    },
+    "contentType": {
+      "type": "string"
+    },
+    "data": {
+      "type": [
+        "object",
+        "string"
+      ]
+    },
+    "event": {
+      "properties": {
+        "cloudEventsVersion": {
+          "$ref": "#/definitions/cloudEventsVersion"
+        },
+        "contentType": {
+          "$ref": "#/definitions/contentType"
+        },
+        "data": {
+          "$ref": "#/definitions/data"
+        },
+        "eventID": {
+          "$ref": "#/definitions/eventID"
+        },
+        "eventTime": {
+          "$ref": "#/definitions/eventTime"
+        },
+        "eventType": {
+          "$ref": "#/definitions/eventType"
+        },
+        "extensions": {
+          "$ref": "#/definitions/extensions"
+        },
+        "source": {
+          "$ref": "#/definitions/source"
+        }
+      },
+      "required": [
+        "eventType",
+        "cloudEventsVersion",
+        "source",
+        "eventID",
+        "eventTime",
+        "extensions",
+        "contentType",
+        "data"
+      ],
+      "type": "object"
+    },
+    "eventID": {
+      "type": "string"
+    },
+    "eventTime": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "eventType": {
+      "type": "string"
+    },
+    "extensions": {
+      "type": "object"
+    },
+    "source": {
+      "format": "uri",
+      "type": "string"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This adds a JSONSchema validation document and some docs on how
to validate events in JSON.

Fix #272

Signed-off-by: David Brown <dmlb2000@gmail.com>