### PR TITLE
Syntax fixes

### DIFF
--- a/json-format.md
+++ b/json-format.md
@@ -157,9 +157,7 @@ Example event with `String`-valued `data`:
     "id" : "A234-1234-1234",
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
-    "comexampleextension2" : {
-        "otherValue": 5
-    },
+    "comexampleextension2" : 5,
     "datacontenttype" : "text/xml",
     "data" : "<much wow=\"xml\"/>"
 }
@@ -175,9 +173,7 @@ Example event with `Binary`-valued data
     "id" : "B234-1234-1234",
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
-    "comexampleextension2" : {
-        "otherValue": 5
-    },
+    "comexampleextension2" : 5,
     "datacontenttype" : "application/vnd.apache.thrift.binary",
     "data_base64" : "... base64 encoded string ..."
 }
@@ -194,9 +190,7 @@ or [JSON data](#31-handling-of-data) data:
     "id" : "C234-1234-1234",
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
-    "comexampleextension2" : {
-        "otherValue": 5
-    },
+    "comexampleextension2" : 5,
     "datacontenttype" : "application/json",
     "data" : {
         "appinfoA" : "abc",
@@ -244,9 +238,7 @@ second with JSON data.
       "id" : "B234-1234-1234",
       "time" : "2018-04-05T17:31:00Z",
       "comexampleextension1" : "value",
-      "comexampleextension2" : {
-          "otherValue": 5
-      },
+      "comexampleextension2" : 5,
       "datacontenttype" : "application/vnd.apache.thrift.binary",
       "data_base64" : "... base64 encoded string ..."
   },
@@ -257,9 +249,7 @@ second with JSON data.
       "id" : "C234-1234-1234",
       "time" : "2018-04-05T17:31:05Z",
       "comexampleextension1" : "value",
-      "comexampleextension2" : {
-          "otherValue": 5
-      },
+      "comexampleextension2" : 5,
       "datacontenttype" : "application/json",
       "data" : {
           "appinfoA" : "abc",

--- a/json-format.md
+++ b/json-format.md
@@ -157,7 +157,7 @@ Example event with `String`-valued `data`:
     "id" : "A234-1234-1234",
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
-    "comexampleextension2" : 5,
+    "comexampleothervalue" : 5,
     "datacontenttype" : "text/xml",
     "data" : "<much wow=\"xml\"/>"
 }
@@ -173,7 +173,7 @@ Example event with `Binary`-valued data
     "id" : "B234-1234-1234",
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
-    "comexampleextension2" : 5,
+    "comexampleothervalue" : 5,
     "datacontenttype" : "application/vnd.apache.thrift.binary",
     "data_base64" : "... base64 encoded string ..."
 }
@@ -190,7 +190,7 @@ or [JSON data](#31-handling-of-data) data:
     "id" : "C234-1234-1234",
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
-    "comexampleextension2" : 5,
+    "comexampleothervalue" : 5,
     "datacontenttype" : "application/json",
     "data" : {
         "appinfoA" : "abc",
@@ -238,7 +238,7 @@ second with JSON data.
       "id" : "B234-1234-1234",
       "time" : "2018-04-05T17:31:00Z",
       "comexampleextension1" : "value",
-      "comexampleextension2" : 5,
+      "comexampleothervalue" : 5,
       "datacontenttype" : "application/vnd.apache.thrift.binary",
       "data_base64" : "... base64 encoded string ..."
   },
@@ -249,7 +249,7 @@ second with JSON data.
       "id" : "C234-1234-1234",
       "time" : "2018-04-05T17:31:05Z",
       "comexampleextension1" : "value",
-      "comexampleextension2" : 5,
+      "comexampleothervalue" : 5,
       "datacontenttype" : "application/json",
       "data" : {
           "appinfoA" : "abc",

--- a/spec.md
+++ b/spec.md
@@ -58,22 +58,6 @@ will then silently ignore that part of the message. The producer needs to be
 prepared for the situation where a consumer ignores that feature. An
 [Intermediary](#intermediary) SHOULD forward OPTIONAL attributes.
 
-### Attribute Naming Convention
-
-The CloudEvents specifications define mappings to various protocols and
-encodings, and the accompanying CloudEvents SDK targets various runtimes and
-languages. Some of these treat metadata elements as case-sensitive while others
-do not, and a single CloudEvent might be routed via multiple hops that involve a
-mix of protocols, encodings, and runtimes. Therefore, this specification limits
-the available character set of all attributes such that case-sensitivity issues
-or clashes with the permissible character set for identifiers in common
-languages are prevented.
-
-CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or
-digits ('0' to '9') from the ASCII character set and MUST begin with a
-lower-case letter. Attribute names SHOULD be descriptive and terse and SHOULD
-NOT exceed 20 characters in length.
-
 ### Terminology
 
 This specification defines the following terms:
@@ -154,6 +138,22 @@ attributes.
 These attributes, while descriptive of the event, are designed such that they
 can be serialized independent of the event data. This allows for them to be
 inspected at the destination without having to deserialize the event data.
+
+### Attribute Naming Convention
+
+The CloudEvents specifications define mappings to various protocols and
+encodings, and the accompanying CloudEvents SDK targets various runtimes and
+languages. Some of these treat metadata elements as case-sensitive while others
+do not, and a single CloudEvent might be routed via multiple hops that involve a
+mix of protocols, encodings, and runtimes. Therefore, this specification limits
+the available character set of all attributes such that case-sensitivity issues
+or clashes with the permissible character set for identifiers in common
+languages are prevented.
+
+CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or
+digits ('0' to '9') from the ASCII character set and MUST begin with a
+lower-case letter. Attribute names SHOULD be descriptive and terse and SHOULD
+NOT exceed 20 characters in length.
 
 ### Type System
 
@@ -523,7 +523,7 @@ The following example shows a CloudEvent serialized as JSON:
     "id" : "A234-1234-1234",
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
-    "comexampleextension2" : 5,
+    "comexampleothervalue" : 5,
     "datacontenttype" : "text/xml",
     "data" : "<much wow=\"xml\"/>"
 }

--- a/spec.md
+++ b/spec.md
@@ -14,7 +14,7 @@ This document is a working draft.
 - [Overview](#overview)
 - [Notations and Terminology](#notations-and-terminology)
 - [Context Attributes](#context-attributes)
-- [Data](#data)
+- [Event Data](#event-data)
 - [Size Limits](#size-limits)
 - [Privacy & Security](#privacy-and-security)
 - [Example](#example)
@@ -93,9 +93,9 @@ An "event" is a data record expressing an occurrence and its context. Events are
 routed from an event producer (the source) to interested event consumers. The
 routing can be performed based on information contained in the event, but an
 event will not identify a specific routing destination. Events will contain two
-types of information: the [Data](#data) representing the Occurrence and
-[Context](#context) metadata providing contextual information about the
-Occurrence. A single occurrence MAY result in more than one event.
+types of information: the [Event Data](#event-data) representing the
+Occurrence and [Context](#context) metadata providing contextual information
+about the Occurrence. A single occurrence MAY result in more than one event.
 
 #### Producer
 
@@ -132,7 +132,7 @@ or to other Events.
 
 Domain-specific information about the occurrence (i.e. the payload). This might
 include information about the occurrence, details about the data that was
-changed, or more. See the [Data](#data) section for more
+changed, or more. See the [Event Data](#event-data) section for more
 information.
 
 #### Message
@@ -431,13 +431,11 @@ without needing to decode and examine the event data. Such identity attributes
 can also be used to help intermediate gateways determine how to route the
 events.
 
-## Data
+## Event Data
 
 As defined by the term [Data](#data), CloudEvents MAY include domain-specific
 information about the occurrence. When present, this information will be
 encapsulated within `data`.
-
-### data
 
 - Description: The event payload. This specification does not place any
   restriction on the type of this information. It is encoded into a media format
@@ -502,10 +500,10 @@ Consider the following to prevent inadvertent leakage especially when leveraging
 
 - Data
 
-  Domain specific [data](#data) SHOULD be encrypted to restrict visibility to
-  trusted parties. The mechanism employed for such encryption is an agreement
-  between producers and consumers and thus outside the scope of this
-  specification.
+  Domain specific [event data](#event-data) SHOULD be encrypted to restrict
+  visibility to trusted parties. The mechanism employed for such encryption is
+  an agreement between producers and consumers and thus outside the scope of
+  this specification.
 
 - Transport Bindings
 
@@ -525,9 +523,7 @@ The following example shows a CloudEvent serialized as JSON:
     "id" : "A234-1234-1234",
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
-    "comexampleextension2" : {
-        "othervalue": 5
-    },
+    "comexampleextension2" : 5,
     "datacontenttype" : "text/xml",
     "data" : "<much wow=\"xml\"/>"
 }


### PR DESCRIPTION
Evan noticed we have more than one #data header so I tried to fix that.

Also, we still used a complex/map in an example.

Signed-off-by: Doug Davis <dug@us.ibm.com>