### PR TITLE
Technical motivation for keeping extension attributes minimal

### DIFF
--- a/primer.md
+++ b/primer.md
@@ -159,6 +159,12 @@ transportation or processing of the CloudEvent, should instead be placed
 within the proper extensibility points of the event (the `data` attribute)
 itself.
 
+Extension attributes should be kept minimal to ensure the CloudEvent can be
+properly serialized and transported. For example, the
+[HTTP Binary Mode](http-transport-binding.md#31-binary-content-mode) uses HTTP
+headers to transport metadata. Most HTTP servers will reject requests with
+excessive HTTP header data, with limits as low as 8kb.
+
 The specification places no restrictions on the type of the extension
 attributes. Meaning, they may be simple types (e.g. strings, integers),
 complex (e.g. structured) or undefined collection of attributes.

--- a/primer.md
+++ b/primer.md
@@ -161,9 +161,12 @@ itself.
 
 Extension attributes should be kept minimal to ensure the CloudEvent can be
 properly serialized and transported. For example, the
+Event producers should consider the technical limitations that might be
+encountered when adding extensions to a CloudEvent. For example, the
 [HTTP Binary Mode](http-transport-binding.md#31-binary-content-mode) uses HTTP
-headers to transport metadata. Most HTTP servers will reject requests with
-excessive HTTP header data, with limits as low as 8kb.
+headers to transport metadata; most HTTP servers will reject requests with
+excessive HTTP header data, with limits as low as 8kb. Therefore, the aggregate
+size and number of extension attributes should be kept minimal.
 
 The specification places no restrictions on the type of the extension
 attributes. Meaning, they may be simple types (e.g. strings, integers),


### PR DESCRIPTION
This paragraph should provide technical motivation for keeping the usage of extension attributes in check. For background information, see https://github.com/cloudevents/spec/issues/286

I expect that the following paragraph from https://github.com/cloudevents/spec/pull/277 will precede the paragraph I'm proposing, which provides a more conceptual motivation for limiting the usage:

```
Extension attributes to the CloudEvent specification are meant to
be additional metadata that needs to be included to help ensure proper
routing and processing of the CloudEvent. Additional metadata for other
purposes, that is related to the event itself and not needed in the
transportation of the CloudEvent, should instead be placed within the proper
extensibility points of the event itself.
```

I do think that at a later point in time we can still have a discussion on whether we want to set actual limits (e.g. a CloudEvent MUST NOT have more than #kb of metadata) or guarantees (e.g. a CloudEvent consumer MUST at least accept events with #kb of metadata) in `spec.md`.

However, I believe this change in the primer would not be affected much by that discussion.

Signed-off-by: Christoph Neijenhuis <christoph.neijenhuis@commercetools.de>