### PR TITLE
Add some dates to our complete roadmap items

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -5,14 +5,14 @@ The CloudEvents Roadmap.
 _Note: The ordered lists for each milestone provide a way to reference each
 item; they don't imply an order for implementation._
 
-*Setup*
+*Setup* - Completed - 2018/02/26
 
 1. Establish governance, contributing guidelines and initial stakeholders.
 1. Define design goals for CloudEvents V.1.
 1. Describe the scope of the specification.
 1. Draft educational materials that provide context for reading the spec.
 
-*0.1*
+*0.1* - Completed - 2018/04/20
 
 1. Draft specification that project members agree *could* provide
    interoperability.


### PR DESCRIPTION
While it might be clear based on our version number where we are
in our plan/roadmap - I thought it might be good to put dates next
to each milestone.

For v0.1 it was easy, I just picked the date the release was cut.
For "Setup" it was a bit of a guess since its a unclear when we actually
complete ALL of those items. I picked Feb 26th since that was the date
we merged Dan's PR to add a LICENSE doc. It seemed as good of a date as
any - not sure it matters much.

Signed-off-by: Doug Davis <dug@us.ibm.com>