### PR TITLE
Specify the media type for proto representations

### DIFF
--- a/json-format.md
+++ b/json-format.md
@@ -114,7 +114,7 @@ The CloudEvents [JSONSchema](http://json-schema.org) for the spec is located
 
 Each CloudEvents event can be wholly represented as a JSON object.
 
-Such a representation uses the media type `application/cloudevents+json`.
+Such a representation MUST use the media type `application/cloudevents+json`.
 
 All REQUIRED and all not omitted OPTIONAL attributes in the given event MUST
 become members of the JSON object, with the respective JSON object member name

--- a/protobuf-format.md
+++ b/protobuf-format.md
@@ -88,6 +88,7 @@ The CloudEvents type system MUST be mapped into the fields of
 | Integer      | int_value
 | Any          | Not applicable. Any is the enclosing CloudEventAny message itself
 
+Protocol Buffer representations of CloudEvents use the media type `application/cloudevents+proto`.
 
 ## 3. Examples
 

--- a/protobuf-format.md
+++ b/protobuf-format.md
@@ -88,7 +88,7 @@ The CloudEvents type system MUST be mapped into the fields of
 | Integer      | int_value
 | Any          | Not applicable. Any is the enclosing CloudEventAny message itself
 
-Protocol Buffer representations of CloudEvents use the media type `application/cloudevents+proto`.
+Protocol Buffer representations of CloudEvents MUST use the media type `application/cloudevents+proto`.
 
 ## 3. Examples
 


### PR DESCRIPTION
This PR addresses a concern [raised](https://github.com/cloudevents/spec/pull/295#issuecomment-435609246) by @JemDay that the [proto spec](https://github.com/cloudevents/spec/blob/master/protobuf-format.md) didn't specify which media type should be used in the envelopes for messages using the proto spec. 

This follows the convention of the json spec and specifies the media type of `application/cloudevents+proto`.