### PR TITLE
Add Apache RocketMQ proprietary transport binding with cloudevents

### DIFF
--- a/proprietary-specs.md
+++ b/proprietary-specs.md
@@ -4,4 +4,4 @@ Disclaimer: CloudEvents does not endorse these protocols or specs, and does not
 ensure that they are up to date with the current version of CloudEvents. That is
 the responsibility of the respective project maintainers.
 
-- [placeholder](/)
+- [Apache RocketMQ Transport Binding](https://github.com/apache/rocketmq-externals/blob/master/rocketmq-cloudevents-binding/rocketmq-transport-binding.md)


### PR DESCRIPTION
As we discussed in the Apache RocketMQ binding [PR](https://github.com/cloudevents/spec/pull/352) and followed with the voting result in the [PR](https://github.com/cloudevents/spec/pull/380), we proposed this PR.