### PR TITLE
Fix README table - missing protobuf and reorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ The following documents are available:
 | CloudEvents                   |          [v0.3](https://github.com/cloudevents/spec/blob/v0.3/spec.md)          |          [master](https://github.com/cloudevents/spec/blob/master/spec.md)          |
 |                               |
 | **Optional Specifications:**  |
-| HTTP Transport Binding        | [v0.3](https://github.com/cloudevents/spec/blob/v0.3/http-transport-binding.md) | [master](https://github.com/cloudevents/spec/blob/master/http-transport-binding.md) |
-| JSON Event Format             |      [v0.3](https://github.com/cloudevents/spec/blob/v0.3/json-format.md)       |      [master](https://github.com/cloudevents/spec/blob/master/json-format.md)       |
-| Web hook                      |      [v0.3](https://github.com/cloudevents/spec/blob/v0.3/http-webhook.md)      |      [master](https://github.com/cloudevents/spec/blob/master/http-webhook.md)      |
-| MQTT Transport Binding        | [v0.3](https://github.com/cloudevents/spec/blob/v0.3/mqtt-transport-binding.md) | [master](https://github.com/cloudevents/spec/blob/master/mqtt-transport-binding.md) |
-| NATS Transport Binding        | [v0.3](https://github.com/cloudevents/spec/blob/v0.3/nats-transport-binding.md) | [master](https://github.com/cloudevents/spec/blob/master/nats-transport-binding.md) |
 | AMQP Event Format             |      [v0.3](https://github.com/cloudevents/spec/blob/v0.3/amqp-format.md)       |      [master](https://github.com/cloudevents/spec/blob/master/amqp-format.md)       |
 | AMQP Transport Binding        | [v0.3](https://github.com/cloudevents/spec/blob/v0.3/amqp-transport-binding.md) | [master](https://github.com/cloudevents/spec/blob/master/amqp-transport-binding.md) |
+| HTTP Transport Binding        | [v0.3](https://github.com/cloudevents/spec/blob/v0.3/http-transport-binding.md) | [master](https://github.com/cloudevents/spec/blob/master/http-transport-binding.md) |
+| JSON Event Format             |      [v0.3](https://github.com/cloudevents/spec/blob/v0.3/json-format.md)       |      [master](https://github.com/cloudevents/spec/blob/master/json-format.md)       |
+| MQTT Transport Binding        | [v0.3](https://github.com/cloudevents/spec/blob/v0.3/mqtt-transport-binding.md) | [master](https://github.com/cloudevents/spec/blob/master/mqtt-transport-binding.md) |
+| NATS Transport Binding        | [v0.3](https://github.com/cloudevents/spec/blob/v0.3/nats-transport-binding.md) | [master](https://github.com/cloudevents/spec/blob/master/nats-transport-binding.md) |
+| Protocol Buffers Event Format | [v0.3](https://github.com/cloudevents/spec/blob/v0.3/protobuf-format.md)        | [master](https://github.com/cloudevents/spec/blob/master/protobuf-format.md)        |
+| Web hook                      |      [v0.3](https://github.com/cloudevents/spec/blob/v0.3/http-webhook.md)      |      [master](https://github.com/cloudevents/spec/blob/master/http-webhook.md)      |
 |                               |
 | **Additional Documentation:** |
 | Primer                        |         [v0.3](https://github.com/cloudevents/spec/blob/v0.3/primer.md)         |         [master](https://github.com/cloudevents/spec/blob/master/primer.md)         |


### PR DESCRIPTION
It was noticed that we were missing the protobuf spec - while in there I alphabetized things

Signed-off-by: Doug Davis <dug@us.ibm.com>