### PR TITLE
Initial guideline for binding the "Size Limits" section of the spec.

### DIFF
--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -30,7 +30,10 @@ This document is a working draft.
 - 3.2. [Structured Content Mode](#32-structured-content-mode)
 - 3.3. [Batched Content Mode](#33-batched-content-mode)
 
-4. [References](#4-references)
+4. [HTTP Response Handling](#4-http-responses)
+- 4.1. [Size Limits](#41-size-limits)
+
+5. [References](#5-references)
 
 ## 1. Introduction
 
@@ -443,7 +446,18 @@ Content-Length: nnnn
 
 ```
 
-## 4. References
+## 4. HTTP Responses
+### 4.1. Size Limits
+When CloudEvents are forwarded through one or more generic intermediaries,
+a minimum payload size SHOULD be considered, in accordance to the
+[CloudEvents spec][ce-size].
+
+In the event of the payload being larger than what can be forwarded or
+accepted, the HTTP status code 413 MUST be sent back to the source.
+See [RFC7231][rfc7231-section-6-5-11] for more information on this response
+code. 
+
+## 5. References
 
 - [RFC2046][rfc2046] Multipurpose Internet Mail Extensions (MIME) Part Two:
   Media Types
@@ -464,6 +478,7 @@ Content-Length: nnnn
 - [RFC7540][rfc7540] Hypertext Transfer Protocol Version 2 (HTTP/2)
 
 [ce]: ./spec.md
+[ce-size]: ./spec.md#size-limits
 [json-format]: ./json-format.md
 [json-batch-format]: ./json-format.md#4-json-batch-format
 [content-type]: https://tools.ietf.org/html/rfc7231#section-3.1.1.5
@@ -483,5 +498,6 @@ Content-Length: nnnn
 [rfc7231]: https://tools.ietf.org/html/rfc7231
 [rfc7230-section-3]: https://tools.ietf.org/html/rfc7230#section-3
 [rfc7231-section-4]: https://tools.ietf.org/html/rfc7231#section-4
+[rfc7231-section-6-5-11]: https://tools.ietf.org/html/rfc7231#section-6.5.11
 [rfc7230-section-5-1]: https://tools.ietf.org/html/rfc7230#section-5.1
 [rfc7540]: https://tools.ietf.org/html/rfc7540

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -448,14 +448,15 @@ Content-Length: nnnn
 
 ## 4. HTTP Responses
 ### 4.1. Size Limits
-When CloudEvents are forwarded through one or more generic intermediaries,
-a minimum payload size SHOULD be considered, in accordance to the
-[CloudEvents spec][ce-size].
+When CloudEvents are transported via HTTP, a minimum payload size SHOULD be
+considered in accordance with the [CloudEvents spec][ce-size].
 
-In the event of the payload being larger than what can be forwarded or
-accepted, the HTTP status code 413 MUST be sent back to the source.
-See [RFC7231][rfc7231-section-6-5-11] for more information on this response
-code. 
+In the case of the payload of an incoming HTTP request is larger than what
+can be accepted, the HTTP status code of `413 Payload Too Large` MUST be
+sent in the response.
+
+See [RFC7231][rfc2731-section-6-5-11] for more information on this
+response code.
 
 ## 5. References
 

--- a/http-transport-binding.md
+++ b/http-transport-binding.md
@@ -30,10 +30,7 @@ This document is a working draft.
 - 3.2. [Structured Content Mode](#32-structured-content-mode)
 - 3.3. [Batched Content Mode](#33-batched-content-mode)
 
-4. [HTTP Response Handling](#4-http-responses)
-- 4.1. [Size Limits](#41-size-limits)
-
-5. [References](#5-references)
+4. [References](#4-references)
 
 ## 1. Introduction
 
@@ -446,19 +443,7 @@ Content-Length: nnnn
 
 ```
 
-## 4. HTTP Responses
-### 4.1. Size Limits
-When CloudEvents are transported via HTTP, a minimum payload size SHOULD be
-considered in accordance with the [CloudEvents spec][ce-size].
-
-In the case of the payload of an incoming HTTP request is larger than what
-can be accepted, the HTTP status code of `413 Payload Too Large` MUST be
-sent in the response.
-
-See [RFC7231][rfc2731-section-6-5-11] for more information on this
-response code.
-
-## 5. References
+## 4. References
 
 - [RFC2046][rfc2046] Multipurpose Internet Mail Extensions (MIME) Part Two:
   Media Types
@@ -479,7 +464,6 @@ response code.
 - [RFC7540][rfc7540] Hypertext Transfer Protocol Version 2 (HTTP/2)
 
 [ce]: ./spec.md
-[ce-size]: ./spec.md#size-limits
 [json-format]: ./json-format.md
 [json-batch-format]: ./json-format.md#4-json-batch-format
 [content-type]: https://tools.ietf.org/html/rfc7231#section-3.1.1.5
@@ -499,6 +483,5 @@ response code.
 [rfc7231]: https://tools.ietf.org/html/rfc7231
 [rfc7230-section-3]: https://tools.ietf.org/html/rfc7230#section-3
 [rfc7231-section-4]: https://tools.ietf.org/html/rfc7231#section-4
-[rfc7231-section-6-5-11]: https://tools.ietf.org/html/rfc7231#section-6.5.11
 [rfc7230-section-5-1]: https://tools.ietf.org/html/rfc7230#section-5.1
 [rfc7540]: https://tools.ietf.org/html/rfc7540

--- a/http-webhook.md
+++ b/http-webhook.md
@@ -110,6 +110,9 @@ If the delivery cannot be accepted because the notification format has not been
 understood, the service MUST respond with status code [415 Unsupported Media
 Type][415].
 
+If the delivery cannot be accepted due to the payload being too large,
+the service MUST respond with status code [413 Payload Too Large][413].
+
 All further error status codes apply as specified in [RFC7231][rfc7231].
 
 ## 3. Authorization
@@ -362,6 +365,7 @@ WebHook-Allowed-Rate: 100
 [202]: https://tools.ietf.org/html/rfc7231#section-6.3.3
 [204]: https://tools.ietf.org/html/rfc7231#section-6.3.5
 [410]: https://tools.ietf.org/html/rfc7231#section-6.5.9
+[413]: https://tools.ietf.org/html/rfc7231#section-6.5.11
 [415]: https://tools.ietf.org/html/rfc7231#section-6.5.13
 [429]: https://tools.ietf.org/html/rfc6585#section-4
 [bearer]: https://tools.ietf.org/html/rfc6750#section-2.1


### PR DESCRIPTION
This is an attempt to resolve #433. Since HTTP is the only request/response protocol, I've added it only for the HTTP transport binding. The other transport bindings do not require any change, since there is no "request/response" cycle.

I'm having some trouble come up with a better title for section 4. At the time of writing, it says, "HTTP Responses". Any help would be appreciated :)

Closes #433.