### PR TITLE
Restrict character set (keep case-sensitivity/camelCase), dashes for HTTP case-insensitivity

### DIFF
--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -165,9 +165,9 @@ each attribute name MUST be prefixed with "CE-".
 
 Note: per the [HTTP](https://tools.ietf.org/html/rfc7230#section-3.2)
 specification, header names are case-insensitive. Upper-case letters are
-prefixed with a dash ("-"). When converting a HTTP Header Name back, the dash
-converts the following letter back to upper-case, all other letters are
-lower-case.
+prefixed with a dash ("-"). When converting a HTTP Header Name back, the
+prefixed "CE-" is ignored. All other dashes convert the following letter back
+to upper-case, all other letters are lower-case.
 
 Examples:
 

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -163,16 +163,23 @@ Except for attributes [explicitly handled in this specification]
 HTTP header mapping of well-known CloudEvents attributes is that 
 each attribute name MUST be prefixed with "CE-".
 
+Note: per the [HTTP](https://tools.ietf.org/html/rfc7230#section-3.2)
+specification, header names are case-insensitive. Upper-case letters are
+prefixed with a dash ("-"). When converting a HTTP Header Name back, the dash
+converts the following letter back to upper-case, all other letters are
+lower-case.
+
 Examples:
 
-    * `eventTime` maps to `CE-EventTime`
-    * `eventID` maps to `CE-EventID`
-    * `cloudEventsVersion` maps to `CE-CloudEventsVersion`
+    * `eventTime` maps to `CE-Event-Time`
+    * `eventID` maps to `CE-Event-I-D`
+    * `cloudEventsVersion` maps to `CE-Cloud-Events-Version`
+    * The HTTP Header `CE-COM-exAMPle-attrib` maps back to `comExampleAttrib`
 
 `Map`-typed CloudEvents attributes MUST be flattened into a set
 of HTTP headers, where by the name of each header carries the prefix
-"CE-", an infix reflecting the map attribute followed by a dash 
-("-"), and the name of the map entry key, e.g. "CE-attrib-key".
+"CE-", an infix reflecting the map attribute followed by a plus 
+("+"), and the name of the map entry key, e.g. "CE-attrib+key".
 
 CloudEvents extensions that define their own attributes MAY define a 
 diverging mapping to HTTP headers for those attributes, especially if 
@@ -180,9 +187,6 @@ specific header names need to align with HTTP features or with
 other specifications that have explicit HTTP header bindings. If specific
 names are not required, extensions SHOULD follow the naming convention
 cited here.
-
-Note: per the [HTTP](https://tools.ietf.org/html/rfc7230#section-3.2)
-specification, header names are case-insensitive.
 
 ##### 3.1.3.2 HTTP Header Values
 
@@ -216,10 +220,10 @@ request:
 ``` text
 POST /someresource HTTP/1.1
 Host: webhook.example.com
-CE-CloudEventsVersion: "0.1"
-CE-EventType: "com.example.someevent"
-CE-EventTime: "2018-04-05T03:56:24Z"
-CE-EventID: "1234-1234-1234"
+CE-Cloud-Events-Version: "0.1"
+CE-Event-Type: "com.example.someevent"
+CE-Event-Time: "2018-04-05T03:56:24Z"
+CE-Event-I-D: "1234-1234-1234"
 CE-Source: "/mycontext/subcontext"
     .... further attributes ...
 Content-Type: application/json; charset=utf-8
@@ -234,10 +238,10 @@ This example shows a response containing an event:
 
 ``` text
 HTTP/1.1 200 OK
-CE-CloudEventsVersion: "0.1"
-CE-EventType: "com.example.someevent"
-CE-EventTime: "2018-04-05T03:56:24Z"
-CE-EventID: "1234-1234-1234"
+CE-Cloud-Events-Version: "0.1"
+CE-Event-Type: "com.example.someevent"
+CE-Event-Time: "2018-04-05T03:56:24Z"
+CE-Event-I-D: "1234-1234-1234"
 CE-Source: "/mycontext/subcontext"
     .... further attributes ...
 Content-Type: application/json; charset=utf-8

--- a/spec.md
+++ b/spec.md
@@ -49,15 +49,19 @@ be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 ### Attribute Naming Convention
 
-CloudEvents attributes use "camelCasing" for the object member names, to aid
-integration with common programming languages.
+To aid integration with common programming languages, CloudEvents attributes
+MUST only contain alpha-numeric characters, and MUST start with a letter.
 
-Attribute names that are composed of multiple words are expressed as compound
-words, with the first word starting with a lower-case character and all
-subsequent words starting with an upper-case character, and no separator
-characters.
+Attribute names use "camelCasing" for the object member names: they are composed
+of multiple words are expressed as compound words, with the first word starting
+with a lower-case character and all subsequent words starting with an upper-case
+character, and no separator characters.
 
 Words that are acronyms are written in all-caps, e.g. "ID" and "URL".
+
+Protocols or SDKs MAY have a different convention (e.g. snake_case), but MUST
+ensure that the attribute name is converted back, without loss of information,
+when the CloudEvent is passed along to a different protocol.
 
 ### Terminology
 
@@ -169,6 +173,9 @@ the identity attributes to the "context attributes" so that
 event consumers can easily access this information without needing to decode
 and examine the event data. Such identity attributes can also be used to
 help intermediate gateways determine how to route the events.
+
+Extension Attributes MUST follow the [Attribute Naming
+Convention](spec.md#attribute-naming-convention).
 
 ### eventType
 * Type: `String`

--- a/spec.md
+++ b/spec.md
@@ -175,7 +175,7 @@ and examine the event data. Such identity attributes can also be used to
 help intermediate gateways determine how to route the events.
 
 Extension Attributes MUST follow the [Attribute Naming
-Convention](spec.md#attribute-naming-convention).
+Convention](#attribute-naming-convention).
 
 ### eventType
 * Type: `String`


### PR DESCRIPTION
Currently, an (extension) attribute name isn't limited in any way. This poses problems for Transport Bindings and SDKs if they have to work with any string. Protocols may only support a (subset of) ASCII for names, or some programming languages only allow alphanumeric characters.

In particular for HTTP, Headers are case-insensitive, see https://github.com/cloudevents/spec/issues/177 and the following discussion on the headaches involved with having to deal with any possible string.

With this PR, I'm proposing to limit attribute names to alphanumeric characters, starting with a letter. This should help fulfill the existing goal to "aid integration with common programming languages".
Transport Bindings and SDKs may represent attribute names differently, but must convert them back without loss (see https://github.com/cloudevents/spec/issues/177#issuecomment-423462921).

To show how this will help Transport Bindings, I've fixed https://github.com/cloudevents/spec/issues/177 and https://github.com/cloudevents/spec/issues/265 in the HTTP Binding.

PS: While GitHub shows the http file first, I suggest to start with the changes in `spec.md`.