### PR TITLE
Primer edits - Architecture section 

### DIFF
--- a/primer.md
+++ b/primer.md
@@ -139,7 +139,7 @@ elements that form a layered architecture model.
 1. The [base specification](spec.md) defines an abstract information model
    made up of attributes (key-value pairs) and associated rules for what 
    constitutes a CloudEvent.
-2. The [extensions](./spec.md#extension-attributes) add use-case specific
+2. The [extensions](./spec.md#extension-context-attributes) add use-case specific
    and potentially overlapping sets of extension attributes and associated
    rules, e.g. to support different tracing standards.
 3. The event format encodings, e.g. [JSON](json-format.md), define how the

--- a/primer.md
+++ b/primer.md
@@ -136,11 +136,12 @@ The following will not be part of the specification:
 The CloudEvents specification set defines four different kinds of protocol
 elements that form a layered architecture model.
 
-1. The [base specification](spec.md) defines an abstract information model and
-   associated rules for what constitutes CloudEvent.
-2. The [extensions](./extensions) add use-case specific and potentially
-   overlapping sets of extension attributes and associated rules, e.g. to
-   support different tracing standards.
+1. The [base specification](spec.md) defines an abstract information model
+   made up of attributes (key-value pairs) and associated rules for what 
+   constitutes a CloudEvent.
+2. The [extensions](./spec.md#extension-attributes) add use-case specific
+   and potentially overlapping sets of extension attributes and associated
+   rules, e.g. to support different tracing standards.
 3. The event format encodings, e.g. [JSON](json-format.md), define how the
    information model of the base specification together with the chosen
    extensions is encoded for mapping it to header and payload elements of

--- a/primer.md
+++ b/primer.md
@@ -17,6 +17,7 @@ This document is a working draft.
 - [History](#history)
 - [CloudEvents Concepts](#cloudevents-concepts)
 - [Design Goals](#design-goals)
+- [Architecture](#architecture)
 - [Versioning of Attributes](#versioning-of-attributes)
 - [CloudEvent Attributes Extensions](#cloudevent-attribute-extensions)
 - [Qualifying Protocols and Encodings](#qualifying-protocols-and-encodings)
@@ -128,6 +129,34 @@ The following will not be part of the specification:
 - Function build and invocation process
 - Language-specific runtime APIs
 - Selecting a single identity/access control system
+
+
+## Architecture
+
+The CloudEvents specification set defines four different kinds of protocol
+elements that form a layered architecture model.
+
+1. The [base specification](spec.md) defines an abstract information model and
+   associated rules for what constitutes CloudEvent.
+2. The [extensions](./extensions) add use-case specific and potentially
+   overlapping sets of extension attributes and associated rules, e.g. to
+   support different tracing standards.
+3. The event format encodings, e.g. [JSON](json-format.md), define how the
+   information model of the base specification together with the chosen
+   extensions is encoded for mapping it to header and payload elements of
+   an application protocol.
+4. The transport bindings, e.g. [HTTP](http-transport-binding.md), defines
+   how the CloudEvent is bound to an application protocol's transport frame,
+   in the case of HTTP to the HTTP message. The transport binding does not 
+   constrain how the transport frame is used, meaning that the HTTP binding
+   can be used with any HTTP method and with request and response messages.
+
+If required to assure broader interoperability, the CloudEvents specification
+set provides specific constraints for event delivery using a particular
+application protocol. The [HTTP Webhook](http-webhook.md) specification is
+not specific to CloudEvents and can be used to post any kind of one-way event
+and notifications to a conformant HTTP endpoint. However, the lack of such a
+specification elsewhere makes it necessary for CloudEvents to define it.
 
 ## Versioning of Attributes
 


### PR DESCRIPTION
I have an open AI that has nagged me each week for the better part of the last decade to add some more content to the primer. I want to be a little careful with doing that because we've got a lot of authors on this document already, so I'll be doing smaller chunks. 

This PR adds an architecture summary of how the specs relate, which I don't think we have yet. There's a parallel PR (#389) for the SDK doc that is worded somewhat differently and presents how that same layering ought to be reflected in the SDK class/object/structure model.

Signed-off-by: Clemens Vasters <clemensv@microsoft.com>