### PR TITLE
Clean up definition of string type

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -168,7 +168,17 @@ string-encoding for each type that MUST be supported by all implementations.
   `Integer` values in this range.
   - String encoding: Integer portion of the JSON Number per
     [RFC 7159, Section 6](https://tools.ietf.org/html/rfc7159#section-6)
-- `String` - Sequence of printable Unicode characters.
+- `String` - Sequence of allowable Unicode characters. The following characters
+  are disallowed:
+  - the "control characters" in the ranges U+0000-U+001F and U+007F-U+009F (both
+    ranges inclusive), since most have no agreed-on meaning, and some, such as
+    U+000A (newline), are not usable in contexts such as HTTP headers. 
+  - code points
+    [identified as noncharacters by Unicode](http://www.unicode.org/faq/private_use.html#noncharacters).
+  - code points identifying Surrogates, U+D800-U+DBFF and U+DC00-U+DFFF, both ranges
+    inclusive, unless used properly in pairs. Thus (in JSON notation) "\uDEAD" is
+    invalid because it is an unpaired surrogate, while "\uD800\uDEAD" would be
+    legal.
 - `Binary` - Sequence of bytes.
   - String encoding: Base64 encoding per
     [RFC4648](https://tools.ietf.org/html/rfc4648).


### PR DESCRIPTION
Remove "printable" and disallow dodgy Unicode characters.