### PR TITLE
Make OWNERS point to the spreadsheet for our list of 'approvers'

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -40,7 +40,7 @@ There are three categories of project membership:
     operations of the group, Voting Members and Members are the same with
     respect to influence over the groups actions. The rights associated with
     being a Voting Member only apply in the event of a formal vote being taken.
-3 - Admins. Admins are Members of the group but have the ability to perform
+3 - Admin. Admins are Members of the group but have the ability to perform
     administrative actions on behalf of the group. For example, manage the
     website, github repos and moderate the meetings. Their actions should
     be done with the knowledge and consent of the group. They also have the

--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,11 @@
-# This file contains the current list of "Admins" for the CloudEvents
-# group. See the GOVERNANCE.md document for more information on their
-# roles and responsibilities.
-- duglin
-- markpeek
-- kenowens12
+# See the GOVERNANCE.md document for the definition of the roles and
+# responsibilities
+admins:
+  - duglin
+  - markpeek
+  - kenowens12
+approvers:
+  # Approvers are "Voting Members" as defined in the GOVERNANCE.md document.
+  # See the "Voting Rights?" column in:
+  # https://docs.google.com/spreadsheets/d/1bw5s9sC2ggYyAiGJHEk7xm-q2KG6jyrfBy69ifkdmt0/edit?pli=1#gid=0
+  # for the current list of Voting members


### PR DESCRIPTION
Right now our 'approvers' == 'Voting members', so make that clear in our
OWNERS doc - just for completeness.

Signed-off-by: Doug Davis <dug@us.ibm.com>