### PR TITLE
Encoding & Transport Independent Interoperability Guarantee (Generic Size Measurement)

### DIFF
--- a/primer.md
+++ b/primer.md
@@ -187,6 +187,9 @@ encountered when adding extensions to a CloudEvent. For example, the
 headers to transport metadata; most HTTP servers will reject requests with
 excessive HTTP header data, with limits as low as 8kb. Therefore, the aggregate
 size and number of extension attributes should be kept minimal.
+A [Minimum Supported Event Size](spec.md#minimum-supported-event-size) should
+be supported by all event consumers. Event producers should leave additional
+space for a middleware to add extension attributes.
 
 The specification places no restrictions on the type of the extension
 attributes. Meaning, they may be simple types (e.g. strings, integers),

--- a/spec.md
+++ b/spec.md
@@ -295,15 +295,15 @@ encapsulated within the `data` attribute.
 In order to increase interoperability, all CloudEvent consumers SHOULD accept
 events that follow these rules:
 
-* The number of attributes does not exceed 100. Each index of a `Map` is
-  considered an attribute.
+* The number of attributes, including the `data` attribute, does not exceed 100.
+  Each index of a `Map` is considered an attribute.
 * All attribute names are 20 characters or less long.
 * All indexes of `Maps` are 20 characters or less long.
-* All `Binary` attributes do not exceed a size of 1KB.
-* All `String` attributes (including String expressions like `URI-reference` and
-  `Timestamp`) do not exceed a size of 1KB.
 * `Any` attributes containing a `Binary` or a `String` follow the respective
-  rule above. The `data` attribute is excempt from this rule.
+  rule below. The `data` attribute is excempt from this rule.
+* All `Binary` attributes do not exceed a size of 2KB.
+* All `String` attributes (including String expressions like `URI-reference` and
+  `Timestamp`) do not exceed a size of 2KB.
 * For a `Map`, the `Any`-typed values follow the rules above.
 * The total size of all attributes (including the `data` attribute) does not
   exceed 40KB/64KB.

--- a/spec.md
+++ b/spec.md
@@ -293,12 +293,12 @@ encapsulated within the `data` attribute.
 # Minimum Supported Event Size
 
 In order to increase interoperability, all CloudEvent consumers MUST accept
-messages up to a size of 256KB, measured by serializing the CloudEvent as
+events up to a size of 256KB, measured by serializing the CloudEvent as
 [JSON](./json-format.md) (minified, i.e. without white-space).
 
-CloudEvent consumers MAY reject CloudEvents above this size.
-It is RECOMMENDED for CloudEvent producers to only create CloudEvents within
-this size, unless they can be sure all consumers support larger sizes.
+CloudEvent consumers MAY reject events above this size.
+It is RECOMMENDED for CloudEvent producers to only create events within this
+size, unless they can be sure all consumers support larger sizes.
 
 # Example
 

--- a/spec.md
+++ b/spec.md
@@ -15,7 +15,7 @@ This document is a working draft.
 - [Type System](#type-system)
 - [Context Attributes](#context-attributes)
 - [Data Attribute](#data-attribute)
-- [Event Size Guarantees](#event-size-guarantees)
+- [Minimum Supported Event Size](#minimum-supported-event-size)
 - [Example](#example)
 
 ## Overview
@@ -290,7 +290,7 @@ encapsulated within the `data` attribute.
 * Constraints:
   * OPTIONAL
 
-# Event Size Guarantees
+# Minimum Supported Event Size
 
 In order to increase interoperability, all CloudEvent consumers MUST accept
 messages up to a size of 256KB, measured by serializing the CloudEvent as

--- a/spec.md
+++ b/spec.md
@@ -15,6 +15,7 @@ This document is a working draft.
 - [Type System](#type-system)
 - [Context Attributes](#context-attributes)
 - [Data Attribute](#data-attribute)
+- [Size Limits](#size-limits)
 - [Example](#example)
 
 ## Overview
@@ -288,6 +289,32 @@ encapsulated within the `data` attribute.
   which is specified by the `contenttype` attribute (e.g. application/json).
 * Constraints:
   * OPTIONAL
+
+# Size Limits
+
+In order to increase interoperability, the following size limits apply to any
+CloudEvent:
+
+* The CloudEvent serialized as JSON (minified, i.e. without white-space) MUST
+  NOT exceed a size of 128KB.
+* The CloudEvent MUST NOT have more than 100 top-level attributes.
+
+CloudEvent producers SHOULD only create CloudEvents within these limits.
+CloudEvent consumers MUST accept all CloudEvents within these limits and SHOULD
+reject messages that violate these limits.
+
+# Size Guarantees // Another option
+
+In order to increase interoperability, all CloudEvent consumers MUST accept
+messages up to the following sizes:
+
+* The CloudEvent serialized as JSON (minified, i.e. without white-space) does
+  not exceed a size of 128KB.
+* The CloudEvent does not have more than 100 top-level attributes.
+
+CloudEvent consumers MAY reject messages that violate these limits.
+It is RECOMMENDED for CloudEvent producers to only create CloudEvents within
+these limits, unless they can be sure all consumers support larger sizes.
 
 # Example
 

--- a/spec.md
+++ b/spec.md
@@ -305,15 +305,16 @@ events that follow these rules:
 * All `String` attributes (including String expressions like `URI-reference` and
   `Timestamp`) do not exceed a size of 2KB.
 * For a `Map`, the `Any`-typed values follow the rules above.
-* The total size of all attributes (including the `data` attribute) does not
-  exceed 40KB/64KB.
+* The total size of all attributes (including the `data` attribute) and
+  nonessential data does not exceed 45KB.
 
+Nonessential data, such as whitespace or comments, is data that can be removed
+from an encoding or transport format without affecting the CloudEvent.
 The size of a `String` attribute is measured by encoding it in
 [UTF-8](https://tools.ietf.org/html/rfc3629).
 The size of an `Integer` attribute is 4 bytes.
 
-CloudEvent consumers MAY reject events that do not follow these rules and MAY
-reject messages that are not minified (e.g. contain unnecessary white-space).
+CloudEvent consumers MAY reject events that do not follow these rules.
 It is RECOMMENDED for CloudEvent producers to only create events that follow
 these rules, unless they can be sure all consumers support larger sizes.
 

--- a/spec.md
+++ b/spec.md
@@ -293,26 +293,30 @@ encapsulated within the `data` attribute.
 # Minimum Supported Event Size
 
 In order to increase interoperability, all CloudEvent consumers SHOULD accept
-events up to a size of 64KB, measured by serializing the CloudEvent as
-[JSON](./json-format.md) (minified, i.e. without white-space).
+events that follow these rules:
 
-CloudEvent consumers MAY reject events above this size and MAY reject messages
-that are not minified (e.g. contain unnecessary white-space).
-It is RECOMMENDED for CloudEvent producers to only create events within this
-size, unless they can be sure all consumers support larger sizes.
+* The number of attributes does not exceed 100. Each index of a `Map` is
+  considered an attribute.
+* All attribute names are 20 characters or less long.
+* All indexes of `Maps` are 20 characters or less long.
+* All `Binary` attributes do not exceed a size of 1KB.
+* All `String` attributes (including String expressions like `URI-reference` and
+  `Timestamp`) do not exceed a size of 1KB.
+* `Any` attributes containing a `Binary` or a `String` follow the respective
+  rule above. The `data` attribute is excempt from this rule.
+* For a `Map`, the `Any`-typed values follow the rules above.
+* The total size of all attributes (including the `data` attribute) does not
+  exceed 40KB/64KB.
 
-The same event serialized with a different format will likely result in a
-different size. However, to aid interoperability, only the minified
-[JSON](./json-format.md) is used to measure the size. As an example, an
-[AMQP](./amqp-format.md) message of 70KB MUST be accepted if the contained
-event serialized as JSON is below 64KB. However, an [AMQP](./amqp-format.md)
-message of 60KB MAY be rejected if the contained event serialized as JSON
-exceeds 64KB. Practically, an [AMQP](./amqp-format.md) consumer that wants to
-protect theirself from large messages MAY simply choose to reject messagess
-after a higher limit (e.g. 256KB) that comfortably fits any valid event size.
-However, a middleware that wants to guarantee that the event can be forwarded
-in any format SHOULD measure the size of the event independently of the format
-it was received in.
+The size of a `String` attribute is measured by encoding it in
+[UTF-8](https://tools.ietf.org/html/rfc3629).
+The size of an `Integer` attribute is 4 bytes.
+
+CloudEvent consumers MAY reject events that do not follow these rules and MAY
+reject messages that are not minified (e.g. contain unnecessary white-space).
+It is RECOMMENDED for CloudEvent producers to only create events that follow
+these rules, unless they can be sure all consumers support larger sizes.
+
 
 # Example
 

--- a/spec.md
+++ b/spec.md
@@ -15,7 +15,7 @@ This document is a working draft.
 - [Type System](#type-system)
 - [Context Attributes](#context-attributes)
 - [Data Attribute](#data-attribute)
-- [Size Limits](#size-limits)
+- [Event Size Guarantees](#event-size-guarantees)
 - [Example](#example)
 
 ## Overview
@@ -290,31 +290,15 @@ encapsulated within the `data` attribute.
 * Constraints:
   * OPTIONAL
 
-# Size Limits
-
-In order to increase interoperability, the following size limits apply to any
-CloudEvent:
-
-* The CloudEvent serialized as JSON (minified, i.e. without white-space) MUST
-  NOT exceed a size of 128KB.
-* The CloudEvent MUST NOT have more than 100 top-level attributes.
-
-CloudEvent producers SHOULD only create CloudEvents within these limits.
-CloudEvent consumers MUST accept all CloudEvents within these limits and SHOULD
-reject messages that violate these limits.
-
-# Size Guarantees // Another option
+# Event Size Guarantees
 
 In order to increase interoperability, all CloudEvent consumers MUST accept
-messages up to the following sizes:
+messages up to a size of 256KB, measured by serializing the CloudEvent as
+[JSON](./json-format.md) (minified, i.e. without white-space).
 
-* The CloudEvent serialized as JSON (minified, i.e. without white-space) does
-  not exceed a size of 128KB.
-* The CloudEvent does not have more than 100 top-level attributes.
-
-CloudEvent consumers MAY reject messages that violate these limits.
+CloudEvent consumers MAY reject CloudEvents above this size.
 It is RECOMMENDED for CloudEvent producers to only create CloudEvents within
-these limits, unless they can be sure all consumers support larger sizes.
+this size, unless they can be sure all consumers support larger sizes.
 
 # Example
 

--- a/spec.md
+++ b/spec.md
@@ -296,9 +296,23 @@ In order to increase interoperability, all CloudEvent consumers MUST accept
 events up to a size of 256KB, measured by serializing the CloudEvent as
 [JSON](./json-format.md) (minified, i.e. without white-space).
 
-CloudEvent consumers MAY reject events above this size.
+CloudEvent consumers MAY reject events above this size and MAY reject messages
+that are not minified (e.g. contain unnecessary white-space).
 It is RECOMMENDED for CloudEvent producers to only create events within this
 size, unless they can be sure all consumers support larger sizes.
+
+The same event serialized with a different format will likely result in a
+different size. However, to aid interoperability, only the minified
+[JSON](./json-format.md) is used to measure the size. As an example, an
+[AMQP](./amqp-format.md) message of 270KB MUST be accepted if the contained
+event serialized as JSON is below 256KB. However, an [AMQP](./amqp-format.md)
+message of 250KB MAY be rejected if the contained event serialized as JSON
+exceeds 256KB. Practically, an [AMQP](./amqp-format.md) consumer that wants to
+protect theirself from large messages MAY simply choose to reject messagess
+after a higher limit (e.g. 512KB) that comfortably fits any valid event size.
+However, a middleware that wants to guarantee that the event can be forwarded
+in any format SHOULD measure the size of the event independently of the format
+it was received in.
 
 # Example
 

--- a/spec.md
+++ b/spec.md
@@ -292,8 +292,8 @@ encapsulated within the `data` attribute.
 
 # Minimum Supported Event Size
 
-In order to increase interoperability, all CloudEvent consumers MUST accept
-events up to a size of 256KB, measured by serializing the CloudEvent as
+In order to increase interoperability, all CloudEvent consumers SHOULD accept
+events up to a size of 64KB, measured by serializing the CloudEvent as
 [JSON](./json-format.md) (minified, i.e. without white-space).
 
 CloudEvent consumers MAY reject events above this size and MAY reject messages
@@ -304,12 +304,12 @@ size, unless they can be sure all consumers support larger sizes.
 The same event serialized with a different format will likely result in a
 different size. However, to aid interoperability, only the minified
 [JSON](./json-format.md) is used to measure the size. As an example, an
-[AMQP](./amqp-format.md) message of 270KB MUST be accepted if the contained
-event serialized as JSON is below 256KB. However, an [AMQP](./amqp-format.md)
-message of 250KB MAY be rejected if the contained event serialized as JSON
-exceeds 256KB. Practically, an [AMQP](./amqp-format.md) consumer that wants to
+[AMQP](./amqp-format.md) message of 70KB MUST be accepted if the contained
+event serialized as JSON is below 64KB. However, an [AMQP](./amqp-format.md)
+message of 60KB MAY be rejected if the contained event serialized as JSON
+exceeds 64KB. Practically, an [AMQP](./amqp-format.md) consumer that wants to
 protect theirself from large messages MAY simply choose to reject messagess
-after a higher limit (e.g. 512KB) that comfortably fits any valid event size.
+after a higher limit (e.g. 256KB) that comfortably fits any valid event size.
 However, a middleware that wants to guarantee that the event can be forwarded
 in any format SHOULD measure the size of the event independently of the format
 it was received in.


### PR DESCRIPTION
Alternative proposal to https://github.com/cloudevents/spec/pull/364

The feedback on last weeks call was that it was bad that we're forcing non-JSON implementations to serialize a CloudEvent to JSON to ensure that it is within the supported size.

This proposes a different way to measure the event size by looking at the attributes.

Note that this proposal doesn't measure the size of the event on the wire in any format. The size on the wire will differ, including in JSON. Particularly for JSON, `Binary` and `Integer` fields are likely bigger than measured here.
If we want to keep a JSON CloudEvent below 64KB (basically for Azure EventGrid compatibility), the last rule should probably state 40KB. If we're more targeting "around 64KB in efficient wire formats", we can go for 64KB in the last rule.

Tradeoff compared to #364 : 
CON: More complexity for measuring the size of the event, given that all implementations must support JSON.
PRO: No need to serialize an event to JSON. More fine-granular limits on individual fields.