### PR TITLE
Only OPTIONAL attributes (conditional not needed)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -305,7 +305,7 @@ The following attributes are REQUIRED to be present in all CloudEvents:
   - com.github.pull.create
   - com.example.object.delete.v2
 
-### OPTIONAL or Conditional Attributes
+### OPTIONAL Attributes
 
 The following attributes are OPTIONAL to appear in CloudEvents. See the
 [Notational Conventions](#notational-conventions) section for more information


### PR DESCRIPTION
Minor follow-up to #492 - I noticed this when checking the closure of #481 .

All attributes in this section are truly optional (again), no attribute is required under some conditions anymore 👍 

We can simplify the header again.

Signed-off-by: Christoph Neijenhuis <christoph.neijenhuis@commercetools.de>