### PR TITLE
change specversion to cloudeventsversion to maintain compatibility

### DIFF
--- a/amqp-transport-binding.md
+++ b/amqp-transport-binding.md
@@ -174,7 +174,7 @@ Examples:
 
     * `time` maps to `cloudEvents:time`
     * `id` maps to `cloudEvents:id`
-    * `specversion` maps to `cloudEvents:specversion`
+    * `cloudeventsversioin` maps to `cloudEvents:cloudeventsversioin`
 
 ##### 3.1.3.2 AMQP Application Property Values
 
@@ -195,7 +195,7 @@ content-type: application/json; charset=utf-8
 
 ----------- application-properties -----------
 
-cloudEvents:specversion: "0.1"
+cloudEvents:cloudeventsversioin: "0.1"
 cloudEvents:type: "com.example.someevent"
 cloudEvents:time: "2018-04-05T03:56:24Z"
 cloudEvents:id: "1234-1234-1234"
@@ -257,7 +257,7 @@ content-type: application/cloudevents+json; charset=utf-8
 ------------- application-data --------------------------
 
 {
-    "specversion" : "0.1",
+    "cloudeventsversioin" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/amqp-transport-binding.md
+++ b/amqp-transport-binding.md
@@ -174,7 +174,7 @@ Examples:
 
     * `time` maps to `cloudEvents:time`
     * `id` maps to `cloudEvents:id`
-    * `cloudeventsversioin` maps to `cloudEvents:cloudeventsversioin`
+    * `cloudeventsversion` maps to `cloudEvents:cloudeventsversion`
 
 ##### 3.1.3.2 AMQP Application Property Values
 
@@ -195,7 +195,7 @@ content-type: application/json; charset=utf-8
 
 ----------- application-properties -----------
 
-cloudEvents:cloudeventsversioin: "0.1"
+cloudEvents:cloudeventsversion: "0.1"
 cloudEvents:type: "com.example.someevent"
 cloudEvents:time: "2018-04-05T03:56:24Z"
 cloudEvents:id: "1234-1234-1234"
@@ -257,7 +257,7 @@ content-type: application/cloudevents+json; charset=utf-8
 ------------- application-data --------------------------
 
 {
-    "cloudeventsversioin" : "0.1",
+    "cloudeventsversion" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -178,7 +178,7 @@ Examples:
 
     * `time` maps to `ce-time`
     * `id` maps to `ce-id`
-    * `cloudeventsversioin` maps to `ce-cloudeventsversioin`
+    * `cloudeventsversion` maps to `ce-cloudeventsversion`
 
 `Map`-typed CloudEvents attributes MUST be flattened into a set
 of HTTP headers, where by the name of each header carries the prefix
@@ -220,7 +220,7 @@ request:
 ``` text
 POST /someresource HTTP/1.1
 Host: webhook.example.com
-ce-cloudeventsversioin: "0.1"
+ce-cloudeventsversion: "0.1"
 ce-type: "com.example.someevent"
 ce-time: "2018-04-05T03:56:24Z"
 ce-id: "1234-1234-1234"
@@ -238,7 +238,7 @@ This example shows a response containing an event:
 
 ``` text
 HTTP/1.1 200 OK
-ce-cloudeventsversioin: "0.1"
+ce-cloudeventsversion: "0.1"
 ce-type: "com.example.someevent"
 ce-time: "2018-04-05T03:56:24Z"
 ce-id: "1234-1234-1234"
@@ -297,7 +297,7 @@ Content-Type: application/cloudevents+json; charset=utf-8
 Content-Length: nnnn
 
 {
-    "cloudeventsversioin" : "0.1",
+    "cloudeventsversion" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -318,7 +318,7 @@ Content-Type: application/cloudevents+json; charset=utf-8
 Content-Length: nnnn
 
 {
-    "cloudeventsversioin" : "0.1",
+    "cloudeventsversion" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -178,7 +178,7 @@ Examples:
 
     * `time` maps to `ce-time`
     * `id` maps to `ce-id`
-    * `specversion` maps to `ce-specversion`
+    * `cloudeventsversioin` maps to `ce-cloudeventsversioin`
 
 `Map`-typed CloudEvents attributes MUST be flattened into a set
 of HTTP headers, where by the name of each header carries the prefix
@@ -220,7 +220,7 @@ request:
 ``` text
 POST /someresource HTTP/1.1
 Host: webhook.example.com
-ce-specversion: "0.1"
+ce-cloudeventsversioin: "0.1"
 ce-type: "com.example.someevent"
 ce-time: "2018-04-05T03:56:24Z"
 ce-id: "1234-1234-1234"
@@ -238,7 +238,7 @@ This example shows a response containing an event:
 
 ``` text
 HTTP/1.1 200 OK
-ce-specversion: "0.1"
+ce-cloudeventsversioin: "0.1"
 ce-type: "com.example.someevent"
 ce-time: "2018-04-05T03:56:24Z"
 ce-id: "1234-1234-1234"
@@ -297,7 +297,7 @@ Content-Type: application/cloudevents+json; charset=utf-8
 Content-Length: nnnn
 
 {
-    "specversion" : "0.1",
+    "cloudeventsversioin" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -318,7 +318,7 @@ Content-Type: application/cloudevents+json; charset=utf-8
 Content-Length: nnnn
 
 {
-    "specversion" : "0.1",
+    "cloudeventsversioin" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/json-format.md
+++ b/json-format.md
@@ -96,7 +96,7 @@ The following table shows exemplary mappings:
 | CloudEvents        | Type          | Exemplary JSON Value
 |--------------------|---------------|--------------------------
 | type               | String        | "com.example.someevent"
-| cloudeventsversioin        | String        | "0.1"
+| cloudeventsversion        | String        | "0.1"
 | source             | URI-reference | "/mycontext"
 | id                 | String        | "1234-1234-1234"
 | time               | Timestamp     | "2018-04-05T17:31:00Z"
@@ -154,7 +154,7 @@ Example event with `String`-valued `data`:
 
 ``` JSON
 {
-    "cloudeventsversioin" : "0.1",
+    "cloudeventsversion" : "0.1",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "A234-1234-1234",
@@ -172,7 +172,7 @@ Example event with `Binary`-valued data
 
 ``` JSON
 {
-    "cloudeventsversioin" : "0.1",
+    "cloudeventsversion" : "0.1",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "B234-1234-1234",
@@ -191,7 +191,7 @@ a `Map` or [JSON data](#31-special-handling-of-the-data-attribute) data:
 
 ``` JSON
 {
-    "cloudeventsversioin" : "0.1",
+    "cloudeventsversion" : "0.1",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "C234-1234-1234",

--- a/json-format.md
+++ b/json-format.md
@@ -96,7 +96,7 @@ The following table shows exemplary mappings:
 | CloudEvents        | Type          | Exemplary JSON Value
 |--------------------|---------------|--------------------------
 | type               | String        | "com.example.someevent"
-| specversion        | String        | "0.1"
+| cloudeventsversioin        | String        | "0.1"
 | source             | URI-reference | "/mycontext"
 | id                 | String        | "1234-1234-1234"
 | time               | Timestamp     | "2018-04-05T17:31:00Z"
@@ -154,7 +154,7 @@ Example event with `String`-valued `data`:
 
 ``` JSON
 {
-    "specversion" : "0.1",
+    "cloudeventsversioin" : "0.1",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "A234-1234-1234",
@@ -172,7 +172,7 @@ Example event with `Binary`-valued data
 
 ``` JSON
 {
-    "specversion" : "0.1",
+    "cloudeventsversioin" : "0.1",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "B234-1234-1234",
@@ -191,7 +191,7 @@ a `Map` or [JSON data](#31-special-handling-of-the-data-attribute) data:
 
 ``` JSON
 {
-    "specversion" : "0.1",
+    "cloudeventsversioin" : "0.1",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "C234-1234-1234",

--- a/mqtt-transport-binding.md
+++ b/mqtt-transport-binding.md
@@ -195,7 +195,7 @@ Content Type: application/json; charset=utf-8
 
 ------------- User Properties ----------------
 
-cloudeventsversioin: "0.1"
+cloudeventsversion: "0.1"
 type: "com.example.someevent"
 time: "2018-04-05T03:56:24Z"
 id: "1234-1234-1234"
@@ -257,7 +257,7 @@ Content Type: application/cloudevents+json; charset=utf-8
 ------------------ payload -------------------
 
 {
-    "cloudeventsversioin" : "0.1",
+    "cloudeventsversion" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -282,7 +282,7 @@ Topic Name: mytopic
 ------------------ payload -------------------
 
 {
-    "cloudeventsversioin" : "0.1",
+    "cloudeventsversion" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/mqtt-transport-binding.md
+++ b/mqtt-transport-binding.md
@@ -195,7 +195,7 @@ Content Type: application/json; charset=utf-8
 
 ------------- User Properties ----------------
 
-specversion: "0.1"
+cloudeventsversioin: "0.1"
 type: "com.example.someevent"
 time: "2018-04-05T03:56:24Z"
 id: "1234-1234-1234"
@@ -257,7 +257,7 @@ Content Type: application/cloudevents+json; charset=utf-8
 ------------------ payload -------------------
 
 {
-    "specversion" : "0.1",
+    "cloudeventsversioin" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -282,7 +282,7 @@ Topic Name: mytopic
 ------------------ payload -------------------
 
 {
-    "specversion" : "0.1",
+    "cloudeventsversioin" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/nats-transport-binding.md
+++ b/nats-transport-binding.md
@@ -122,7 +122,7 @@ Subject: mySubject
 ------------------ payload -------------------
 
 {
-    "specversion" : "0.1",
+    "cloudeventsversioin" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/nats-transport-binding.md
+++ b/nats-transport-binding.md
@@ -122,7 +122,7 @@ Subject: mySubject
 ------------------ payload -------------------
 
 {
-    "cloudeventsversioin" : "0.1",
+    "cloudeventsversion" : "0.1",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/spec.json
+++ b/spec.json
@@ -1,7 +1,7 @@
 {
   "$ref": "#/definitions/event",
   "definitions": {
-    "specversion": {
+    "cloudeventsversioin": {
       "type": "string"
     },
     "contenttype": {
@@ -15,8 +15,8 @@
     },
     "event": {
       "properties": {
-        "specversion": {
-          "$ref": "#/definitions/specversion"
+        "cloudeventsversioin": {
+          "$ref": "#/definitions/cloudeventsversioin"
         },
         "contenttype": {
           "$ref": "#/definitions/contenttype"
@@ -41,7 +41,7 @@
         }
       },
       "required": [
-        "specversion",
+        "cloudeventsversioin",
         "id",
         "type",
         "source"

--- a/spec.json
+++ b/spec.json
@@ -1,7 +1,7 @@
 {
   "$ref": "#/definitions/event",
   "definitions": {
-    "cloudeventsversioin": {
+    "cloudeventsversion": {
       "type": "string"
     },
     "contenttype": {
@@ -15,8 +15,8 @@
     },
     "event": {
       "properties": {
-        "cloudeventsversioin": {
-          "$ref": "#/definitions/cloudeventsversioin"
+        "cloudeventsversion": {
+          "$ref": "#/definitions/cloudeventsversion"
         },
         "contenttype": {
           "$ref": "#/definitions/contenttype"
@@ -41,7 +41,7 @@
         }
       },
       "required": [
-        "cloudeventsversioin",
+        "cloudeventsversion",
         "id",
         "type",
         "source"

--- a/spec.md
+++ b/spec.md
@@ -183,7 +183,7 @@ help intermediate gateways determine how to route the events.
 * Examples
    * com.github.pull.create
 
-### specversion
+### cloudeventsversioin
 * Type: `String`
 * Description: The version of the CloudEvents specification which the event
   uses. This enables the interpretation of the context.
@@ -284,7 +284,7 @@ The following example shows a CloudEvent serialized as JSON:
 
 ``` JSON
 {
-    "specversion" : "0.1",
+    "cloudeventsversioin" : "0.1",
     "type" : "com.github.pull.create",
     "source" : "https://github.com/cloudevents/spec/pull/123",
     "id" : "A234-1234-1234",

--- a/spec.md
+++ b/spec.md
@@ -183,7 +183,7 @@ help intermediate gateways determine how to route the events.
 * Examples
    * com.github.pull.create
 
-### cloudeventsversioin
+### cloudeventsversion
 * Type: `String`
 * Description: The version of the CloudEvents specification which the event
   uses. This enables the interpretation of the context.
@@ -284,7 +284,7 @@ The following example shows a CloudEvent serialized as JSON:
 
 ``` JSON
 {
-    "cloudeventsversioin" : "0.1",
+    "cloudeventsversion" : "0.1",
     "type" : "com.github.pull.create",
     "source" : "https://github.com/cloudevents/spec/pull/123",
     "id" : "A234-1234-1234",


### PR DESCRIPTION
as described in issue #349, I am creating this pull request to reinstate the cloudeventsversion for the compatibility issue, as it's the identifier for each version of the cloudevents spec and used as discriminator in swagger. 

Signed-off-by: Kevin, Wen kevin.wen@oracle.com