### PR TITLE
Clarify our docs in the README per #268

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,25 @@ a Cloud Native sandbox level project on
 
 ## CloudEvents Documents
 
-The following specifications are available:
+The following documents are available:
 
 | | Latest Release | Working Draft |
 | :--- | :---: | :---: |
-| **CloudEvents** | [v0.1](https://github.com/cloudevents/spec/blob/v0.1/spec.md) | [master](https://github.com/cloudevents/spec/blob/master/spec.md) |
-| **HTTP Transport Binding** | [v0.1](https://github.com/cloudevents/spec/blob/v0.1/http-transport-binding.md) | [master](https://github.com/cloudevents/spec/blob/master/http-transport-binding.md) |
-| **JSON Event Format** | [v0.1](https://github.com/cloudevents/spec/blob/v0.1/json-format.md) | [master](https://github.com/cloudevents/spec/blob/master/json-format.md) |
-| **Web hook** | - | [master](https://github.com/cloudevents/spec/blob/master/http-webhook.md) |
-| **NATS Transport Binding** | - | [master](https://github.com/cloudevents/spec/blob/master/nats-transport-binding.md) |
-| **AMQP Event Format** | - | [master](https://github.com/cloudevents/spec/blob/master/amqp-format.md) |
-| **AMQP Transport Binding** | - | [master](https://github.com/cloudevents/spec/blob/master/amqp-transport-binding.md) |
+| **Core Specification:** |
+| CloudEvents | [v0.1](https://github.com/cloudevents/spec/blob/v0.1/spec.md) | [master](https://github.com/cloudevents/spec/blob/master/spec.md) |
+| |
+| **Optional Specifications:** |
+| HTTP Transport Binding | [v0.1](https://github.com/cloudevents/spec/blob/v0.1/http-transport-binding.md) | [master](https://github.com/cloudevents/spec/blob/master/http-transport-binding.md) |
+| JSON Event Format | [v0.1](https://github.com/cloudevents/spec/blob/v0.1/json-format.md) | [master](https://github.com/cloudevents/spec/blob/master/json-format.md) |
+| Web hook | - | [master](https://github.com/cloudevents/spec/blob/master/http-webhook.md) |
+| NATS Transport Binding | - | [master](https://github.com/cloudevents/spec/blob/master/nats-transport-binding.md) |
+| AMQP Event Format | - | [master](https://github.com/cloudevents/spec/blob/master/amqp-format.md) |
+| AMQP Transport Binding | - | [master](https://github.com/cloudevents/spec/blob/master/amqp-transport-binding.md) |
+| |
+| **Additional Documentation:** |
+| Primer | - | [master](https://github.com/cloudevents/spec/blob/master/primer.md) |
+| Documented Extensions | | [master](https://github.com/cloudevents/spec/blob/master/documented-extensions.md) |
 
-There is also the
-[CloudEvents documented extension attributes](https://github.com/cloudevents/spec/blob/master/documented-extensions.md)
-document and a [CloudEvents Primer](primer.md) to help understand some of
-the history and design goals of the project.
 
 ## Community
 


### PR DESCRIPTION
Closes #268

Per #268 I tried to make it clear which specs are optional by adding
sections/headers to the table of docs we produce.

ping @dmlb2000 - does this address your concern?

Signed-off-by: Doug Davis <dug@us.ibm.com>