### PR TITLE
Resolve quote issue for HTTP Binary Transport Encoding.

### DIFF
--- a/amqp-format.md
+++ b/amqp-format.md
@@ -56,7 +56,7 @@ exceptions noted below.
 | CloudEvents   | AMQP                        |
 | ------------- | --------------------------- |
 | String        | [string][amqp-string]       |
-| Integer       | [long][amqp-long]           |
+| Integer       | [string][amqp-string]       |
 | Binary        | [binary][amqp-binary]       |
 | URI-reference | [string][amqp-string]       |
 | Timestamp     | [timestamp][amqp-timestamp] |

--- a/amqp-transport-binding.md
+++ b/amqp-transport-binding.md
@@ -201,11 +201,11 @@ content-type: application/json; charset=utf-8
 
 ----------- application-properties -----------
 
-cloudEvents:specversion: "0.3-wip"
-cloudEvents:type: "com.example.someevent"
-cloudEvents:time: "2018-04-05T03:56:24Z"
-cloudEvents:id: "1234-1234-1234"
-cloudEvents:source: "/mycontext/subcontext"
+cloudEvents:specversion: 0.3-wip
+cloudEvents:type: com.example.someevent
+cloudEvents:time: 2018-04-05T03:56:24Z
+cloudEvents:id: 1234-1234-1234
+cloudEvents:source: /mycontext/subcontext
        .... further attributes ...
 
 ------------- application-data ---------------

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -226,7 +226,10 @@ with [RFC7230, sections 3, 3.2, 3.2.6][rfc7230-section-3]. The rules for
 encoding of the percent character ('%') apply as defined in [RFC 3986 Section
 2.4.][rfc3986-section-2-4].
 
-JSON objects and arrays are NOT surrounded with single or double quotes.
+[JSON values][json-value] for well-known context attributes as defined by the
+[CloudEvents specification][ce] or [CloudEvents Extensions][extensions] MAY omit
+the surrounding single or double quote. All values are assumed to be a string
+unless well-known.
 
 #### 3.1.4 Examples
 
@@ -236,11 +239,11 @@ request:
 ```text
 POST /someresource HTTP/1.1
 Host: webhook.example.com
-ce-specversion: "0.2"
-ce-type: "com.example.someevent"
-ce-time: "2018-04-05T03:56:24Z"
-ce-id: "1234-1234-1234"
-ce-source: "/mycontext/subcontext"
+ce-specversion: 0.2
+ce-type: com.example.someevent
+ce-time: 2018-04-05T03:56:24Z
+ce-id: 1234-1234-1234
+ce-source: /mycontext/subcontext
     .... further attributes ...
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -254,11 +257,11 @@ This example shows a response containing an event:
 
 ```text
 HTTP/1.1 200 OK
-ce-specversion: "0.2"
-ce-type: "com.example.someevent"
-ce-time: "2018-04-05T03:56:24Z"
-ce-id: "1234-1234-1234"
-ce-source: "/mycontext/subcontext"
+ce-specversion: 0.2
+ce-type: com.example.someevent
+ce-time: 2018-04-05T03:56:24Z
+ce-id: 1234-1234-1234
+ce-source: /mycontext/subcontext
     .... further attributes ...
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -266,6 +269,29 @@ Content-Length: nnnn
 {
     ... application data ...
 }
+```
+
+The following are equivalent in binary mode:
+
+```text
+ce-specversion: 0.2
+ce-type: com.example.someevent
+ce-custom: {"my":"value"}
+    .... further attributes ...
+```
+
+```text
+ce-specversion: '0.2'
+ce-type: 'com.example.someevent'
+ce-custom: '{"my":"value"}'
+    .... further attributes ...
+```
+
+```text
+ce-specversion: "0.2"
+ce-type: "com.example.someevent"
+ce-custom: "{\"my\":\"value\"}"
+    .... further attributes ...
 ```
 
 ### 3.2. Structured Content Mode
@@ -467,6 +493,7 @@ Content-Length: nnnn
 - [RFC7540][rfc7540] Hypertext Transfer Protocol Version 2 (HTTP/2)
 
 [ce]: ./spec.md
+[extensions]: ./extensions/
 [json-format]: ./json-format.md
 [json-batch-format]: ./json-format.md#4-json-batch-format
 [content-type]: https://tools.ietf.org/html/rfc7231#section-3.1.1.5

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -207,7 +207,7 @@ specification, header names are case-insensitive.
 ##### 3.1.3.2 HTTP Header Values
 
 The value for each HTTP header is constructed from the respective attribute's
-[JSON value][json-value] representation, compliant with the [JSON event
+unquoted [JSON value][json-value] representation, compliant with the [JSON event
 format][json-format] specification.
 
 Some CloudEvents metadata attributes can contain arbitrary UTF-8 string content,
@@ -225,11 +225,6 @@ be percent-encoded to be represented as HTTP header characters, in compliance
 with [RFC7230, sections 3, 3.2, 3.2.6][rfc7230-section-3]. The rules for
 encoding of the percent character ('%') apply as defined in [RFC 3986 Section
 2.4.][rfc3986-section-2-4].
-
-[JSON values][json-value] for well-known context attributes as defined by the
-[CloudEvents specification][ce] or [CloudEvents Extensions][extensions] MAY omit
-the surrounding single or double quote. All values are assumed to be a string
-unless well-known.
 
 #### 3.1.4 Examples
 
@@ -269,29 +264,6 @@ Content-Length: nnnn
 {
     ... application data ...
 }
-```
-
-The following are equivalent in binary mode:
-
-```text
-ce-specversion: 0.2
-ce-type: com.example.someevent
-ce-custom: {"my":"value"}
-    .... further attributes ...
-```
-
-```text
-ce-specversion: '0.2'
-ce-type: 'com.example.someevent'
-ce-custom: '{"my":"value"}'
-    .... further attributes ...
-```
-
-```text
-ce-specversion: "0.2"
-ce-type: "com.example.someevent"
-ce-custom: "{\"my\":\"value\"}"
-    .... further attributes ...
 ```
 
 ### 3.2. Structured Content Mode

--- a/json-format.md
+++ b/json-format.md
@@ -64,7 +64,7 @@ exceptions noted below.
 | CloudEvents   | JSON                                                           |
 | ------------- | -------------------------------------------------------------- |
 | String        | [string][json-string]                                          |
-| Integer       | [number][json-number], only the `int` component is permitted   |
+| Integer       | [string][json-string], interpreted as a [number][json-number]  |
 | Binary        | [string][json-string], [Base64-encoded][base64] binary         |
 | URI-reference | [string][json-string] following [RFC 3986][rfc3986]            |
 | Timestamp     | [string][json-string] following [RFC 3339][rfc3339] (ISO 8601) |
@@ -180,7 +180,7 @@ Example event with `String`-valued `data`:
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
     "comexampleextension2" : {
-        "otherValue": 5
+        "otherValue": "5"
     },
     "datacontenttype" : "text/xml",
     "data" : "<much wow=\"xml\"/>"
@@ -198,7 +198,7 @@ Example event with `Binary`-valued data
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
     "comexampleextension2" : {
-        "otherValue": 5
+        "otherValue": "5"
     },
     "datacontenttype" : "application/vnd.apache.thrift.binary",
     "data" : "... base64 encoded string ..."
@@ -217,7 +217,7 @@ or [JSON data](#31-special-handling-of-the-data-attribute) data:
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
     "comexampleextension2" : {
-        "otherValue": 5
+        "otherValue": "5"
     },
     "datacontenttype" : "application/json",
     "data" : {
@@ -267,7 +267,7 @@ second with JSON data.
       "time" : "2018-04-05T17:31:00Z",
       "comexampleextension1" : "value",
       "comexampleextension2" : {
-          "otherValue": 5
+          "otherValue": "5"
       },
       "datacontenttype" : "application/vnd.apache.thrift.binary",
       "data" : "... base64 encoded string ..."
@@ -280,7 +280,7 @@ second with JSON data.
       "time" : "2018-04-05T17:31:05Z",
       "comexampleextension1" : "value",
       "comexampleextension2" : {
-          "otherValue": 5
+          "otherValue": "5"
       },
       "datacontenttype" : "application/json",
       "data" : {

--- a/spec.md
+++ b/spec.md
@@ -411,7 +411,7 @@ The following example shows a CloudEvent serialized as JSON:
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
     "comexampleextension2" : {
-        "othervalue": 5
+        "othervalue": "5"
     },
     "datacontenttype" : "text/xml",
     "data" : "<much wow=\"xml\"/>"

--- a/spec.md
+++ b/spec.md
@@ -297,6 +297,29 @@ without needing to decode and examine the event data. Such identity attributes
 can also be used to help intermediate gateways determine how to route the
 events.
 
+### datacontentencoding
+* Type: `String` per [RFC 2045 Section 6.1](https://tools.ietf.org/html/rfc2045#section-6.1)
+* Description: Describes the content encoding for the `data`
+  attribute for when the `data` field MUST be encoded as a string,
+  like with structured transport binding modes using the JSON event
+  format, but the `datacontenttype` indicates a non-string media
+  type. When the `data` field's effective data type is not `String`,
+  this attribute MUST NOT be set and MUST be ignored when set.
+  
+  The "Base64" value for the Base64 encoding as defined in [RFC 2045 Section 6.8](https://tools.ietf.org/html/rfc2045#section-6.8)
+  MUST be supported. When set, the event-format-encoded value of the `data` 
+  attribute is a base64 string, but the effective data type of
+  the `data` attribute towards the application is the base64-decoded
+  binary array.
+  
+  All other RFC2045 schemes are undefined for CloudEvents.
+
+* Constraints:
+  * The attribute MUST be set if the `data` attribute contains string-encoded
+    binary data. Otherwise the attribute MUST NOT be set.
+  * If present, MUST adhere to [RFC 2045 Section 6.1](https://tools.ietf.org/html/rfc2045#section-6.1)
+
+
 ## Data Attribute
 
 As defined by the term [Data](#data), CloudEvents MAY include domain-specific


### PR DESCRIPTION
Fixes https://github.com/cloudevents/spec/issues/396

I am proposing no quotes. All values inside the CloudEvents context attributes assumed to be strings.

Signed-off-by: Scott Nichols <nicholss@google.com>