### PR TITLE
Consistency: schemaurl uses URI-reference, protobuf uses URI-reference

### DIFF
--- a/protobuf-format.md
+++ b/protobuf-format.md
@@ -78,15 +78,15 @@ The CloudEvents type system MUST be mapped into the fields of
 `CloudEventAny` as follows:
 
 
-| CloudEvents  | CloudEventAny field
-|--------------|-------------------------------------------------------------
-| String       | string_value
-| Binary       | binary_value
-| URI          | string_value (string expression conforming to URI-reference as defined in [RFC 3986 §4.1](https://tools.ietf.org/html/rfc3986#section-4.1))
-| Timestamp    | string_value (string expression as defined in [RFC 3339](https://tools.ietf.org/html/rfc3339))
-| Map          | map_value
-| Integer      | int_value
-| Any          | Not applicable. Any is the enclosing CloudEventAny message itself
+| CloudEvents   | CloudEventAny field
+|---------------|-------------------------------------------------------------
+| String        | string_value
+| Binary        | binary_value
+| URI-reference | string_value (string expression conforming to URI-reference as defined in [RFC 3986 §4.1](https://tools.ietf.org/html/rfc3986#section-4.1))
+| Timestamp     | string_value (string expression as defined in [RFC 3339](https://tools.ietf.org/html/rfc3339))
+| Map           | map_value
+| Integer       | int_value
+| Any           | Not applicable. Any is the enclosing CloudEventAny message itself
 
 Protocol Buffer representations of CloudEvents MUST use the media type `application/cloudevents+proto`.
 

--- a/spec.json
+++ b/spec.json
@@ -62,7 +62,7 @@
     },
     "schemaurl": {
       "type": "string",
-      "format": "uri"
+      "format": "uri-reference"
     },
     "type": {
       "type": "string",

--- a/spec.md
+++ b/spec.md
@@ -235,7 +235,7 @@ help intermediate gateways determine how to route the events.
     [RFC 3339](https://tools.ietf.org/html/rfc3339)
 
 ### schemaurl
-* Type: `URI`
+* Type: `URI-reference`
 * Description: A link to the schema that the `data` attribute adheres to.
   Incompatible changes to the schema SHOULD be reflected by a different URL.
   See
@@ -243,8 +243,6 @@ help intermediate gateways determine how to route the events.
   for more information.
 * Constraints:
   * OPTIONAL
-  * If present, MUST adhere to the format specified in
-    [RFC 3986](https://tools.ietf.org/html/rfc3986)
 
 ### datacontenttype
 * Type: `String` per [RFC 2046](https://tools.ietf.org/html/rfc2046)


### PR DESCRIPTION
Closes #384

In https://github.com/cloudevents/spec/pull/169 it was decided that inside the specification, we only use `URI-reference`. (From reading the PR, it is not clear to me whether it was intended to change both `schemaurl` and `source`, or only `source`, but the PR effectively changed both).

In https://github.com/cloudevents/spec/pull/338 I renamed the shorthand `URI` to `URI-reference`, because it was easy to wrongly assume only URIs are supported, but not URI references.
I missed changing the `schemaurl` type.
When `schemaurl` was introduced to `spec.json`, that was mixed up as well.

Related, the `protobuf-format.md` type mapping wasn't consistent with the type naming in `spec.md` (I think both PRs ran concurrently), which I'm fixing as well.

---

There is probably a discussion to be had whether https://github.com/cloudevents/spec/pull/169 actually intended to change `schemaurl` - the constraint suggests otherwise - and if we want to have both `URI` and `URI-reference` in the type system.

Signed-off-by: Christoph Neijenhuis <christoph.neijenhuis@commercetools.de>