### PR TITLE
Master represents the future version of the spec, use the future version in the text.

### DIFF
--- a/amqp-transport-binding.md
+++ b/amqp-transport-binding.md
@@ -201,7 +201,7 @@ content-type: application/json; charset=utf-8
 
 ----------- application-properties -----------
 
-cloudEvents:specversion: "0.2"
+cloudEvents:specversion: "0.3"
 cloudEvents:type: "com.example.someevent"
 cloudEvents:time: "2018-04-05T03:56:24Z"
 cloudEvents:id: "1234-1234-1234"
@@ -263,7 +263,7 @@ content-type: application/cloudevents+json; charset=utf-8
 ------------- application-data --------------------------
 
 {
-    "specversion" : "0.2",
+    "specversion" : "0.3",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/amqp-transport-binding.md
+++ b/amqp-transport-binding.md
@@ -201,7 +201,7 @@ content-type: application/json; charset=utf-8
 
 ----------- application-properties -----------
 
-cloudEvents:specversion: "0.3"
+cloudEvents:specversion: "0.3-wip"
 cloudEvents:type: "com.example.someevent"
 cloudEvents:time: "2018-04-05T03:56:24Z"
 cloudEvents:id: "1234-1234-1234"
@@ -263,7 +263,7 @@ content-type: application/cloudevents+json; charset=utf-8
 ------------- application-data --------------------------
 
 {
-    "specversion" : "0.3",
+    "specversion" : "0.3-wip",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -1,4 +1,4 @@
-# HTTP Transport Binding for CloudEvents - Version 0.3
+# HTTP Transport Binding for CloudEvents - Version 0.3-wip
 
 ## Abstract
 
@@ -236,7 +236,7 @@ request:
 ```text
 POST /someresource HTTP/1.1
 Host: webhook.example.com
-ce-specversion: "0.3"
+ce-specversion: "0.3-wip"
 ce-type: "com.example.someevent"
 ce-time: "2018-04-05T03:56:24Z"
 ce-id: "1234-1234-1234"
@@ -254,7 +254,7 @@ This example shows a response containing an event:
 
 ```text
 HTTP/1.1 200 OK
-ce-specversion: "0.3"
+ce-specversion: "0.3-wip"
 ce-type: "com.example.someevent"
 ce-time: "2018-04-05T03:56:24Z"
 ce-id: "1234-1234-1234"
@@ -313,7 +313,7 @@ Content-Type: application/cloudevents+json; charset=utf-8
 Content-Length: nnnn
 
 {
-    "specversion" : "0.3",
+    "specversion" : "0.3-wip",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -334,7 +334,7 @@ Content-Type: application/cloudevents+json; charset=utf-8
 Content-Length: nnnn
 
 {
-    "specversion" : "0.3",
+    "specversion" : "0.3-wip",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -390,7 +390,7 @@ Content-Length: nnnn
 
 [
     {
-        "specversion" : "0.3",
+        "specversion" : "0.3-wip",
         "type" : "com.example.someevent",
 
         ... further attributes omitted ...
@@ -400,7 +400,7 @@ Content-Length: nnnn
         }
     },
     {
-        "specversion" : "0.3",
+        "specversion" : "0.3-wip",
         "type" : "com.example.someotherevent",
 
         ... further attributes omitted ...
@@ -423,7 +423,7 @@ Content-Length: nnnn
 
 [
     {
-        "specversion" : "0.3",
+        "specversion" : "0.3-wip",
         "type" : "com.example.someevent",
 
         ... further attributes omitted ...
@@ -433,7 +433,7 @@ Content-Length: nnnn
         }
     },
     {
-        "specversion" : "0.3",
+        "specversion" : "0.3-wip",
         "type" : "com.example.someotherevent",
 
         ... further attributes omitted ...

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -1,4 +1,4 @@
-# HTTP Transport Binding for CloudEvents - Version 0.2
+# HTTP Transport Binding for CloudEvents - Version 0.3
 
 ## Abstract
 
@@ -236,7 +236,7 @@ request:
 ```text
 POST /someresource HTTP/1.1
 Host: webhook.example.com
-ce-specversion: "0.2"
+ce-specversion: "0.3"
 ce-type: "com.example.someevent"
 ce-time: "2018-04-05T03:56:24Z"
 ce-id: "1234-1234-1234"
@@ -254,7 +254,7 @@ This example shows a response containing an event:
 
 ```text
 HTTP/1.1 200 OK
-ce-specversion: "0.2"
+ce-specversion: "0.3"
 ce-type: "com.example.someevent"
 ce-time: "2018-04-05T03:56:24Z"
 ce-id: "1234-1234-1234"
@@ -313,7 +313,7 @@ Content-Type: application/cloudevents+json; charset=utf-8
 Content-Length: nnnn
 
 {
-    "specversion" : "0.2",
+    "specversion" : "0.3",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -334,7 +334,7 @@ Content-Type: application/cloudevents+json; charset=utf-8
 Content-Length: nnnn
 
 {
-    "specversion" : "0.2",
+    "specversion" : "0.3",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -390,7 +390,7 @@ Content-Length: nnnn
 
 [
     {
-        "specversion" : "0.2",
+        "specversion" : "0.3",
         "type" : "com.example.someevent",
 
         ... further attributes omitted ...
@@ -400,7 +400,7 @@ Content-Length: nnnn
         }
     },
     {
-        "specversion" : "0.2",
+        "specversion" : "0.3",
         "type" : "com.example.someotherevent",
 
         ... further attributes omitted ...
@@ -423,7 +423,7 @@ Content-Length: nnnn
 
 [
     {
-        "specversion" : "0.2",
+        "specversion" : "0.3",
         "type" : "com.example.someevent",
 
         ... further attributes omitted ...
@@ -433,7 +433,7 @@ Content-Length: nnnn
         }
     },
     {
-        "specversion" : "0.2",
+        "specversion" : "0.3",
         "type" : "com.example.someotherevent",
 
         ... further attributes omitted ...

--- a/json-format.md
+++ b/json-format.md
@@ -1,4 +1,4 @@
-# JSON Event Format for CloudEvents - Version 0.3
+# JSON Event Format for CloudEvents - Version 0.3-wip
 
 ## Abstract
 
@@ -109,7 +109,7 @@ The following table shows exemplary mappings:
 | CloudEvents     | Type          | Exemplary JSON Value            |
 | --------------- | ------------- | ------------------------------- |
 | type            | String        | "com.example.someevent"         |
-| specversion     | String        | "0.3"                           |
+| specversion     | String        | "0.3-wip"                           |
 | source          | URI-reference | "/mycontext"                    |
 | id              | String        | "1234-1234-1234"                |
 | time            | Timestamp     | "2018-04-05T17:31:00Z"          |
@@ -173,7 +173,7 @@ Example event with `String`-valued `data`:
 
 ```JSON
 {
-    "specversion" : "0.3",
+    "specversion" : "0.3-wip",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "A234-1234-1234",
@@ -191,7 +191,7 @@ Example event with `Binary`-valued data
 
 ```JSON
 {
-    "specversion" : "0.3",
+    "specversion" : "0.3-wip",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "B234-1234-1234",
@@ -210,7 +210,7 @@ or [JSON data](#31-special-handling-of-the-data-attribute) data:
 
 ```JSON
 {
-    "specversion" : "0.3",
+    "specversion" : "0.3-wip",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "C234-1234-1234",
@@ -260,7 +260,7 @@ second with JSON data.
 ```JSON
 [
   {
-      "specversion" : "0.3",
+      "specversion" : "0.3-wip",
       "type" : "com.example.someevent",
       "source" : "/mycontext/4",
       "id" : "B234-1234-1234",
@@ -273,7 +273,7 @@ second with JSON data.
       "data" : "... base64 encoded string ..."
   },
   {
-      "specversion" : "0.3",
+      "specversion" : "0.3-wip",
       "type" : "com.example.someotherevent",
       "source" : "/mycontext/9",
       "id" : "C234-1234-1234",

--- a/json-format.md
+++ b/json-format.md
@@ -1,4 +1,4 @@
-# JSON Event Format for CloudEvents - Version 0.2
+# JSON Event Format for CloudEvents - Version 0.3
 
 ## Abstract
 
@@ -109,7 +109,7 @@ The following table shows exemplary mappings:
 | CloudEvents     | Type          | Exemplary JSON Value            |
 | --------------- | ------------- | ------------------------------- |
 | type            | String        | "com.example.someevent"         |
-| specversion     | String        | "0.2"                           |
+| specversion     | String        | "0.3"                           |
 | source          | URI-reference | "/mycontext"                    |
 | id              | String        | "1234-1234-1234"                |
 | time            | Timestamp     | "2018-04-05T17:31:00Z"          |
@@ -173,7 +173,7 @@ Example event with `String`-valued `data`:
 
 ```JSON
 {
-    "specversion" : "0.2",
+    "specversion" : "0.3",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "A234-1234-1234",
@@ -191,7 +191,7 @@ Example event with `Binary`-valued data
 
 ```JSON
 {
-    "specversion" : "0.2",
+    "specversion" : "0.3",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "B234-1234-1234",
@@ -210,7 +210,7 @@ or [JSON data](#31-special-handling-of-the-data-attribute) data:
 
 ```JSON
 {
-    "specversion" : "0.2",
+    "specversion" : "0.3",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "C234-1234-1234",
@@ -260,7 +260,7 @@ second with JSON data.
 ```JSON
 [
   {
-      "specversion" : "0.2",
+      "specversion" : "0.3",
       "type" : "com.example.someevent",
       "source" : "/mycontext/4",
       "id" : "B234-1234-1234",
@@ -273,7 +273,7 @@ second with JSON data.
       "data" : "... base64 encoded string ..."
   },
   {
-      "specversion" : "0.2",
+      "specversion" : "0.3",
       "type" : "com.example.someotherevent",
       "source" : "/mycontext/9",
       "id" : "C234-1234-1234",

--- a/mqtt-transport-binding.md
+++ b/mqtt-transport-binding.md
@@ -198,7 +198,7 @@ Content Type: application/json; charset=utf-8
 
 ------------- User Properties ----------------
 
-specversion: "0.2"
+specversion: "0.3"
 type: "com.example.someevent"
 time: "2018-04-05T03:56:24Z"
 id: "1234-1234-1234"
@@ -260,7 +260,7 @@ Content Type: application/cloudevents+json; charset=utf-8
 ------------------ payload -------------------
 
 {
-    "specversion" : "0.2",
+    "specversion" : "0.3",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -285,7 +285,7 @@ Topic Name: mytopic
 ------------------ payload -------------------
 
 {
-    "specversion" : "0.2",
+    "specversion" : "0.3",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/mqtt-transport-binding.md
+++ b/mqtt-transport-binding.md
@@ -198,7 +198,7 @@ Content Type: application/json; charset=utf-8
 
 ------------- User Properties ----------------
 
-specversion: "0.3"
+specversion: "0.3-wip"
 type: "com.example.someevent"
 time: "2018-04-05T03:56:24Z"
 id: "1234-1234-1234"
@@ -260,7 +260,7 @@ Content Type: application/cloudevents+json; charset=utf-8
 ------------------ payload -------------------
 
 {
-    "specversion" : "0.3",
+    "specversion" : "0.3-wip",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -285,7 +285,7 @@ Topic Name: mytopic
 ------------------ payload -------------------
 
 {
-    "specversion" : "0.3",
+    "specversion" : "0.3-wip",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/nats-transport-binding.md
+++ b/nats-transport-binding.md
@@ -128,7 +128,7 @@ Subject: mySubject
 ------------------ payload -------------------
 
 {
-    "specversion" : "0.2",
+    "specversion" : "0.3",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/nats-transport-binding.md
+++ b/nats-transport-binding.md
@@ -128,7 +128,7 @@ Subject: mySubject
 ------------------ payload -------------------
 
 {
-    "specversion" : "0.3",
+    "specversion" : "0.3-wip",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/protobuf-format.md
+++ b/protobuf-format.md
@@ -1,4 +1,4 @@
-# Protocol Buffers Event Format for CloudEvents - Version 0.3
+# Protocol Buffers Event Format for CloudEvents - Version 0.3-wip
 
 ## Abstract
 
@@ -102,7 +102,7 @@ CloudEventMap event = CloudEventMap.newBuilder()
   .putValue(
     "specversion",
     CloudEventAny.newBuilder()
-      .setStringValue("0.3")
+      .setStringValue("0.3-wip")
       .build())
   .putValue(
     "time",

--- a/protobuf-format.md
+++ b/protobuf-format.md
@@ -1,4 +1,4 @@
-# Protocol Buffers Event Format for CloudEvents - Version 0.2
+# Protocol Buffers Event Format for CloudEvents - Version 0.3
 
 ## Abstract
 
@@ -102,7 +102,7 @@ CloudEventMap event = CloudEventMap.newBuilder()
   .putValue(
     "specversion",
     CloudEventAny.newBuilder()
-      .setStringValue("0.2")
+      .setStringValue("0.3")
       .build())
   .putValue(
     "time",

--- a/roadmap.md
+++ b/roadmap.md
@@ -55,7 +55,7 @@ _0.2_ - Completed - 2018/12/06
 1. Define the set of protocol and serialization mappings we're going to produce
    for 0.4 milestone
 
-_0.3_
+_0.3-wip_
 
 1. Resolve all known "proposed optional attributes" issues
 1. Resolve all known "security related" issues

--- a/spec.md
+++ b/spec.md
@@ -1,4 +1,4 @@
-# CloudEvents - Version 0.3
+# CloudEvents - Version 0.3-wip
 
 ## Abstract
 
@@ -179,7 +179,7 @@ within the same JSON object.
 - Type: `String`
 - Description: The version of the CloudEvents specification which the event
   uses. This enables the interpretation of the context. Compliant event
-  producers MUST use a value of `0.3` when referring to this version of the
+  producers MUST use a value of `0.3-wip` when referring to this version of the
   specification.
 - Constraints:
   - REQUIRED
@@ -371,7 +371,7 @@ The following example shows a CloudEvent serialized as JSON:
 
 ```JSON
 {
-    "specversion" : "0.3",
+    "specversion" : "0.3-wip",
     "type" : "com.github.pull.create",
     "source" : "https://github.com/cloudevents/spec/pull/123",
     "id" : "A234-1234-1234",

--- a/spec.md
+++ b/spec.md
@@ -1,4 +1,4 @@
-# CloudEvents - Version 0.2
+# CloudEvents - Version 0.3
 
 ## Abstract
 
@@ -179,7 +179,7 @@ within the same JSON object.
 - Type: `String`
 - Description: The version of the CloudEvents specification which the event
   uses. This enables the interpretation of the context. Compliant event
-  producers MUST use a value of `0.2` when referring to this version of the
+  producers MUST use a value of `0.3` when referring to this version of the
   specification.
 - Constraints:
   - REQUIRED
@@ -298,27 +298,28 @@ can also be used to help intermediate gateways determine how to route the
 events.
 
 ### datacontentencoding
-* Type: `String` per [RFC 2045 Section 6.1](https://tools.ietf.org/html/rfc2045#section-6.1)
-* Description: Describes the content encoding for the `data`
-  attribute for when the `data` field MUST be encoded as a string,
-  like with structured transport binding modes using the JSON event
-  format, but the `datacontenttype` indicates a non-string media
-  type. When the `data` field's effective data type is not `String`,
-  this attribute MUST NOT be set and MUST be ignored when set.
-  
-  The "Base64" value for the Base64 encoding as defined in [RFC 2045 Section 6.8](https://tools.ietf.org/html/rfc2045#section-6.8)
-  MUST be supported. When set, the event-format-encoded value of the `data` 
-  attribute is a base64 string, but the effective data type of
-  the `data` attribute towards the application is the base64-decoded
-  binary array.
-  
+
+- Type: `String` per
+  [RFC 2045 Section 6.1](https://tools.ietf.org/html/rfc2045#section-6.1)
+- Description: Describes the content encoding for the `data` attribute for when
+  the `data` field MUST be encoded as a string, like with structured transport
+  binding modes using the JSON event format, but the `datacontenttype` indicates
+  a non-string media type. When the `data` field's effective data type is not
+  `String`, this attribute MUST NOT be set and MUST be ignored when set.
+
+  The "Base64" value for the Base64 encoding as defined in
+  [RFC 2045 Section 6.8](https://tools.ietf.org/html/rfc2045#section-6.8) MUST
+  be supported. When set, the event-format-encoded value of the `data` attribute
+  is a base64 string, but the effective data type of the `data` attribute
+  towards the application is the base64-decoded binary array.
+
   All other RFC2045 schemes are undefined for CloudEvents.
 
-* Constraints:
-  * The attribute MUST be set if the `data` attribute contains string-encoded
+- Constraints:
+  - The attribute MUST be set if the `data` attribute contains string-encoded
     binary data. Otherwise the attribute MUST NOT be set.
-  * If present, MUST adhere to [RFC 2045 Section 6.1](https://tools.ietf.org/html/rfc2045#section-6.1)
-
+  - If present, MUST adhere to
+    [RFC 2045 Section 6.1](https://tools.ietf.org/html/rfc2045#section-6.1)
 
 ## Data Attribute
 
@@ -370,7 +371,7 @@ The following example shows a CloudEvent serialized as JSON:
 
 ```JSON
 {
-    "specversion" : "0.2",
+    "specversion" : "0.3",
     "type" : "com.github.pull.create",
     "source" : "https://github.com/cloudevents/spec/pull/123",
     "id" : "A234-1234-1234",


### PR DESCRIPTION
This change bumps the version used in master to `0.3-wip` of the spec.

This becomes very clear (and confusing) when you are reading the examples of features are are only in `0.3-wip`, like Batch support.

Signed-off-by: Scott Nichols <nicholss@google.com>