### PR TITLE
Minor: Format data consistently with the paragraph above

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -262,12 +262,12 @@ help intermediate gateways determine how to route the events.
   example, the JSON event format defines the relationship in
   [section 3.1](./json-format.md#31-special-handling-of-the-data-attribute).
 
-  When this attribute is omitted, the "data" attribute simply follows the
-  event format's encoding rules. For the JSON event format, the "data"
+  When this attribute is omitted, the `data` attribute simply follows the
+  event format's encoding rules. For the JSON event format, the `data`
   attribute value can therefore be a JSON object, array, or value.
 
   For the binary mode of some of the CloudEvents transport bindings,
-  where the "data" content is immediately mapped into the payload of the
+  where the `data` content is immediately mapped into the payload of the
   transport frame, this field is directly mapped to the respective transport
   or application protocol's content-type metadata property. Normative rules
   for the binary mode and the content-type metadata mapping can be found


### PR DESCRIPTION
Minor cosmetic edit: This formats `data` consistently with the paragraph above in the contenttype section.

Signed-off-by: Christoph Neijenhuis <christoph.neijenhuis@commercetools.de>