### PR TITLE
Update AVRO mappings to match current event schema and type system.

### DIFF
--- a/avro-format.md
+++ b/avro-format.md
@@ -139,7 +139,7 @@ described by the [CloudEvent Avro Schema](./spec.avsc):
 ## 3 Data
 
 Before encoding, the AVRO serializer MUST first determine the runtime data type
-of the content. This may be determined by examining the data for invalid UTF-8
+of the content. This can be determined by examining the data for invalid UTF-8
 sequences or by consulting the `datacontenttype` attribute.
 
 If the implementation determines that the type of the data is binary, the value

--- a/avro-format.md
+++ b/avro-format.md
@@ -2,8 +2,8 @@
 
 ## Abstract
 
-The Avro Format for CloudEvents defines how events attributes are expressed
-in the [Avro 1.9.0 Specification][avro-spec].
+The Avro Format for CloudEvents defines how events attributes are expressed in
+the [Avro 1.9.0 Specification][avro-spec].
 
 ## Status of this document
 
@@ -13,7 +13,8 @@ This document is a working draft.
 
 1. [Introduction](#1-introduction)
 2. [Attributes](#2-attributes)
-3. [Examples](#3-examples)
+3. [Data](#3-data)
+4. [Examples](#4-examples)
 
 ## 1. Introduction
 
@@ -47,108 +48,81 @@ The CloudEvents type system MUST be mapped to Avro types as follows.
 
 | CloudEvents   | Avro                                                                   |
 | ------------- | ---------------------------------------------------------------------- |
+| Boolean       | [boolean][avro-primitives]                                             |
 | Integer       | [int][avro-primitives]                                                 |
 | String        | [string][avro-primitives]                                              |
 | Binary        | [bytes][avro-primitives]                                               |
 | URI           | [string][avro-primitives] following [RFC 3986 §4.3][rfc3986-section43] |
 | URI-reference | [string][avro-primitives] following [RFC 3986 §4.1][rfc3986-section41] |
 | Timestamp     | [string][avro-primitives] following [RFC 3339][rfc3339] (ISO 8601)     |
-| Any           | See [2.2](#22-mapping-any-typed-attributes)                            |
 
 Extension specifications MAY define diverging mapping rules for the values of
 attributes they define.
 
-### 2.2 Mapping Any-typed Attributes
-
-`Any`-typed CloudEvents values can either hold a `String`, or a `Binary` value,
-or a `Map`, or any of all other types. Avro type system satisfies this requirement by employing a recursive reference,
-where a `record` type is referenced as a value inside of its own `map`.
-
-Example:
-
-```json
-{
-  "type":"record",
-  "name":"MyRecord",
-  "fields":[
-    {
-      "name":"wow",
-      "type":{
-        "type":"map",
-        "values":[
-          "null",
-          "string",
-          "MyRecord"
-        ]
-      }
-    }
-  ]
-}
-```
-
 ### 2.3 OPTIONAL Attributes
 
-CloudEvents Spec defines OPTIONAL attributes. The Avro format defines that
-these fields MUST use the `null` type and the actual type through
-the [union][avro-unions].
+CloudEvents Spec defines OPTIONAL attributes. The Avro format defines that these
+fields MUST use the `null` type and the actual type through the
+[union][avro-unions].
 
 Example:
 
 ```json
-[
-  "null",
-  "string"
-]
+["null", "string"]
 ```
 
 ### 2.4 Definition
 
-Users of Avro MUST use a message whose binary encoding is identical
-to the one described by the [CloudEvent Avro Schema](./spec.avsc):
+Users of Avro MUST use a message whose binary encoding is identical to the one
+described by the [CloudEvent Avro Schema](./spec.avsc):
 
 ```json
 {
-  "namespace":"io.cloudevents",
-  "type":"record",
-  "name":"CloudEvent",
-  "version":"0.4-wip",
-  "doc":"Avro Event Format for CloudEvents",
-  "fields":[
+  "namespace": "io.cloudevents",
+  "type": "record",
+  "name": "CloudEvent",
+  "version": "0.4-wip",
+  "doc": "Avro Event Format for CloudEvents",
+  "fields": [
     {
-      "name":"attribute",
-      "type":{
-        "type":"map",
-        "values":[
-          "null",
-          "int",
-          "string",
-          "bytes",
-          "CloudEvent"
-        ]
+      "name": "attribute",
+      "type": {
+        "type": "map",
+        "values": ["null", "boolean", "int", "string", "bytes"]
       }
+    },
+    {
+      "name": "data",
+      "type": "bytes"
     }
   ]
 }
 ```
 
-## 3 Examples
+## 3 Data
+
+The `data` of the CloudEvent should be encoded in a top-level field called
+`data` of type `bytes`. No additional encoding should be done, regardless of the
+`contenttype` attribute.
+
+## 4 Examples
 
 The following table shows exemplary mappings:
 
-| CloudEvents  | Type      | Exemplary Avro Value                           |
-| ------------ | --------- | ---------------------------------------------- |
-| type         | string    | `"com.example.someevent"`                      |
-| specversion  | string    | `"0.4-wip`                                     |
-| source       | string    | `"/mycontext"`                                 |
-| id           | string    | `"7a0dc520-c870-4193c8"`                       |
-| time         | string    | `"2019-06-05T23:45:00Z"`                       |
-| dataschema   | string    | `"http://registry.com/schema/v1/much.json"`    |
-| contenttype  | string    | `"application/json"`                           |
-| data         | string    | `"{"much":{"wow":"json"}}"`                    |
-||||
-| dataschema   | string    | `"http://registry.com/subjects/ce/versions/1"` |
-| contenttype  | string    | `"application/avro"`                           |
-| data         | string    | `"Q2xvdWRFdmVudHM="`                           |
+| CloudEvents | Type   | Exemplary Avro Value                           |
+| ----------- | ------ | ---------------------------------------------- |
+| type        | string | `"com.example.someevent"`                      |
+| specversion | string | `"0.4-wip`                                     |
+| source      | string | `"/mycontext"`                                 |
+| id          | string | `"7a0dc520-c870-4193c8"`                       |
+| time        | string | `"2019-06-05T23:45:00Z"`                       |
+| dataschema  | string | `"http://registry.com/schema/v1/much.json"`    |
+| contenttype | string | `"application/json"`                           |
+| data        | bytes  | `"{"much":{"wow":"json"}}"`                    |
+|             |        |                                                |
+| dataschema  | string | `"http://registry.com/subjects/ce/versions/1"` |
+| contenttype | string | `"application/avro"`                           |
+| data        | string | `"Q2xvdWRFdmVudHM="`                           |
 
 ## References
 
@@ -158,9 +132,7 @@ The following table shows exemplary mappings:
 [avro-primitives]: http://avro.apache.org/docs/1.9.0/spec.html#schema_primitive
 [avro-logical-types]: http://avro.apache.org/docs/1.9.0/spec.html#Logical+Types
 [avro-unions]: http://avro.apache.org/docs/1.9.0/spec.html#Unions
-
 [ce]: ./spec.md
-
 [rfc2119]: https://tools.ietf.org/html/rfc2119
 [rfc3986-section41]: https://tools.ietf.org/html/rfc3986#section-4.1
 [rfc3986-section43]: https://tools.ietf.org/html/rfc3986#section-4.3

--- a/avro-format.md
+++ b/avro-format.md
@@ -101,8 +101,8 @@ described by the [CloudEvent Avro Schema](./spec.avsc):
 
 ## 3 Data
 
-The `data` of the CloudEvent should be encoded in a top-level field called
-`data` of type `bytes`. No additional encoding should be done, regardless of the
+The `data` of the CloudEvent MUST be encoded in a top-level field called
+`data` of type `bytes`. Additional encoding MUST NOT be done, regardless of the
 `contenttype` attribute.
 
 ## 4 Examples

--- a/avro-format.md
+++ b/avro-format.md
@@ -93,7 +93,44 @@ described by the [CloudEvent Avro Schema](./spec.avsc):
     },
     {
       "name": "data",
-      "type": "bytes"
+      "type": [
+        "bytes",
+        "null",
+        "boolean",
+        {
+          "type": "map",
+          "values": [
+            "null",
+            "boolean",
+            {
+              "type": "record",
+              "name": "CloudEventData",
+              "doc": "Representation of a JSON Value",
+              "fields": [
+                {
+                  "name": "value",
+                  "type": {
+                    "type": "map",
+                    "values": [
+                      "null",
+                      "boolean",
+                      { "type": "map", "values": "CloudEventData" },
+                      { "type": "array", "items": "CloudEventData" },
+                      "double",
+                      "string"
+                    ]
+                  }
+                }
+              ]
+            },
+            "double",
+            "string"
+          ]
+        },
+        { "type": "array", "items": "CloudEventData" },
+        "double",
+        "string"
+      ]
     }
   ]
 }
@@ -101,9 +138,16 @@ described by the [CloudEvent Avro Schema](./spec.avsc):
 
 ## 3 Data
 
-The `data` of the CloudEvent MUST be encoded in a top-level field called
-`data` of type `bytes`. Additional encoding MUST NOT be done, regardless of the
-`contenttype` attribute.
+Before encoding, the AVRO serializer MUST first determine the runtime data type
+of the content. This may be determined by examining the data for invalid UTF-8
+sequences or by consulting the `datacontenttype` attribute.
+
+If the implementation determines that the type of the data is binary, the value
+MUST be stored in the `data` field using the `bytes` type.
+
+For other types (non-binary data without a `datacontenttype` attribute), the
+implementation MUST translate the data value into a representation of the JSON
+value using the union types described for the `data` record.
 
 ## 4 Examples
 

--- a/spec.avsc
+++ b/spec.avsc
@@ -11,12 +11,16 @@
         "type":"map",
         "values":[
           "null",
+          "boolean",
           "int",
           "string",
-          "bytes",
-          "CloudEvent"
+          "bytes"
         ]
       }
+    },
+    {
+      "name": "data",
+      "type": "bytes"
     }
   ]
 }

--- a/spec.avsc
+++ b/spec.avsc
@@ -20,7 +20,45 @@
     },
     {
       "name": "data",
-      "type": "bytes"
+      "type": [
+        "bytes",
+        "null",
+        "boolean",
+        {
+          "type": "map",
+          "values": [
+            "null",
+            "boolean",
+            {
+              "type": "record",
+              "name": "CloudEventData",
+              "doc": "Representation of a JSON Value",
+              "fields": [
+                {
+                  "name": "value",
+                  "type": {
+                    "type": "map",
+                    "values": [
+                      "null",
+                      "boolean",
+                      { "type": "map", "values": "CloudEventData" },
+                      { "type": "array", "items": "CloudEventData" },
+                      "double",
+                      "string"
+                    ]
+                  }
+                }
+              ]
+            },
+            "double",
+            "string"
+          ]
+        },
+        { "type": "array", "items": "CloudEventData" },
+        "double",
+        "string"
+      ]
     }
   ]
 }
+


### PR DESCRIPTION
It looks like we didn't update the AVRO format to actually include a place to store `data` when we graduated the payload from a special attribute to a header + payload model.