### PR TITLE
A draft of an extension defining attributes indicating correlation-id…

### DIFF
--- a/documented-extensions.md
+++ b/documented-extensions.md
@@ -52,3 +52,4 @@ their `Attributes`.
 - [Partitioning](extensions/partitioning.md)
 - [Sampling](extensions/sampled-rate.md)
 - [Sequence](extensions/sequence.md)
+- [Correlation](extensions/correlation.md)

--- a/extensions/correlation.md
+++ b/extensions/correlation.md
@@ -1,0 +1,45 @@
+# Correlation 
+
+This extension defines two attributes that can be included within a CloudEvent
+to describe an identifier for correlating multiple events produced by one or more  
+event sources in order to identify related events for auditing purposes. 
+
+The `correlationid` attribute represents the value of this event's correlation 
+attribute. The exact value and meaning of this attribute is defined by the 
+`correlationtype` attribute. If the `correlationtype` is missing, event 
+consumers MUST assume the default value of `uuid`. If the `correlationtype` is not 
+defined in this specification, event consumers will need to have some out-of-band
+communication with the event producer to understand how to interpret the value
+of the attribute.
+
+## Attributes
+
+### correlationid
+
+- Type: `String`
+- Description: Value expressing the correlation identifier of the event. 
+- Constraints:
+  - REQUIRED, if this extension is used
+  - MUST be a non-empty string in the format defined by the `correlationtype`. 
+
+### correlationtype
+
+- Type: `String`
+- Description: Specifies the semantics of the `correlationid` attribute. See the
+  [CorrelationType Values](#correlationtype-values) section for more information.
+- Constraints:
+  - OPTIONAL
+  - If present, MUST be a non-empty string
+
+## CorrelationType Values
+
+This specification defines the following values for `correlationtype`. Additional
+values MAY be defined by other specifications.
+
+### UUID
+
+If the `correlationtype` is set to `uuid`, the `correlationid` attribute has the
+following semantics:
+
+- The values of `correlationid` are string-encoded UUID.
+

--- a/extensions/correlation.md
+++ b/extensions/correlation.md
@@ -6,40 +6,29 @@ event sources in order to identify related events for auditing purposes.
 
 The `correlationid` attribute represents the value of this event's correlation 
 attribute. The exact value and meaning of this attribute is defined by the 
-`correlationtype` attribute. If the `correlationtype` is missing, event 
-consumers MUST assume the default value of `uuid`. If the `correlationtype` is not 
-defined in this specification, event consumers will need to have some out-of-band
-communication with the event producer to understand how to interpret the value
-of the attribute.
+event producer.  
 
 ## Attributes
 
 ### correlationid
 
 - Type: `String`
-- Description: Value expressing the correlation identifier of the event. 
+- Description: Value expressing the correlation identifier of the event.  
+- Examples:
+  - A UUID  
 - Constraints:
-  - REQUIRED, if this extension is used
-  - MUST be a non-empty string in the format defined by the `correlationtype`. 
+  - REQUIRED;
+  - MUST be a non-empty string. 
 
-### correlationtype
+## Encoding
 
-- Type: `String`
-- Description: Specifies the semantics of the `correlationid` attribute. See the
-  [CorrelationType Values](#correlationtype-values) section for more information.
-- Constraints:
-  - OPTIONAL
-  - If present, MUST be a non-empty string
+### In-memory formats
 
-## CorrelationType Values
+The Correlation extension uses the key `correlationid` for in-memory formats.
 
-This specification defines the following values for `correlationtype`. Additional
-values MAY be defined by other specifications.
+### Transport bindings
 
-### UUID
+The Correlation extension does not customize any transport binding's storage for
+extensions.
 
-If the `correlationtype` is set to `uuid`, the `correlationid` attribute has the
-following semantics:
-
-- The values of `correlationid` are string-encoded UUID. 
 

--- a/extensions/correlation.md
+++ b/extensions/correlation.md
@@ -41,5 +41,5 @@ values MAY be defined by other specifications.
 If the `correlationtype` is set to `uuid`, the `correlationid` attribute has the
 following semantics:
 
-- The values of `correlationid` are string-encoded UUID.
+- The values of `correlationid` are string-encoded UUID. 
 


### PR DESCRIPTION
A draft of an extension defining attributes indicating correlation-id of events for auditing and other similar purposes. I see the need and wide use of this functionality, especially for enterprise applications, but specific semantic can be changed based on the discussion.