### PR TITLE
Move "extension attributes" section down to end of context attributes

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -140,39 +140,6 @@ attributes and the event data will be materialized. For example, in the case
 of a JSON serialization, the context attributes and the event data might
 both appear within the same JSON object.
 
-### Extension Attributes
-CloudEvents producers MAY include additional context attributes in the event
-that might be used in ancillary actions related to the processing of the event.
-See
-[CloudEvent Attributes Extensions](primer.md#cloudevent-attribute-extensions)
-for additional information concerning the use and definition of extensions.
-
-This specification places no restriction on the type or semantics of the
-extension attributes. Each definition of an extensions SHOULD fully
-define all aspects of the attribute - e.g. its name, semantic meaning
-and possible values or even to indicate that it places no restrictions on
-its values.  New extension definitions SHOULD use a name that is
-descriptive enough to reduce the chances of name collisions with other
-extensions. In particular, extension authors SHOULD check the
-[documented extensions](documented-extensions.md) document for the
-set of known extensions - not just for possible name conflicts but
-for extensions that might be of interest.
-
-Each specification that defines how to serialize a CloudEvent will
-define how extension attributes will appear.
-
-Here is an example that illustrates the need for additional attributes.
-In many IoT and enterprise use cases, an event could be used in
-a serverless application that performs actions across multiple types of events.
-To support such use cases, the event producer will need to add additional
-identity attributes to the "context attributes" which the event consumers can
-use to correlate this event with the other events. If such identity attributes
-happen to be part of the event "data", the event producer SHOULD also add
-the identity attributes to the "context attributes" so that
-event consumers can easily access this information without needing to decode
-and examine the event data. Such identity attributes can also be used to
-help intermediate gateways determine how to route the events.
-
 ### type
 * Type: `String`
 * Description: Type of occurrence which has happened. Often this
@@ -273,6 +240,39 @@ help intermediate gateways determine how to route the events.
   * If present, MUST adhere to the format specified in
     [RFC 2046](https://tools.ietf.org/html/rfc2046)
 * For Media Type examples see [IANA Media Types](http://www.iana.org/assignments/media-types/media-types.xhtml)
+
+### Extension Context Attributes
+CloudEvents producers MAY include additional context attributes in the event
+that might be used in ancillary actions related to the processing of the event.
+See
+[CloudEvent Attributes Extensions](primer.md#cloudevent-attribute-extensions)
+for additional information concerning the use and definition of extensions.
+
+This specification places no restriction on the type or semantics of the
+extension attributes. Each definition of an extensions SHOULD fully
+define all aspects of the attribute - e.g. its name, semantic meaning
+and possible values or even to indicate that it places no restrictions on
+its values.  New extension definitions SHOULD use a name that is
+descriptive enough to reduce the chances of name collisions with other
+extensions. In particular, extension authors SHOULD check the
+[documented extensions](documented-extensions.md) document for the
+set of known extensions - not just for possible name conflicts but
+for extensions that might be of interest.
+
+Each specification that defines how to serialize a CloudEvent will
+define how extension attributes will appear.
+
+Here is an example that illustrates the need for additional attributes.
+In many IoT and enterprise use cases, an event could be used in
+a serverless application that performs actions across multiple types of events.
+To support such use cases, the event producer will need to add additional
+identity attributes to the "context attributes" which the event consumers can
+use to correlate this event with the other events. If such identity attributes
+happen to be part of the event "data", the event producer SHOULD also add
+the identity attributes to the "context attributes" so that
+event consumers can easily access this information without needing to decode
+and examine the event data. Such identity attributes can also be used to
+help intermediate gateways determine how to route the events.
 
 ## Data Attribute
 


### PR DESCRIPTION
Closes #401 

Also added changes the title of the sub-section to make it clear we're talking about context attributes

Signed-off-by: Doug Davis <dug@us.ibm.com>