### PR TITLE
Update example for 'application/avro' content

### DIFF
--- a/avro-format.md
+++ b/avro-format.md
@@ -167,7 +167,7 @@ The following table shows exemplary mappings:
 |             |        |                                                |
 | dataschema  | string | `"http://registry.com/subjects/ce/versions/1"` |
 | contenttype | string | `"application/avro"`                           |
-| data        | string | `"Q2xvdWRFdmVudHM="`                           |
+| data        | bytes  | `[avro-serialized-bytes]`                      |
 
 ## References
 


### PR DESCRIPTION
This PR updates the example for 'application/avro' content data where it should be written using the Avro `bytes` type.

Closes #515