### PR TITLE
Encoding & Transport Independent Interoperability Guarantee (JSON-based Size Measurement)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -293,12 +293,12 @@ encapsulated within the `data` attribute.
 # Minimum Supported Event Size
 
 In order to increase interoperability, all CloudEvent consumers MUST accept
-messages up to a size of 256KB, measured by serializing the CloudEvent as
+events up to a size of 256KB, measured by serializing the CloudEvent as
 [JSON](./json-format.md) (minified, i.e. without white-space).
 
-CloudEvent consumers MAY reject CloudEvents above this size.
-It is RECOMMENDED for CloudEvent producers to only create CloudEvents within
-this size, unless they can be sure all consumers support larger sizes.
+CloudEvent consumers MAY reject events above this size.
+It is RECOMMENDED for CloudEvent producers to only create events within this
+size, unless they can be sure all consumers support larger sizes.
 
 # Example
 

--- a/spec.md
+++ b/spec.md
@@ -15,7 +15,7 @@ This document is a working draft.
 - [Type System](#type-system)
 - [Context Attributes](#context-attributes)
 - [Data Attribute](#data-attribute)
-- [Event Size Guarantees](#event-size-guarantees)
+- [Minimum Supported Event Size](#minimum-supported-event-size)
 - [Example](#example)
 
 ## Overview
@@ -290,7 +290,7 @@ encapsulated within the `data` attribute.
 * Constraints:
   * OPTIONAL
 
-# Event Size Guarantees
+# Minimum Supported Event Size
 
 In order to increase interoperability, all CloudEvent consumers MUST accept
 messages up to a size of 256KB, measured by serializing the CloudEvent as

--- a/spec.md
+++ b/spec.md
@@ -15,6 +15,7 @@ This document is a working draft.
 - [Type System](#type-system)
 - [Context Attributes](#context-attributes)
 - [Data Attribute](#data-attribute)
+- [Size Limits](#size-limits)
 - [Example](#example)
 
 ## Overview
@@ -288,6 +289,32 @@ encapsulated within the `data` attribute.
   which is specified by the `contenttype` attribute (e.g. application/json).
 * Constraints:
   * OPTIONAL
+
+# Size Limits
+
+In order to increase interoperability, the following size limits apply to any
+CloudEvent:
+
+* The CloudEvent serialized as JSON (minified, i.e. without white-space) MUST
+  NOT exceed a size of 128KB.
+* The CloudEvent MUST NOT have more than 100 top-level attributes.
+
+CloudEvent producers SHOULD only create CloudEvents within these limits.
+CloudEvent consumers MUST accept all CloudEvents within these limits and SHOULD
+reject messages that violate these limits.
+
+# Size Guarantees // Another option
+
+In order to increase interoperability, all CloudEvent consumers MUST accept
+messages up to the following sizes:
+
+* The CloudEvent serialized as JSON (minified, i.e. without white-space) does
+  not exceed a size of 128KB.
+* The CloudEvent does not have more than 100 top-level attributes.
+
+CloudEvent consumers MAY reject messages that violate these limits.
+It is RECOMMENDED for CloudEvent producers to only create CloudEvents within
+these limits, unless they can be sure all consumers support larger sizes.
 
 # Example
 

--- a/spec.md
+++ b/spec.md
@@ -15,7 +15,7 @@ This document is a working draft.
 - [Type System](#type-system)
 - [Context Attributes](#context-attributes)
 - [Data Attribute](#data-attribute)
-- [Size Limits](#size-limits)
+- [Event Size Guarantees](#event-size-guarantees)
 - [Example](#example)
 
 ## Overview
@@ -290,31 +290,15 @@ encapsulated within the `data` attribute.
 * Constraints:
   * OPTIONAL
 
-# Size Limits
-
-In order to increase interoperability, the following size limits apply to any
-CloudEvent:
-
-* The CloudEvent serialized as JSON (minified, i.e. without white-space) MUST
-  NOT exceed a size of 128KB.
-* The CloudEvent MUST NOT have more than 100 top-level attributes.
-
-CloudEvent producers SHOULD only create CloudEvents within these limits.
-CloudEvent consumers MUST accept all CloudEvents within these limits and SHOULD
-reject messages that violate these limits.
-
-# Size Guarantees // Another option
+# Event Size Guarantees
 
 In order to increase interoperability, all CloudEvent consumers MUST accept
-messages up to the following sizes:
+messages up to a size of 256KB, measured by serializing the CloudEvent as
+[JSON](./json-format.md) (minified, i.e. without white-space).
 
-* The CloudEvent serialized as JSON (minified, i.e. without white-space) does
-  not exceed a size of 128KB.
-* The CloudEvent does not have more than 100 top-level attributes.
-
-CloudEvent consumers MAY reject messages that violate these limits.
+CloudEvent consumers MAY reject CloudEvents above this size.
 It is RECOMMENDED for CloudEvent producers to only create CloudEvents within
-these limits, unless they can be sure all consumers support larger sizes.
+this size, unless they can be sure all consumers support larger sizes.
 
 # Example
 

--- a/spec.md
+++ b/spec.md
@@ -296,9 +296,23 @@ In order to increase interoperability, all CloudEvent consumers MUST accept
 events up to a size of 256KB, measured by serializing the CloudEvent as
 [JSON](./json-format.md) (minified, i.e. without white-space).
 
-CloudEvent consumers MAY reject events above this size.
+CloudEvent consumers MAY reject events above this size and MAY reject messages
+that are not minified (e.g. contain unnecessary white-space).
 It is RECOMMENDED for CloudEvent producers to only create events within this
 size, unless they can be sure all consumers support larger sizes.
+
+The same event serialized with a different format will likely result in a
+different size. However, to aid interoperability, only the minified
+[JSON](./json-format.md) is used to measure the size. As an example, an
+[AMQP](./amqp-format.md) message of 270KB MUST be accepted if the contained
+event serialized as JSON is below 256KB. However, an [AMQP](./amqp-format.md)
+message of 250KB MAY be rejected if the contained event serialized as JSON
+exceeds 256KB. Practically, an [AMQP](./amqp-format.md) consumer that wants to
+protect theirself from large messages MAY simply choose to reject messagess
+after a higher limit (e.g. 512KB) that comfortably fits any valid event size.
+However, a middleware that wants to guarantee that the event can be forwarded
+in any format SHOULD measure the size of the event independently of the format
+it was received in.
 
 # Example
 

--- a/spec.md
+++ b/spec.md
@@ -292,8 +292,8 @@ encapsulated within the `data` attribute.
 
 # Minimum Supported Event Size
 
-In order to increase interoperability, all CloudEvent consumers MUST accept
-events up to a size of 256KB, measured by serializing the CloudEvent as
+In order to increase interoperability, all CloudEvent consumers SHOULD accept
+events up to a size of 64KB, measured by serializing the CloudEvent as
 [JSON](./json-format.md) (minified, i.e. without white-space).
 
 CloudEvent consumers MAY reject events above this size and MAY reject messages
@@ -304,12 +304,12 @@ size, unless they can be sure all consumers support larger sizes.
 The same event serialized with a different format will likely result in a
 different size. However, to aid interoperability, only the minified
 [JSON](./json-format.md) is used to measure the size. As an example, an
-[AMQP](./amqp-format.md) message of 270KB MUST be accepted if the contained
-event serialized as JSON is below 256KB. However, an [AMQP](./amqp-format.md)
-message of 250KB MAY be rejected if the contained event serialized as JSON
-exceeds 256KB. Practically, an [AMQP](./amqp-format.md) consumer that wants to
+[AMQP](./amqp-format.md) message of 70KB MUST be accepted if the contained
+event serialized as JSON is below 64KB. However, an [AMQP](./amqp-format.md)
+message of 60KB MAY be rejected if the contained event serialized as JSON
+exceeds 64KB. Practically, an [AMQP](./amqp-format.md) consumer that wants to
 protect theirself from large messages MAY simply choose to reject messagess
-after a higher limit (e.g. 512KB) that comfortably fits any valid event size.
+after a higher limit (e.g. 256KB) that comfortably fits any valid event size.
 However, a middleware that wants to guarantee that the event can be forwarded
 in any format SHOULD measure the size of the event independently of the format
 it was received in.


### PR DESCRIPTION
For background, please see https://github.com/cloudevents/spec/issues/257

TLDR: Most serverless platforms today have size limitations. For interoperability, we should address this issue.

This PR presents two options, the first one is more assertive in that the limit shouldn't be violated, the second one is less strict.

I'm mainly trying to force a discussion with this PR, and am happy to apply changes. In particular, I picked rather low size limits - we should definitely have a discussion on that.

If we settle on some sizes, I'd like to create some events that are exactly at the limit, so that implementations can test whether they are compliant with the spec.