### PR TITLE
Rename URI to URI-reference, fix JSON Schema

### DIFF
--- a/amqp-format.md
+++ b/amqp-format.md
@@ -53,14 +53,14 @@ system, which this mapping leans on.
 The CloudEvents type system MUST be mapped to AMQP types as follows,
 with exceptions noted below.
 
-| CloudEvents | AMQP
-|-------------|-------------------------------------------------------------
-| String      | [string][AMQP-String]
-| Binary      | [binary][AMQP-Binary]
-| URI         | [string][AMQP-String]
-| Timestamp   | [timestamp][AMQP-Timestamp]
-| Map         | [map][AMQP-Map]
-| Any         | See 2.3.
+| CloudEvents   | AMQP
+|---------------|-----------------------------------------------------------
+| String        | [string][AMQP-String]
+| Binary        | [binary][AMQP-Binary]
+| URI-reference | [string][AMQP-String]
+| Timestamp     | [timestamp][AMQP-Timestamp]
+| Map           | [map][AMQP-Map]
+| Any           | See 2.3.
 
 Extension specifications MAY define diverging mapping rules for the values of
 attributes they define.

--- a/documented-extensions.md
+++ b/documented-extensions.md
@@ -44,9 +44,9 @@ pre-existing specs; extensions with custom transport bindings are much
 more likely to be dropped by middleware that does not understand the
 extension.
 
-As a convention, extensions of scalar types (e.g. `String`, `Binary`, `URI`,
-`Number`) document their `Value` and structured types document their
-`Attributes`.
+As a convention, extensions of scalar types (e.g. `String`, `Binary`,
+`URI-reference`, `Number`) document their `Value` and structured types document
+their `Attributes`.
 
 ## Known Extensions
 

--- a/json-format.md
+++ b/json-format.md
@@ -53,14 +53,14 @@ system, which this mapping leans on.
 The CloudEvents type system MUST be mapped to JSON types as follows, with
 exceptions noted below.
 
-| CloudEvents  | JSON
-|--------------|-------------------------------------------------------------
-| String       | [string][JSON-String]
-| Binary       | [string][JSON-String], [Base64-encoded][base64] binary
-| URI          | [string][JSON-String]
-| Timestamp    | [string][JSON-String]
-| Map          | [JSON object][JSON-Object]
-| Any          | [JSON value][JSON-Value]
+| CloudEvents   | JSON
+|---------------|------------------------------------------------------------
+| String        | [string][JSON-String]
+| Binary        | [string][JSON-String], [Base64-encoded][base64] binary
+| URI-reference | [string][JSON-String]
+| Timestamp     | [string][JSON-String]
+| Map           | [JSON object][JSON-Object]
+| Any           | [JSON value][JSON-Value]
 
 Extension specifications MAY define diverging mapping rules for the values of
 attributes they define.
@@ -93,17 +93,17 @@ values become the respective member's value.
 
 The following table shows exemplary mappings:
 
-| CloudEvents       | Type     | Exemplary JSON Value
-|--------------------|----------|-------------------------------
-| eventtype          | String   | "com.example.someevent"
-| cloudeventsversion | String   | "0.1"
-| source             | URI      | "/mycontext"
-| eventid            | String   | "1234-1234-1234"
-| eventtime          | Timestamp| "2018-04-05T17:31:00Z"
-| contenttype        | String   | "application/json"
-| data               | String   | "<much wow=\"xml\"/>"
-| data               | Binary   | "Q2xvdWRFdmVudHM="
-| data               | Map      | { "objA" : "vA", "objB", "vB" }
+| CloudEvents        | Type          | Exemplary JSON Value
+|--------------------|---------------|--------------------------
+| eventtype          | String        | "com.example.someevent"
+| cloudeventsversion | String        | "0.1"
+| source             | URI-reference | "/mycontext"
+| eventid            | String        | "1234-1234-1234"
+| eventtime          | Timestamp     | "2018-04-05T17:31:00Z"
+| contenttype        | String        | "application/json"
+| data               | String        | "<much wow=\"xml\"/>"
+| data               | Binary        | "Q2xvdWRFdmVudHM="
+| data               | Map           | { "objA" : "vA", "objB", "vB" }
 
 ## 2.5. JSONSchema Validation
 

--- a/spec.json
+++ b/spec.json
@@ -62,7 +62,7 @@
       "type": "object"
     },
     "source": {
-      "format": "uri",
+      "format": "uri-reference",
       "type": "string"
     }
   },

--- a/spec.md
+++ b/spec.md
@@ -116,7 +116,7 @@ The following abstract data types are available for use in attributes.
 - `Binary` - Sequence of bytes.
 - `Map` - `String`-indexed dictionary of `Any`-typed values.
 - `Any` - Either a `String`, or a `Binary`, or a `Map`, or an `Integer`.
-- `URI` - String expression conforming to `URI-reference`
+- `URI-reference` - String expression conforming to `URI-reference`
   as defined in
   [RFC 3986 §4.1](https://tools.ietf.org/html/rfc3986#section-4.1).
 - `Timestamp` - String expression as defined in
@@ -195,7 +195,7 @@ help intermediate gateways determine how to route the events.
   * MUST be a non-empty string
 
 ### source
-* Type: `URI`
+* Type: `URI-reference`
 * Description: This describes the event producer. Often this will include
   information such as the type of the event source, the organization
   publishing the event, and some unique identifiers. The exact syntax and
@@ -204,6 +204,7 @@ help intermediate gateways determine how to route the events.
   * REQUIRED
 * Examples
     * https://github.com/cloudevents/spec/pull/123
+    * /cloudevents/spec/pull/123
     * urn:event:from:myapi/resourse/123
     * mailto:cncf-wg-serverless@lists.cncf.io
 


### PR DESCRIPTION
Following the discussion in https://github.com/cloudevents/spec/issues/332, we figured out that the spec actually meant to support URI-references all along. However, by defining the type as `URI`, it is easy to make a mistake and assume it is only a URI, not a URI-reference.
This mistake was also made in the JSON Schema.

This PR therefore does three things:
* Rename the type to `URI-reference`, in order to make it easier to grasp for others in the future
* Fix the JSON Schema
* Add an example for a relative URI

The main changes are in `spec.md` and `spec.json`.

Signed-off-by: Christoph Neijenhuis <christoph.neijenhuis@commercetools.de>