### PR TITLE
Cleanup: Map and add URI in formats; re-add "Type System" heading

### DIFF
--- a/amqp-format.md
+++ b/amqp-format.md
@@ -58,9 +58,9 @@ exceptions noted below.
 | String        | [string][amqp-string]       |
 | Integer       | [long][amqp-long]           |
 | Binary        | [binary][amqp-binary]       |
+| URI           | [string][amqp-string]       |
 | URI-reference | [string][amqp-string]       |
 | Timestamp     | [timestamp][amqp-timestamp] |
-| Map           | [map][amqp-map]             |
 | Any           | See 2.3.                    |
 
 A CloudEvents AMQP format implementation MUST allow for attribute values to be

--- a/avro-format.md
+++ b/avro-format.md
@@ -50,7 +50,7 @@ The CloudEvents type system MUST be mapped to Avro types as follows.
 | Integer       | [int][avro-primitives]                                                 |
 | String        | [string][avro-primitives]                                              |
 | Binary        | [bytes][avro-primitives]                                               |
-| Map           | [map][avro-primitives]                                                 |
+| URI           | [string][avro-primitives] following [RFC 3986 §4.3][rfc3986-section43] |
 | URI-reference | [string][avro-primitives] following [RFC 3986 §4.1][rfc3986-section41] |
 | Timestamp     | [string][avro-primitives] following [RFC 3339][rfc3339] (ISO 8601)     |
 | Any           | See [2.2](#22-mapping-any-typed-attributes)                            |
@@ -163,4 +163,5 @@ The following table shows exemplary mappings:
 
 [rfc2119]: https://tools.ietf.org/html/rfc2119
 [rfc3986-section41]: https://tools.ietf.org/html/rfc3986#section-4.1
+[rfc3986-section43]: https://tools.ietf.org/html/rfc3986#section-4.3
 [rfc3339]: https://tools.ietf.org/html/rfc3339

--- a/json-format.md
+++ b/json-format.md
@@ -66,9 +66,9 @@ with exceptions noted below.
 | String        | [string][json-string]                                          |
 | Integer       | [number][json-number], only the `int` component is permitted   |
 | Binary        | [string][json-string], [Base64-encoded][base64] binary         |
+| URI           | [string][json-string] following [RFC 3986][rfc3986]            |
 | URI-reference | [string][json-string] following [RFC 3986][rfc3986]            |
 | Timestamp     | [string][json-string] following [RFC 3339][rfc3339] (ISO 8601) |
-| Map           | [JSON object][json-object]                                     |
 | Any           | [JSON value][json-value]                                       |
 
 Extension specifications MAY define diverging mapping rules for the values of

--- a/protobuf-format.md
+++ b/protobuf-format.md
@@ -74,9 +74,9 @@ follows:
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | String        | string_value                                                                                                                                |
 | Binary        | binary_value                                                                                                                                |
+| URI           | string_value (string expression conforming to URI-reference as defined in [RFC 3986 §4.3](https://tools.ietf.org/html/rfc3986#section-4.3)) |
 | URI-reference | string_value (string expression conforming to URI-reference as defined in [RFC 3986 §4.1](https://tools.ietf.org/html/rfc3986#section-4.1)) |
 | Timestamp     | string_value (string expression as defined in [RFC 3339](https://tools.ietf.org/html/rfc3339))                                              |
-| Map           | map_value                                                                                                                                   |
 | Integer       | int_value                                                                                                                                   |
 | Any           | Not applicable. Any is the enclosing CloudEventAny message itself                                                                           |
 

--- a/spec.md
+++ b/spec.md
@@ -155,7 +155,7 @@ These attributes, while descriptive of the event, are designed such that they
 can be serialized independent of the event data. This allows for them to be
 inspected at the destination without having to deserialize the event data.
 
-#### Type System
+### Type System
 
 The following abstract data types are available for use in attributes. Each of
 these types MAY be represented differently by different event formats and in

--- a/spec.md
+++ b/spec.md
@@ -155,6 +155,8 @@ These attributes, while descriptive of the event, are designed such that they
 can be serialized independent of the event data. This allows for them to be
 inspected at the destination without having to deserialize the event data.
 
+#### Type System
+
 The following abstract data types are available for use in attributes. Each of
 these types MAY be represented differently by different event formats and in
 transport metadata fields. This specification defines a canonical


### PR DESCRIPTION
Some cleanup in our event formats:
* Removed `Map`
* Added `URI`

All event formats reference back to the `Type System` (e.g. https://github.com/cloudevents/spec/blob/master/json-format.md#22-type-system-mapping also includes a relative link).
Therefore I think it is worth adding a heading for it that can be linked back to.