### PR TITLE
Add dataref attribute and describe Claim Check Pattern

### DIFF
--- a/extensions/dataref.md
+++ b/extensions/dataref.md
@@ -1,0 +1,73 @@
+# Dataref (Claim Check Pattern)
+
+As defined by the term [Data](spec.md#data), CloudEvents MAY include domain-specific
+information about the occurrence. When present, this information will be
+encapsulated within the `data` attribute.
+The `dataref` attribute MAY be used to reference another location where this
+information is stored. The information, whether accessed via `data` or `dataref`
+MUST be identical.
+
+Both the `data` and `dataref` attribute MAY exist at the same time. A middleware
+MAY drop the `data` attribute when the `dataref` attribute exists, it MAY add
+the `dataref` attribute and drop the `data` attribute, or it MAY add the `data`
+attribute by using the `dataref` attribute.
+
+## Attributes
+
+### dataref
+* Type: `URI-reference`
+* Description: A reference to a location where the event payload is stored. The
+  location MAY not be accessible without further information (e.g. a pre-shared
+  secret).
+
+  Known as the "Claim Check Pattern", this attribute MAY be used for a variety
+  of purposes, including:
+
+  * If the [Data](spec.md#data) is too large to be included in the message, the
+    `data` attribute is not present, and the consumer can retrieve it using this
+    attribute.
+  * If the consumer wants to verify that the [Data](spec.md#data) has not been
+    tampered with, it can retrieve it from a trusted source using this
+    attribute.
+  * If the [Data](spec.md#data) MUST only be viewed by trusted consumers (e.g.
+    personally identifiable information), only a trusted consumer can retrieve
+    it using this attribute and a pre-shared secret.
+
+  If this attribute is used, the information SHOULD be accessible long enough
+  for all consumers to retrieve it, but MAY not be stored for an extended period
+  of time.
+
+* Constraints:
+  * OPTIONAL
+
+# Examples
+
+The following example shows a CloudEvent in which the event producer has included
+both `data` and `dataref` (serialized as JSON):
+
+``` JSON
+{
+    "specversion" : "0.2",
+    "type" : "com.github.pull.create",
+    "source" : "https://github.com/cloudevents/spec/pull/123",
+    "id" : "A234-1234-1234",
+    "datacontenttype" : "text/xml",
+    "data" : "<much wow=\"xml\"/>",
+    "dataref" : "https://github.com/cloudevents/spec/pull/123/events/A234-1234-1234.xml"
+}
+```
+
+The following example shows a CloudEvent in which a middleware has replaced the
+`data` with a `dataref` (serialized as JSON):
+
+``` JSON
+{
+    "specversion" : "0.2",
+    "type" : "com.github.pull.create",
+    "source" : "https://github.com/cloudevents/spec/pull/123",
+    "id" : "A234-1234-1234",
+    "datacontenttype" : "text/xml",
+    "dataref" : "https://tenant123.middleware.com/events/data/A234-1234-1234.xml"
+}
+```
+

--- a/extensions/dataref.md
+++ b/extensions/dataref.md
@@ -1,8 +1,8 @@
 # Dataref (Claim Check Pattern)
 
-As defined by the term [Data](spec.md#data), CloudEvents MAY include domain-specific
-information about the occurrence. When present, this information will be
-encapsulated within the `data` attribute.
+As defined by the term [Data](../spec.md#data), CloudEvents MAY include
+domain-specific information about the occurrence. When present, this information
+will be encapsulated within the `data` attribute.
 The `dataref` attribute MAY be used to reference another location where this
 information is stored. The information, whether accessed via `data` or `dataref`
 MUST be identical.
@@ -23,15 +23,15 @@ attribute by using the `dataref` attribute.
   Known as the "Claim Check Pattern", this attribute MAY be used for a variety
   of purposes, including:
 
-  * If the [Data](spec.md#data) is too large to be included in the message, the
-    `data` attribute is not present, and the consumer can retrieve it using this
+  * If the [Data](../spec.md#data) is too large to be included in the message,
+    the `data` attribute is not present, and the consumer can retrieve it using
+    this attribute.
+  * If the consumer wants to verify that the [Data](../spec.md#data) has not
+    been tampered with, it can retrieve it from a trusted source using this
     attribute.
-  * If the consumer wants to verify that the [Data](spec.md#data) has not been
-    tampered with, it can retrieve it from a trusted source using this
-    attribute.
-  * If the [Data](spec.md#data) MUST only be viewed by trusted consumers (e.g.
-    personally identifiable information), only a trusted consumer can retrieve
-    it using this attribute and a pre-shared secret.
+  * If the [Data](../spec.md#data) MUST only be viewed by trusted consumers
+    (e.g.  personally identifiable information), only a trusted consumer can
+    retrieve it using this attribute and a pre-shared secret.
 
   If this attribute is used, the information SHOULD be accessible long enough
   for all consumers to retrieve it, but MAY not be stored for an extended period

--- a/spec.md
+++ b/spec.md
@@ -282,7 +282,8 @@ As defined by the term [Data](#data), CloudEvents MAY include domain-specific
 information about the occurrence. When present, this information will be
 encapsulated within the `data` attribute.
 The `dataref` attribute MAY be used to reference another location where this
-information is stored.
+information is stored. The information, whether accessed via `data` or `dataref`
+MUST be identical.
 
 Both the `data` and `dataref` attribute MAY exist at the same time. A middleware
 MAY drop the `data` attribute when the `dataref` attribute exists, it MAY add

--- a/spec.md
+++ b/spec.md
@@ -281,12 +281,41 @@ help intermediate gateways determine how to route the events.
 As defined by the term [Data](#data), CloudEvents MAY include domain-specific
 information about the occurrence. When present, this information will be
 encapsulated within the `data` attribute.
+The `dataref` attribute can be used to reference another location where this
+information is stored. Known as the "Claim Check Pattern", the `dataref`
+attribute can be used for different purposes:
+
+* If the information is too large to be included in the message, the `data`
+  attribute is not present, and the consumer can retrieve it based on the
+  `dataref` attribute.
+* If the consumer wants to verify that the information has not been tampered
+  with, it can retrieve it from a trusted source using the `dataref` attribute.
+* If the information MUST only be viewed by trusted consumers (e.g. personally
+  identifiable information), only a trusted consumer can retrieve it using the
+  `dataref` attribute and a pre-shared secret.
+
+Both the `data` and `dataref` attribute MAY exist at the same time. A middleware
+MAY drop the `data` attribute when the `dataref` attribute exists, it MAY add
+the `dataref` attribute and drop the `data` attribute, or it MAY add the `data`
+attribute by using the `dataref` attribute.
+
+If the `dataref` attribute is used, the information SHOULD be accessible long
+enough for all consumers to retrieve it, but MAY not be stored for an extended
+period of time.
 
 ### data
 * Type: `Any`
 * Description: The event payload. The payload depends on the `type` and
   the `schemaurl`. It is encoded into a media format
   which is specified by the `datacontenttype` attribute (e.g. application/json).
+* Constraints:
+  * OPTIONAL
+
+### dataref
+* Type: `URI-reference`
+* Description: A reference to a location where the event payload is stored. The
+  location MAY not be accessible without further information (e.g. a pre-shared
+  secret).
 * Constraints:
   * OPTIONAL
 
@@ -306,6 +335,7 @@ The following example shows a CloudEvent serialized as JSON:
         "othervalue": 5
     },
     "datacontenttype" : "text/xml",
-    "data" : "<much wow=\"xml\"/>"
+    "data" : "<much wow=\"xml\"/>",
+    "dataref" : "https://github.com/cloudevents/spec/pull/123/events/A234-1234-1234.xml"
 }
 ```

--- a/spec.md
+++ b/spec.md
@@ -281,27 +281,13 @@ help intermediate gateways determine how to route the events.
 As defined by the term [Data](#data), CloudEvents MAY include domain-specific
 information about the occurrence. When present, this information will be
 encapsulated within the `data` attribute.
-The `dataref` attribute can be used to reference another location where this
-information is stored. Known as the "Claim Check Pattern", the `dataref`
-attribute can be used for different purposes:
-
-* If the information is too large to be included in the message, the `data`
-  attribute is not present, and the consumer can retrieve it based on the
-  `dataref` attribute.
-* If the consumer wants to verify that the information has not been tampered
-  with, it can retrieve it from a trusted source using the `dataref` attribute.
-* If the information MUST only be viewed by trusted consumers (e.g. personally
-  identifiable information), only a trusted consumer can retrieve it using the
-  `dataref` attribute and a pre-shared secret.
+The `dataref` attribute MAY be used to reference another location where this
+information is stored.
 
 Both the `data` and `dataref` attribute MAY exist at the same time. A middleware
 MAY drop the `data` attribute when the `dataref` attribute exists, it MAY add
 the `dataref` attribute and drop the `data` attribute, or it MAY add the `data`
 attribute by using the `dataref` attribute.
-
-If the `dataref` attribute is used, the information SHOULD be accessible long
-enough for all consumers to retrieve it, but MAY not be stored for an extended
-period of time.
 
 ### data
 * Type: `Any`
@@ -316,6 +302,23 @@ period of time.
 * Description: A reference to a location where the event payload is stored. The
   location MAY not be accessible without further information (e.g. a pre-shared
   secret).
+
+  Known as the "Claim Check Pattern", this attribute MAY be used for a variety
+  of purposes, including:
+
+  * If the [Data](#data) is too large to be included in the message, the `data`
+    attribute is not present, and the consumer can retrieve it using this
+    attribute.
+  * If the consumer wants to verify that the [Data](#data) has not been tampered
+    with, it can retrieve it from a trusted source using this attribute.
+  * If the [Data](#data) MUST only be viewed by trusted consumers (e.g.
+    personally identifiable information), only a trusted consumer can retrieve
+    it using this attribute and a pre-shared secret.
+
+  If this attribute is used, the information SHOULD be accessible long enough
+  for all consumers to retrieve it, but MAY not be stored for an extended period
+  of time.
+
 * Constraints:
   * OPTIONAL
 

--- a/spec.md
+++ b/spec.md
@@ -281,45 +281,12 @@ help intermediate gateways determine how to route the events.
 As defined by the term [Data](#data), CloudEvents MAY include domain-specific
 information about the occurrence. When present, this information will be
 encapsulated within the `data` attribute.
-The `dataref` attribute MAY be used to reference another location where this
-information is stored. The information, whether accessed via `data` or `dataref`
-MUST be identical.
-
-Both the `data` and `dataref` attribute MAY exist at the same time. A middleware
-MAY drop the `data` attribute when the `dataref` attribute exists, it MAY add
-the `dataref` attribute and drop the `data` attribute, or it MAY add the `data`
-attribute by using the `dataref` attribute.
 
 ### data
 * Type: `Any`
 * Description: The event payload. The payload depends on the `type` and
   the `schemaurl`. It is encoded into a media format
   which is specified by the `datacontenttype` attribute (e.g. application/json).
-* Constraints:
-  * OPTIONAL
-
-### dataref
-* Type: `URI-reference`
-* Description: A reference to a location where the event payload is stored. The
-  location MAY not be accessible without further information (e.g. a pre-shared
-  secret).
-
-  Known as the "Claim Check Pattern", this attribute MAY be used for a variety
-  of purposes, including:
-
-  * If the [Data](#data) is too large to be included in the message, the `data`
-    attribute is not present, and the consumer can retrieve it using this
-    attribute.
-  * If the consumer wants to verify that the [Data](#data) has not been tampered
-    with, it can retrieve it from a trusted source using this attribute.
-  * If the [Data](#data) MUST only be viewed by trusted consumers (e.g.
-    personally identifiable information), only a trusted consumer can retrieve
-    it using this attribute and a pre-shared secret.
-
-  If this attribute is used, the information SHOULD be accessible long enough
-  for all consumers to retrieve it, but MAY not be stored for an extended period
-  of time.
-
 * Constraints:
   * OPTIONAL
 
@@ -339,7 +306,6 @@ The following example shows a CloudEvent serialized as JSON:
         "othervalue": 5
     },
     "datacontenttype" : "text/xml",
-    "data" : "<much wow=\"xml\"/>",
-    "dataref" : "https://github.com/cloudevents/spec/pull/123/events/A234-1234-1234.xml"
+    "data" : "<much wow=\"xml\"/>"
 }
 ```


### PR DESCRIPTION
This resulted mostly out of the discussion around https://github.com/cloudevents/spec/pull/364 but is also related to https://github.com/cloudevents/spec/issues/373

The Claim Check Pattern is used for different purposes, including large payload size and security concerns.

This is on purpose "hand-wavy" around the actual retrieval of the payload.
The advantage is that in this way, any auth and storage can be used, e.g. the blob storage of a cloud provider and the protection by their auth mechanisms.
The downside is that it is hard for a middleware or a SDK to retrieve the payload. A non-protected HTTP(S) endpoint would be simpler.

@JemDay I would appreciate it if you could give this a read :)

Signed-off-by: Christoph Neijenhuis <christoph.neijenhuis@commercetools.de>