### PR TITLE
Changed datacontentencoding to dataencoding

### DIFF
--- a/adapters/aws-s3.md
+++ b/adapters/aws-s3.md
@@ -16,7 +16,7 @@ same pattern as described in the following table:
 | `source`              | "eventSource" value + `.` + "awsRegion" value + `.` + "s3.buckets.name" value  |
 | `specversion`         | `0.4-wip`                                       |
 | `type`                | `com.amazonaws.s3.` + "eventName" value         |
-| `datacontentencoding` | Omit                                            |
+| `dataencoding` | Omit                                            |
 | `datacontenttype`     | S3 event type (e.g. `application/json`)         |
 | `dataschema`          | Omit                                            |
 | `subject`             | "s3.object.key" value                           |

--- a/adapters/gitlab.md
+++ b/adapters/gitlab.md
@@ -18,7 +18,7 @@ based on the specified event.
 | `source`              | "repository.homepage" value              |
 | `specversion`         | `0.4-wip`                                |
 | `type`                | `com.gitlab.push`                        |
-| `datacontentencoding` | Omit                                     |
+| `dataencoding` | Omit                                     |
 | `datacontenttype`     | `application/json`                       |
 | `dataschema`          | Omit                                     |
 | `subject`             | "checkout_sha" value                     |
@@ -33,7 +33,7 @@ based on the specified event.
 | `source`              | "repository.homepage" value              |
 | `specversion`         | `0.4-wip`                                |
 | `type`                | `com.gitlab.tag_push`                    |
-| `datacontentencoding` | Omit                                     |
+| `dataencoding` | Omit                                     |
 | `datacontenttype`     | `application/json`                       |
 | `dataschema`          | Omit                                     |
 | `subject`             | "ref" value                              |
@@ -48,7 +48,7 @@ based on the specified event.
 | `source`              | "repository.homepage" value                           |
 | `specversion`         | `0.4-wip`                                             |
 | `type`                | `com.gitlab.issue.` + "object_attributes.state" value |
-| `datacontentencoding` | Omit                                                  |
+| `dataencoding` | Omit                                                  |
 | `datacontenttype`     | `application/json`                                    |
 | `dataschema`          | Omit                                                  |
 | `subject`             | "object_attributes.iid" value                         |
@@ -63,7 +63,7 @@ based on the specified event.
 | `source`              | "commit.url" value                       |
 | `specversion`         | `0.4-wip`                                |
 | `type`                | `com.gitlab.note.commit`                 |
-| `datacontentencoding` | Omit                                     |
+| `dataencoding` | Omit                                     |
 | `datacontenttype`     | `application/json`                       |
 | `dataschema`          | Omit                                     |
 | `subject`             | "object_attributes.id" value             |
@@ -78,7 +78,7 @@ based on the specified event.
 | `source`              | "object_attributes.url" value, without the `#note\_...` part |
 | `specversion`         | `0.4-wip`                                                    |
 | `type`                | `com.gitlab.note.merge_request`                              |
-| `datacontentencoding` | Omit                                                         |
+| `dataencoding` | Omit                                                         |
 | `datacontenttype`     | `application/json`                                           |
 | `dataschema`          | Omit                                                         |
 | `subject`             | "object_attributes.id" value                                 |
@@ -93,7 +93,7 @@ based on the specified event.
 | `source`              | "object_attributes.url" value without the `#note\_...` part |
 | `specversion`         | `0.4-wip`                                                   |
 | `type`                | `com.gitlab.note.issue`                                     |
-| `datacontentencoding` | Omit                                                        |
+| `dataencoding` | Omit                                                        |
 | `datacontenttype`     | `application/json`                                          |
 | `dataschema`          | Omit                                                        |
 | `subject`             | "object_attributes.id" value                                |
@@ -108,7 +108,7 @@ based on the specified event.
 | `source`              | "object_attributes.url" value without the `#note\_...` part |
 | `specversion`         | `0.4-wip`                                                   |
 | `type`                | `com.gitlab.note.snippet`                                   |
-| `datacontentencoding` | Omit                                                        |
+| `dataencoding` | Omit                                                        |
 | `datacontenttype`     | `application/json`                                          |
 | `dataschema`          | Omit                                                        |
 | `subject`             | "object_attributes.id" value                                |
@@ -123,7 +123,7 @@ based on the specified event.
 | `source`              | "repository.homepage" value                                    |
 | `specversion`         | `0.4-wip`                                                      |
 | `type`                | `com.gitlab.merge_request.` + "object_attributes.action" value |
-| `datacontentencoding` | Omit                                                           |
+| `dataencoding` | Omit                                                           |
 | `datacontenttype`     | `application/json`                                             |
 | `dataschema`          | Omit                                                           |
 | `subject`             | "object_attributes.iid" value                                  |
@@ -138,7 +138,7 @@ based on the specified event.
 | `source`              | "project.web_url" value                                    |
 | `specversion`         | `0.4-wip`                                                  |
 | `type`                | `com.gitlab.wiki_page.` + "object_attributes.action" value |
-| `datacontentencoding` | Omit                                                       |
+| `dataencoding` | Omit                                                       |
 | `datacontenttype`     | `application/json`                                         |
 | `dataschema`          | Omit                                                       |
 | `subject`             | "object_attributes.slug" value                             |
@@ -153,7 +153,7 @@ based on the specified event.
 | `source`              | "project.web_url" value                                   |
 | `specversion`         | `0.4-wip`                                                 |
 | `type`                | `com.gitlab.pipeline.` + "object_attributes.status" value |
-| `datacontentencoding` | Omit                                                      |
+| `dataencoding` | Omit                                                      |
 | `datacontenttype`     | `application/json`                                        |
 | `dataschema`          | Omit                                                      |
 | `subject`             | "object_attributes.id" value                              |
@@ -168,7 +168,7 @@ based on the specified event.
 | `source`              | "repository.homepage" value              |
 | `specversion`         | `0.4-wip`                                |
 | `type`                | `com.gitlab.job.` + "job_status" value   |
-| `datacontentencoding` | Omit                                     |
+| `dataencoding` | Omit                                     |
 | `datacontenttype`     | `application/json`                       |
 | `dataschema`          | Omit                                     |
 | `subject`             | "job_id" value                           |

--- a/spec.md
+++ b/spec.md
@@ -309,26 +309,31 @@ The following attributes are OPTIONAL to appear in CloudEvents. See the
 [Notational Conventions](#notational-conventions) section for more information
 on the definition of OPTIONAL.
 
-#### datacontentencoding
+#### dataencoding
 
-- Type: `String` per
-  [RFC 2045 Section 6.1](https://tools.ietf.org/html/rfc2045#section-6.1)
-- Description: Describes the content encoding for `data`.
-  There are cases where the value of `data` might need to be
+- Type: `String` 
+- Description: Describes the encoding for `data`, if and only if the `data`
+  value is carried inside the same envelope as the context attributes.
+  In this case, the value of `data` might need to be
   encoded so that it can be carried within the serialization format being used.
-  For example, in JSON, binary data will likely need to be Base64 encoded.
+  For example, when `data` is carried inside a JSON document, binary data will
+  have to be Base64 encoded.
   When this attribute is set, the consumer can use its value to know how
   to decode `data` value to retrieve its original contents.
 
-  If this attribute is supported, then the "Base64" encoding as defined in
-  [RFC 2045 Section 6.8](https://tools.ietf.org/html/rfc2045#section-6.8) MUST
-  be supported.
+  If this attribute is supported, then the "Base64" value, indicating an 
+  encoding of binary data as text, using the rules defined in
+  [RFC 4648 Section 4](https://tools.ietf.org/html/rfc4648#section-4) MUST
+  be supported. 
 
 - Constraints:
-  - The attribute MUST be set if `data` is encoded and not
-    in its original format. Otherwise the attribute MUST NOT be set.
-  - If present, MUST adhere to
-    [RFC 2045 Section 6.1](https://tools.ietf.org/html/rfc2045#section-6.1)
+  - The attribute MUST be set if `data` uses a special encoding. Otherwise the
+    attribute MUST NOT be set.
+  - The "Base64" value MUST be supported. Other encodings MAY be supported and
+    are either application-specific or defined in an extension specification.
+  - The attribute MUST NOT be used when `data` is transferred as the transport
+    frame body using any transport binding's binary mode. In this case, the
+    transport's own encoding facilities MUST be used. 
 
 #### datacontenttype
 
@@ -465,9 +470,9 @@ encapsulated within `data`.
   repspective attributes are present.
 
   If `data`'s native syntax, or its syntax based on the `datacontenttype`
-  attribute if present, can not be copied directly into the desired
+  attribute, if present, cannot be copied directly into the desired
   serialization format, and therefore needs to be further encoded, then
-  the `datacontentencoding` attribute MUST include the encoding mechanism
+  the `dataencoding` attribute MUST include the encoding mechanism
   used.
 - Constraints:
   - OPTIONAL


### PR DESCRIPTION
Per discussion on the call last week.

This PR renames `datacontentencoding` to `dataencoding` and tightens the rules around it since there have been several misunderstandings about what the attribute is meant to help with, see #486 #481 #477 

The attribute is ONLY for structured mode and ONLY for when a value cannot be correctly expressed in the chosen event format's type system and needs further encoding. The specific concern is making binary fit into JSON.

The attribute does not map to transport-level content encoding concerns like compression or signatures or encryption or the like, specifically not to Content-Transfer-Encoding fields of SMTP or the Content-Encoding or Transfer-Encoding fields of HTTP. This is a CloudEvents specific construct for the aforementioned purpose. That does not at all preclude that one uses message-level compression in HTTP for transferring a CloudEvent; it's simply an orthogonal concern.

Signed-off-by: Clemens Vasters <clemensv@microsoft.com>