### PR TITLE
Transports are responsible for batching messages

### DIFF
--- a/primer.md
+++ b/primer.md
@@ -119,7 +119,8 @@ and transports (e.g. HTTP, AMQP, Kafka).
 
 Batching of multiple events into a single API call is natively supported by some
 transports. To aid interoperability, it is left up to the transports if and how
-batching is implemented.
+batching is implemented. Details may be found in the transport binding or in
+the transport specification.
 
 ### Non-Goals
 The following will not be part of the specification:

--- a/primer.md
+++ b/primer.md
@@ -114,8 +114,12 @@ and processing, of the message. Data that is not intended for that purpose
 should instead be placed within the event (the `data` attribute) itself.
 
 Along with the definition of these attributes, there will also be
-specifications of how to serialize the event in different formats and
-transports (e.g. JSON and HTTP).
+specifications of how to serialize the event in different formats (e.g. JSON)
+and transports (e.g. HTTP, AMQP, Kafka).
+
+Batching of multiple events into a single API call is natively supported by some
+transports. To aid interoperability, it is left up to the transports if and how
+batching is implemented.
 
 ### Non-Goals
 The following will not be part of the specification:


### PR DESCRIPTION
Follow up to the discussions in #330 and #282 : Since it seems to be a frequently asked question, we should somewhere in the spec write down how to handle multiple messages.

I think the `primer.md` is the place that fits best. I'm not sure if the Design Goal section is a perfect fit, but I didn't find a better place.