### PR TITLE
HTTP Transport Binding for batching JSON

### DIFF
--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -344,8 +344,10 @@ Content-Length: nnnn
 
 In the *batched* content mode several events are batched into a single HTTP
 request or response body. The chosen [event format](#14-event-formats) MUST
-define how a batch is represented. Currently, the only format supporting
-batching is the [JSON Batch Format][JSON-batch-format].
+define how a batch is represented.
+Based on the [JSON format][JSON-format] (that MUST be supported by any
+compliant implementation), the [JSON Batch format][JSON-batch-format] is an
+event format that supports batching.
 
 #### 3.3.1. HTTP Content-Type
 
@@ -366,7 +368,7 @@ all event attributes, including the `data` attribute, are represented.
 The batch of events is then rendered in accordance with the event format
 specification and the resulting data becomes the HTTP message body.
 
-The batch MAY be empty (typically used in a HTTP response).
+The batch MAY be empty.
 All batched CloudEvents MUST have the same `specversion` attribute. Other
 attributes MAY differ, including the `contenttype` attribute.
 

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -80,8 +80,8 @@ supports batching.
 
 Event formats, used with the *structured* content mode, define how an event is
 expressed in a particular data format. All implementations of this
-specification MUST support the [JSON event format][JSON-format], but MAY
-support any additional, including proprietary, formats.
+specification MUST support the non-batching [JSON event format][JSON-format],
+but MAY support any additional, including proprietary, formats.
 
 Event formats MAY additionally define how a batch of events is expressed. Those
 can be used with the *batched* content mode

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -370,7 +370,7 @@ specification and the resulting data becomes the HTTP message body.
 
 The batch MAY be empty.
 All batched CloudEvents MUST have the same `specversion` attribute. Other
-attributes MAY differ, including the `contenttype` attribute.
+attributes MAY differ, including the `datacontenttype` attribute.
 
 #### 3.2.3 Examples
 

--- a/json-format.md
+++ b/json-format.md
@@ -14,7 +14,8 @@ This document is a working draft.
 1. [Introduction](#1-introduction)
 2. [Attributes](#2-attributes)
 3. [Envelope](#3-envelope)
-4. [References](#4-references)
+4. [JSON Batch Format](#4-json-batch-format)
+5. [References](#5-references)
 
 ## 1. Introduction
 
@@ -229,7 +230,77 @@ a `Map` or [JSON data](#31-special-handling-of-the-data-attribute) data:
 }
 ```
 
-## 4. References
+## 4. JSON Batch Format
+
+In the *JSON Batch Format* several CloudEvents are batched into a single JSON
+document. The document is a JSON array filled with CloudEvents in the
+[JSON Event format][JSON-format].
+
+Although the *JSON Batch Format* builds ontop of the *JSON Format*, it should
+be considered as a separate format: a valid implementation of the *JSON Format*
+doesn't have to support it. The *JSON Batch Format* MUST NOT be used when only
+support for the *JSON Format* is indicated.
+
+### 4.1. Mapping CloudEvents
+
+This section defines how a batch of CloudEvents is mapped to JSON.
+
+The outermost JSON element is a [JSON Array][JSON-array], which contains
+CloudEvents rendered in accordance with the [JSON event format][JSON-format]
+specification.
+
+### 4.2. Envelope
+
+A JSON Batch of CloudEvents must use the media type
+`application/cloudevents-batch+json`.
+
+### 4.3. Examples
+
+An example containing two CloudEvents: The first with `Binary`-valued data, the
+second with JSON data.
+
+``` JSON
+[
+  {
+      "specversion" : "0.2",
+      "type" : "com.example.someevent",
+      "source" : "/mycontext/4",
+      "id" : "B234-1234-1234",
+      "time" : "2018-04-05T17:31:00Z",
+      "comexampleextension1" : "value",
+      "comexampleextension2" : {
+          "otherValue": 5
+      },
+      "contenttype" : "application/vnd.apache.thrift.binary",
+      "data" : "... base64 encoded string ..."
+  },
+  {
+      "specversion" : "0.2",
+      "type" : "com.example.someotherevent",
+      "source" : "/mycontext/9",
+      "id" : "C234-1234-1234",
+      "time" : "2018-04-05T17:31:05Z",
+      "comexampleextension1" : "value",
+      "comexampleextension2" : {
+          "otherValue": 5
+      },
+      "contenttype" : "application/json",
+      "data" : {
+          "appinfoA" : "abc",
+          "appinfoB" : 123,
+          "appinfoC" : true
+      }
+  }
+]
+```
+
+An example of an empty batch of CloudEvents (typically used in a response):
+
+```JSON
+[]
+```
+
+## 5. References
 
 * [RFC2046][RFC2046] Multipurpose Internet Mail Extensions (MIME) Part Two:
   Media Types
@@ -250,6 +321,7 @@ a `Map` or [JSON data](#31-special-handling-of-the-data-attribute) data:
 [JSON-Number]: https://tools.ietf.org/html/rfc7159#section-6
 [JSON-String]: https://tools.ietf.org/html/rfc7159#section-7
 [JSON-Value]: https://tools.ietf.org/html/rfc7159#section-3
+[JSON-Array]: https://tools.ietf.org/html/rfc7159#section-5
 [RFC2046]: https://tools.ietf.org/html/rfc2046
 [RFC2119]: https://tools.ietf.org/html/rfc2119
 [RFC3986]: https://tools.ietf.org/html/rfc3986

--- a/json-format.md
+++ b/json-format.md
@@ -236,9 +236,9 @@ In the *JSON Batch Format* several CloudEvents are batched into a single JSON
 document. The document is a JSON array filled with CloudEvents in the
 [JSON Event format][JSON-format].
 
-Although the *JSON Batch Format* builds ontop of the *JSON Format*, it should
-be considered as a separate format: a valid implementation of the *JSON Format*
-doesn't have to support it. The *JSON Batch Format* MUST NOT be used when only
+Although the *JSON Batch Format* builds ontop of the *JSON Format*, it is
+considered as a separate format: a valid implementation of the *JSON Format*
+doesn't need to support it. The *JSON Batch Format* MUST NOT be used when only
 support for the *JSON Format* is indicated.
 
 ### 4.1. Mapping CloudEvents
@@ -251,7 +251,7 @@ specification.
 
 ### 4.2. Envelope
 
-A JSON Batch of CloudEvents must use the media type
+A JSON Batch of CloudEvents MUST use the media type
 `application/cloudevents-batch+json`.
 
 ### 4.3. Examples

--- a/json-format.md
+++ b/json-format.md
@@ -246,8 +246,8 @@ support for the *JSON Format* is indicated.
 This section defines how a batch of CloudEvents is mapped to JSON.
 
 The outermost JSON element is a [JSON Array][JSON-array], which contains
-CloudEvents rendered in accordance with the [JSON event format][JSON-format]
-specification.
+as elements CloudEvents rendered in accordance with the
+[JSON event format][JSON-format] specification.
 
 ### 4.2. Envelope
 

--- a/json-format.md
+++ b/json-format.md
@@ -271,7 +271,7 @@ second with JSON data.
       "comexampleextension2" : {
           "otherValue": 5
       },
-      "contenttype" : "application/vnd.apache.thrift.binary",
+      "datacontenttype" : "application/vnd.apache.thrift.binary",
       "data" : "... base64 encoded string ..."
   },
   {
@@ -284,7 +284,7 @@ second with JSON data.
       "comexampleextension2" : {
           "otherValue": 5
       },
-      "contenttype" : "application/json",
+      "datacontenttype" : "application/json",
       "data" : {
           "appinfoA" : "abc",
           "appinfoB" : 123,


### PR DESCRIPTION
In the discussion from last week about https://github.com/cloudevents/spec/pull/360 we agreed that a batching option for the HTTP Transport Binding is useful. This is an attempt to introduce it.

During the call, @clemensv suggested to build the batching into the structured mode. I couldn't figure out how to do this generically for any event format. Instead, I did it for the JSON format only.

I also did not include the batching mode as one of the modes the receiver SHOULD support. Take a Function as a Service: Usually, each event should be processed in on an own instance of a function. This is trivial to implement when a HTTP Request always contains a single event. A batch doesn't map nicely onto the core FaaS abstractions.

The HTTP Content-Type is a bit tricky - we want that the receiver can distinguish between the events based on the header, so I've created `application/cloudevents-batch+json`. However, I'm not sure if this clutters the namespace too much.

Signed-off-by: Christoph Neijenhuis <christoph.neijenhuis@commercetools.de>