### PR TITLE
Add Integer as allowed for Any in description of variant type

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -111,19 +111,16 @@ The following abstract data types are available for use in attributes.
 - `String` - Sequence of printable Unicode characters.
 - `Binary` - Sequence of bytes.
 - `Map` - `String`-indexed dictionary of `Any`-typed values.
-- `Any` - Either a `String`, or a `Binary`, or a `Map`, or an `Integer`.
+- `Any` - Either a `Binary`, `Integer`, `Map` or `String`.
 - `URI-reference` - String expression conforming to `URI-reference`
   as defined in
   [RFC 3986 §4.1](https://tools.ietf.org/html/rfc3986#section-4.1).
 - `Timestamp` - String expression as defined in
   [RFC 3339](https://tools.ietf.org/html/rfc3339).
 
-This specification does not define numeric or logical types.
-
-The `Any` type is a variant type that can take the shape of either a
-`String` or a `Binary` or a `Map`. The type system is intentionally
-abstract, and therefore it is left to implementations how to represent the
-variant type.
+The `Any` type is a variant type that can take the shape of either a `Binary`,
+`Integer`, `Map` or `String`. The type system is intentionally abstract, and
+therefore it is left to implementations how to represent the variant type.
 
 ## Context Attributes
 Every CloudEvent conforming to this specification MUST include context


### PR DESCRIPTION
In https://github.com/cloudevents/spec/commit/3248e31cabace2c8d8d8da46a033923d598c1bfb `Integer` was added as an allowed shape of the variant type `Any`, but the modification was left out of the later description of the variant type, which also lists the allowed shapes. Added `Integer` to the list and made it the same textual style as in the type list. So no normative changes.

Another possibility is to just change the text describing the variant type to refer to the type list instead of repeating the list. 