### PR TITLE
Extensions follow attribute naming scheme introduced in #321

### DIFF
--- a/extensions/distributed-tracing.md
+++ b/extensions/distributed-tracing.md
@@ -24,7 +24,7 @@ platforms like Prometheus are built.
 ## Encoding
 
 ### In-memory formats
-The Distributed Tracing extension uses the key `distributedTracing` for in-memory formats
+The Distributed Tracing extension uses the key `distributedtracing` for in-memory formats
 
 ### HTTP
 

--- a/extensions/sampled-rate.md
+++ b/extensions/sampled-rate.md
@@ -31,7 +31,7 @@ they impose additional sampling.
 ## Encoding
 
 ### In-memory formats
-The Sampling extension uses the key `sampledRate` for in-memory formats.
+The Sampling extension uses the key `sampledrate` for in-memory formats.
 
 ### Transport bindings
 The Sampling extension does not customize any transport binding's storage

--- a/extensions/sequence.md
+++ b/extensions/sequence.md
@@ -6,8 +6,8 @@ by a unique event source.
 
 The `sequence` attribute represents the value of this event's
 order in the stream of events.  The exact value and meaning of this
-attribute is defined by the `sequenceType` attribute. 
-If the `sequenceType` is missing, or not defined in this specification,
+attribute is defined by the `sequencetype` attribute. 
+If the `sequencetype` is missing, or not defined in this specification,
 event consumers will need to have some out-of-band communication with the
 event producer to understand how to interpret the value of the attribute.
 
@@ -22,7 +22,7 @@ event producer to understand how to interpret the value of the attribute.
   * MUST be a non-empty lexicographically-orderable string
   * RECOMMENDED as monotonically increasing and contiguous
 
-### sequenceType
+### sequencetype
 * Type: `String`
 * Description: Specifies the semantics of the sequence attribute.
   See the [SequenceType Values](#sequencetype-values) section for more
@@ -33,11 +33,11 @@ event producer to understand how to interpret the value of the attribute.
 
 ## SequenceType Values
 
-This specification defines the following values for `sequenceType`.
+This specification defines the following values for `sequencetype`.
 Additional values MAY be defined by other specifications.
 
 ### Integer
-If the `sequenceType` is set to `Integer`, the `sequence` attribute has
+If the `sequencetype` is set to `Integer`, the `sequence` attribute has
 the following semantics:
 * The values of `sequence` are string-encoded signed 32-bit Integers.
 * The sequence MUST start with a value of `1` and increase by `1` for each 


### PR DESCRIPTION
#321 made attribute names lower case, but did not apply the new rule to extensions.
This PR cleans that up.

Signed-off-by: Christoph Neijenhuis <christoph.neijenhuis@commercetools.de>