### PR TITLE
s/contenttype/datacontenttype/g

### DIFF
--- a/SDK.md
+++ b/SDK.md
@@ -63,7 +63,7 @@ Event build considered to be an event constructor:
 This particular code sample represents bare minimum number of setters:
 ```
     v01.Event().
-    SetContentType("application/json").
+    SetDataContentType("application/json").
     SetData('{"name":"john"}').
     SetEventID("my-id").
     SetSource("from-galaxy-far-far-away").
@@ -73,7 +73,7 @@ This particular code sample represents bare minimum number of setters:
 
 Content type setter represents an event MIME content type setter:
 ```
-    SetContentType(content_type string)
+    SetDataContentType(content_type string)
 ```
 
 Data setter represents an event data setter:
@@ -122,9 +122,9 @@ Here's the list of getters:
     EventID() -> string
     EventTime() -> RFC3339
     SchemaURL() -> string
+    DataContentType() -> string
     Data() -> serializable
     Extensions() -> map[string]string
-    ContentType() -> string
     
     Get(key string) -> serializable
 

--- a/amqp-transport-binding.md
+++ b/amqp-transport-binding.md
@@ -18,7 +18,7 @@ This document is a working draft.
 - 1.4. [Event Formats](#14-event-formats)
 - 1.5. [Security](#15-security)
 2. [Use of CloudEvents Attributes](#2-use-of-cloudevents-attributes)
-- 2.1. [contenttype Attribute](#21-contenttype-attribute)
+- 2.1. [datacontenttype Attribute](#21-datacontenttype-attribute)
 - 2.2. [data Attribute](#22-data-attribute)
 3. [AMQP Message Mapping](#3-amqp-message-mapping)
 - 3.2. [Binary Content Mode](#31-binary-content-mode)
@@ -65,7 +65,7 @@ using an [event format](#14-event-formats).
 
 In the *binary* content mode, the value of the event `data` attribute is placed
 into the AMQP message's [application data][data] section as-is, with
-the `contenttype` attribute value declaring its media type; all other event
+the `datacontenttype` attribute value declaring its media type; all other event
 attributes are mapped to the AMQP [application-properties][app-properties] section.
 
 ### 1.4. Event Formats
@@ -86,31 +86,31 @@ mandate specific existing features to be used.
 This specification does not further define any of the [CloudEvents][CE] event
 attributes.
 
-Two of the event attributes, `contenttype` and `data` are handled specially
+Two of the event attributes, `datacontenttype` and `data` are handled specially
 and mapped onto AMQP constructs, all other attributes are transferred as
 metadata without further interpretation.
 
 This mapping is intentionally robust against changes, including the addition
 and removal of event attributes, and also accommodates vendor extensions to the
-event metadata. Any mention of event attributes other than `contenttype` and
+event metadata. Any mention of event attributes other than `datacontenttype` and
 `data` is exemplary.
 
-### 2.1. contenttype Attribute
+### 2.1. datacontenttype Attribute
 
-The `contenttype` attribute is assumed to contain a [RFC2046][RFC2046]
+The `datacontenttype` attribute is assumed to contain a [RFC2046][RFC2046]
 compliant media-type expression.
 
 ### 2.2. data Attribute
 
 The `data` attribute is assumed to contain opaque application data that is
-encoded as declared by the `contenttype` attribute.
+encoded as declared by the `datacontenttype` attribute.
 
 An application is free to hold the information in any in-memory representation
 of its choosing, but as the value is transposed into AMQP as defined in this
 specification, the assumption is that the `data` attribute value is made
 available as a sequence of bytes.
 
-For instance, if the declared `contenttype` is
+For instance, if the declared `datacontenttype` is
 `application/json;charset=utf-8`, the expectation is that the `data` attribute
 value is made available as [UTF-8][RFC3629] encoded JSON text for use in
 AMQP.
@@ -140,7 +140,7 @@ efficient transfer and without transcoding effort.
 #### 3.1.1. AMQP content-type
 
 For the *binary* mode, the AMQP `content-type` property field value maps
-directly to the CloudEvents `contenttype` attribute.
+directly to the CloudEvents `datacontenttype` attribute.
 
 #### 3.1.2. Event Data Encoding
 
@@ -149,7 +149,7 @@ The [`data` attribute](#22-data-attribute) byte-sequence is used as the AMQP
 
 #### 3.1.3. Metadata Headers
 
-All [CloudEvents][CE] attributes with exception of `contenttype` and `data`
+All [CloudEvents][CE] attributes with exception of `datacontenttype` and `data`
 MUST be individually mapped to and from the AMQP
 [application-properties][app-properties] section, with exceptions noted
 below.

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -18,7 +18,7 @@ This document is a working draft.
 - 1.4. [Event Formats](#14-event-formats)
 - 1.5. [Security](#15-security)
 2. [Use of CloudEvents Attributes](#2-use-of-cloudevents-attributes)
-- 2.1. [contenttype Attribute](#21-contenttype-attribute)
+- 2.1. [datacontenttype Attribute](#21-datacontenttype-attribute)
 - 2.2. [data Attribute](#22-data-attribute)
 3. [HTTP Message Mapping](#3-http-message-mapping)
 - 3.2. [Binary Content Mode](#31-binary-content-mode)
@@ -67,9 +67,9 @@ placed into the HTTP request or response body using an [event
 format](#14-event-formats).
 
 In the *binary* content mode, the value of the event `data` attribute is placed
-into the HTTP request or response body as-is, with the `contenttype` attribute
-value declaring its media type; all other event attributes are mapped to HTTP
-headers.
+into the HTTP request or response body as-is, with the `datacontenttype`
+attribute value declaring its media type; all other event attributes are
+mapped to HTTP headers.
 
 ### 1.4. Event Formats
 
@@ -89,31 +89,31 @@ identically to [HTTP over TLS]([RFC2818][RFC2818]).
 This specification does not further define any of the [CloudEvents][CE] event
 attributes.
 
-Two of the event attributes, `contenttype` and `data` are handled specially
+Two of the event attributes, `datacontenttype` and `data` are handled specially
 and mapped onto HTTP constructs, all other attributes are transferred as
 metadata without further interpretation.
 
 This mapping is intentionally robust against changes, including the addition
 and removal of event attributes, and also accommodates vendor extensions to the
-event metadata. Any mention of event attributes other than `contenttype` and
+event metadata. Any mention of event attributes other than `datacontenttype` and
 `data` is exemplary.
 
-### 2.1. contenttype Attribute
+### 2.1. datacontenttype Attribute
 
-The `contenttype` attribute is assumed to contain a [RFC2046][RFC2046]
+The `datacontenttype` attribute is assumed to contain a [RFC2046][RFC2046]
 compliant media-type expression.
 
 ### 2.2. data Attribute
 
 The `data` attribute is assumed to contain opaque application data that is
-encoded as declared by the `contenttype` attribute.
+encoded as declared by the `datacontenttype` attribute.
 
 An application is free to hold the information in any in-memory representation
 of its choosing, but as the value is transposed into HTTP as defined in this
 specification, the assumption is that the `data` attribute value is made
 available as a sequence of bytes.
 
-For instance, if the declared `contenttype` is
+For instance, if the declared `datacontenttype` is
 `application/json;charset=utf-8`, the expectation is that the `data` attribute
 value is made available as [UTF-8][RFC3629] encoded JSON text to HTTP.
 
@@ -144,7 +144,7 @@ efficient transfer and without transcoding effort.
 #### 3.1.1. HTTP Content-Type
 
 For the *binary* mode, the HTTP `Content-Type` value maps directly to the
-CloudEvents `contenttype` attribute.
+CloudEvents `datacontenttype` attribute.
 
 #### 3.1.2. Event Data Encoding
 
@@ -153,7 +153,7 @@ message body.
 
 #### 3.1.3. Metadata Headers
 
-All [CloudEvents][CE] attributes with exception of `contenttype` and `data`
+All [CloudEvents][CE] attributes with exception of `datacontenttype` and `data`
 MUST be individually mapped to and from distinct HTTP message headers,
 with exceptions noted below.
 

--- a/json-format.md
+++ b/json-format.md
@@ -113,7 +113,7 @@ The following table shows exemplary mappings:
 | source             | URI-reference | "/mycontext"
 | id                 | String        | "1234-1234-1234"
 | time               | Timestamp     | "2018-04-05T17:31:00Z"
-| contenttype        | String        | "application/json"
+| datacontenttype    | String        | "application/json"
 | data               | String        | "<much wow=\"xml\"/>"
 | data               | Binary        | "Q2xvdWRFdmVudHM="
 | data               | Map           | { "objA" : "vA", "objB", "vB" }
@@ -141,17 +141,18 @@ in [Section 2.3.](#23-mapping-any-typed-attributes), with two additional
 rules:
 
 First, if an implementation determines that the type of the `data` attribute is
-`Binary` or `String`, it MUST inspect the `contenttype` attribute to determine
-whether it is indicated that the data value contains JSON data.
+`Binary` or `String`, it MUST inspect the `datacontenttype` attribute to
+determine whether it is indicated that the data value contains JSON data.
 
-If the `contenttype` value is either ["application/json"][RFC4627] or any media type
-with a [structured +json suffix][RFC6839], the implementation MUST translate
-the `data` attribute value into a [JSON value][JSON-Value], and set the `data`
-attribute of the envelope JSON object to this JSON value.
+If the `datacontenttype` value is either ["application/json"][RFC4627] or any
+media type with a [structured +json suffix][RFC6839], the implementation MUST
+translate the `data` attribute value into a [JSON value][JSON-Value], and set
+the `data` attribute of the envelope JSON object to this JSON value.
 
-If the `contenttype` value does not follow the [structured +json suffix][RFC6839]
-but is known to use JSON encoding, the implementation MUST translate the `data` attribute
-value into a [JSON value][JSON-Value], and set the `data` attribute of the envelope
+If the `datacontenttype` value does not follow the
+[structured +json suffix][RFC6839] but is known to use JSON encoding, the
+implementation MUST translate the `data` attribute value into a
+[JSON value][JSON-Value], and set the `data` attribute of the envelope
 JSON object to this JSON value. Its typical examples are, but not limited to,
 `text/json`, [`application/json-seq`][JSON-seq] and
 [`application/geo+json-seq`][JSON-geoseq].
@@ -162,10 +163,10 @@ member [JSON value][JSON-Value] is unrestricted, and MAY also contain numeric
 and logical JSON types.
 
 Second, whether a Base64-encoded string in the data attribute is treated 
-as `Binary` or as a `String` is also determined by the `contenttype` value. If
-the `contenttype` media type is known to contain text, the data attribute value
-is not further interpreted and treated as a text string. Otherwise, it is decoded
-and treated as a binary value.
+as `Binary` or as a `String` is also determined by the `datacontenttype` value.
+If the `datacontenttype` media type is known to contain text, the data
+attribute value is not further interpreted and treated as a text string.
+Otherwise, it is decoded and treated as a binary value.
 
 
 ### 3.2. Examples
@@ -183,7 +184,7 @@ Example event with `String`-valued `data`:
     "comexampleextension2" : {
         "otherValue": 5
     },
-    "contenttype" : "text/xml",
+    "datacontenttype" : "text/xml",
     "data" : "<much wow=\"xml\"/>"
 }
 ```
@@ -201,7 +202,7 @@ Example event with `Binary`-valued data
     "comexampleextension2" : {
         "otherValue": 5
     },
-    "contenttype" : "application/vnd.apache.thrift.binary",
+    "datacontenttype" : "application/vnd.apache.thrift.binary",
     "data" : "... base64 encoded string ..."
 }
 ```
@@ -220,7 +221,7 @@ a `Map` or [JSON data](#31-special-handling-of-the-data-attribute) data:
     "comexampleextension2" : {
         "otherValue": 5
     },
-    "contenttype" : "application/json",
+    "datacontenttype" : "application/json",
     "data" : {
         "appinfoA" : "abc",
         "appinfoB" : 123,

--- a/mqtt-transport-binding.md
+++ b/mqtt-transport-binding.md
@@ -19,7 +19,7 @@ This document is a working draft.
 - 1.4. [Event Formats](#14-event-formats)
 - 1.5. [Security](#15-security)
 2. [Use of CloudEvents Attributes](#2-use-of-cloudevents-attributes)
-- 2.1. [contenttype Attribute](#21-contenttype-attribute)
+- 2.1. [datacontenttype Attribute](#21-datacontenttype-attribute)
 - 2.2. [data Attribute](#22-data-attribute)
 3. [MQTT PUBLISH Message Mapping](#3-mqtt-publish-message-mapping)
 - 3.2. [Binary Content Mode](#31-binary-content-mode)
@@ -59,7 +59,7 @@ using an [event format](#14-event-formats).
 
 In the *binary* content mode, the value of the event `data` attribute is placed
 into the MQTT PUBLISH message's payload section as-is, with
-the `contenttype` attribute value declaring its media type; all other event
+the `datacontenttype` attribute value declaring its media type; all other event
 attributes are mapped to the MQTT PUBLISH message's
 [properties section][5-publish-properties].
 
@@ -82,31 +82,31 @@ mandate specific existing features to be used.
 This specification does not further define any of the [CloudEvents][CE] event
 attributes.
 
-Two of the event attributes, `contenttype` and `data` are handled specially
+Two of the event attributes, `datacontenttype` and `data` are handled specially
 and mapped onto MQTT constructs, all other attributes are transferred as
 metadata without further interpretation.
 
 This mapping is intentionally robust against changes, including the addition
 and removal of event attributes, and also accommodates vendor extensions to the
-event metadata. Any mention of event attributes other than `contenttype` and
+event metadata. Any mention of event attributes other than `datacontenttype` and
 `data` is exemplary.
 
-### 2.1. contenttype Attribute
+### 2.1. datacontenttype Attribute
 
-The `contenttype` attribute is assumed to contain a [RFC2046][RFC2046]
+The `datacontenttype` attribute is assumed to contain a [RFC2046][RFC2046]
 compliant media-type expression.
 
 ### 2.2. data Attribute
 
 The `data` attribute is assumed to contain opaque application data that is
-encoded as declared by the `contenttype` attribute.
+encoded as declared by the `datacontenttype` attribute.
 
 An application is free to hold the information in any in-memory representation
 of its choosing, but as the value is transposed into MQTT as defined in this
 specification, the assumption is that the `data` attribute value is made
 available as a sequence of bytes.
 
-For instance, if the declared `contenttype` is
+For instance, if the declared `datacontenttype` is
 `application/json;charset=utf-8`, the expectation is that the `data` attribute
 value is made available as [UTF-8][RFC3629] encoded JSON text for use in
 MQTT.
@@ -141,7 +141,7 @@ efficient transfer and without transcoding effort.
 
 For the *binary* mode, the MQTT PUBLISH message's [`Content
 Type`][5-content-type] property MUST be mapped directly to the CloudEvents
-`contenttype` attribute.
+`datacontenttype` attribute.
 
 #### 3.1.2. Event Data Encoding
 
@@ -150,7 +150,7 @@ payload of the MQTT PUBLISH message.
 
 #### 3.1.3. Metadata Headers
 
-All [CloudEvents][CE] attributes with exception of `contenttype` and `data`
+All [CloudEvents][CE] attributes with exception of `datacontenttype` and `data`
 MUST be individually mapped to and from the User Property fields in the MQTT
 PUBLISH message, with exceptions noted below.
 
@@ -178,7 +178,7 @@ respective CloudEvents attribute's JSON type representation, compliant with the
 #### 3.1.4 Examples
 
 This example shows the *binary* mode mapping of an event into the
-MQTT 5.0 PUBLISH message. The CloudEvents `contenttype` attribute
+MQTT 5.0 PUBLISH message. The CloudEvents `datacontenttype` attribute
 is mapped to the MQTT PUBLISH `Content Type` field; all other
 CloudEvents attributes are mapped to MQTT PUBLISH User Property
 fields. The `Topic name` is chosen by the MQTT client and not derived

--- a/nats-transport-binding.md
+++ b/nats-transport-binding.md
@@ -17,7 +17,7 @@ This document is a working draft.
 - 1.4. [Event Formats](#14-event-formats)
 - 1.5. [Security](#15-security)
 2. [Use of CloudEvents Attributes](#2-use-of-cloudevents-attributes)
-- 2.1. [contenttype Attribute](#21-contenttype-attribute)
+- 2.1. [datacontenttype Attribute](#21-datacontenttype-attribute)
 - 2.2. [data Attribute](#22-data-attribute)
 3. [NATS Message Mapping](#3-nats-message-mapping)
 - 3.1. [Event Data Encoding](#31-event-data-encoding)
@@ -73,21 +73,21 @@ mandate specific existing features to be used.
 This specification does not further define any of the [CloudEvents][CE] event
 attributes.
 
-### 2.1. contenttype Attribute
+### 2.1. datacontenttype Attribute
 
-The `contenttype` attribute is assumed to contain a media-type expression
+The `datacontenttype` attribute is assumed to contain a media-type expression
 compliant with [RFC2046][RFC2046].
 
 ### 2.2. data Attribute
 
 The `data` attribute is assumed to contain opaque application data that is
-encoded as declared by the `contenttype` attribute.
+encoded as declared by the `datacontenttype` attribute.
 
 An application is free to hold the information in any in-memory representation
 of its choosing, but as the value is transposed into NATS as defined in this
 specification, core NATS provides data available as a sequence of bytes.
 
-For instance, if the declared `contenttype` is
+For instance, if the declared `datacontenttype` is
 `application/json;charset=utf-8`, the expectation is that the `data` attribute
 value is made available as [UTF-8][RFC3629] encoded JSON text.
 

--- a/spec.json
+++ b/spec.json
@@ -4,7 +4,7 @@
     "specversion": {
       "type": "string"
     },
-    "contenttype": {
+    "datacontenttype": {
       "type": "string"
     },
     "data": {
@@ -18,8 +18,8 @@
         "specversion": {
           "$ref": "#/definitions/specversion"
         },
-        "contenttype": {
-          "$ref": "#/definitions/contenttype"
+        "datacontenttype": {
+          "$ref": "#/definitions/datacontenttype"
         },
         "data": {
           "$ref": "#/definitions/data"

--- a/spec.md
+++ b/spec.md
@@ -245,7 +245,7 @@ help intermediate gateways determine how to route the events.
   * If present, MUST adhere to the format specified in
     [RFC 3986](https://tools.ietf.org/html/rfc3986)
 
-### contenttype
+### datacontenttype
 * Type: `String` per [RFC 2046](https://tools.ietf.org/html/rfc2046)
 * Description: Content type of the `data` attribute value. This attribute
   enables the `data` attribute to carry any type of content, whereby format
@@ -254,7 +254,7 @@ help intermediate gateways determine how to route the events.
   format might carry an XML payload in its `data` attribute, and the
   consumer is informed by this attribute being set to "application/xml". The
   rules for how the `data` attribute content is rendered for different
-  `contenttype` values are defined in the event format specifications; for
+  `datacontenttype` values are defined in the event format specifications; for
   example, the JSON event format defines the relationship in
   [section 3.1](./json-format.md#31-special-handling-of-the-data-attribute).
 
@@ -285,7 +285,7 @@ encapsulated within the `data` attribute.
 * Type: `Any`
 * Description: The event payload. The payload depends on the `type` and
   the `schemaurl`. It is encoded into a media format
-  which is specified by the `contenttype` attribute (e.g. application/json).
+  which is specified by the `datacontenttype` attribute (e.g. application/json).
 * Constraints:
   * OPTIONAL
 
@@ -304,7 +304,7 @@ The following example shows a CloudEvent serialized as JSON:
     "comexampleextension2" : {
         "othervalue": 5
     },
-    "contenttype" : "text/xml",
+    "datacontenttype" : "text/xml",
     "data" : "<much wow=\"xml\"/>"
 }
 ```


### PR DESCRIPTION
Closes #354

2 reasons for this change:
1 - it just makes sense to me that if you have a `foo` property, then
    the property the describes its type is called `footype`, not `bartype`.
2 - when a transport, like http, already has a `contenttype` property, there
    could be unnecessary confusion when the CloudEvents property is serialized
	along side the transport one. Meaning, people might use the wrong one
	since their names are almost the same.

Signed-off-by: Doug Davis <dug@us.ibm.com>