### PR TITLE
Deprecation extension proposal

### DIFF
--- a/extensions/deprecation.md
+++ b/extensions/deprecation.md
@@ -1,0 +1,36 @@
+# Deprecation
+
+This extension defines two attributes that can be included within a CloudEvent
+to indicate the deprecation of the event, delivery method, format or other
+properties, such as the `schemaUrl`.
+
+The `deprecated` attribute indicates deprecation of the event delivery. The
+exact value and meaning of this attribute can be defined by the
+`deprecatedType` attribute. As the specification of the attributes is left
+intentionally open-ended, event consumers will need to have some out-of-band
+communication with the event producer to understand how to interpret the value
+of the attribute.
+
+Event producers should use established or well-known patterns to facilitate
+integration. In addition to or instead of integrating specific patterns,
+consumers can also choose to alert on deprecation and rely on human
+intervention.
+
+## Attributes
+
+### deprecated
+* Type: `String`
+* Description: Value indicating the deprecation of the delivery of these events
+* Constraints
+  * REQUIRED
+  * MUST be a non-empty string
+  * RECOMMENDED to provide information on type and timeline of deprecation and
+    a way to find more information
+
+### deprecatedType
+* Type: `String`
+* Description: Used to specify the format and meaning of the `deprecated`
+  attribute
+* Constraints:
+  * OPTIONAL
+  * If present, MUST be a non-empty string


### PR DESCRIPTION
A draft of an extension defining attributes indicating deprecation of events or properties/versions/schemas etc. I don't feel particularly strong about anything in the draft, except the general direction of leaving things open-ended for development with actual use-cases instead of prescribing specifics. See #365 for more discussion.

Ideas:
* Comment explicitly on middleware and their role in signaling deprecation (of delivery method etc.). I feel like this is so-so on "prescribing specifics"
* Elaborate on versioning by linking to [primer section on versioning]() for the benefit of giving an idea of how this field and versioning might together provide a way to evolve events. Might simplify description of what this field is meant to mean to deprecate (anything) and instead point to primer.
