### PR TITLE
Removed statement about denial

### DIFF
--- a/http-webhook.md
+++ b/http-webhook.md
@@ -188,9 +188,7 @@ it.
 
 Reaching the delivery agreement is realized using the following validation
 handshake. The handshake can either be executed immediately at registration time
-or as a "pre-flight" request immediately preceding a delivery. If the handshake
-outcome is that the delivery is denied, the sender MUST NOT deliver events to
-the target.
+or as a "pre-flight" request immediately preceding a delivery. 
 
 It is important to understand is that the handshake does not aim to establish an
 authentication or authorization context. It only serves to protect the sender


### PR DESCRIPTION
I removed a requirement that a sender MUST NOT send notifications in case of denial by the target, as there is no way for the sender to distinguish denial from a target just not supporting the handshake. As the validation request is mostly about protecting the sender, the statement was unnecessary.

If people come to the conclusion that the statement should not be removed, we need some clear way to distinguish the validation response of a target that does not support validation and a target that denies event delivery.

This PR solves #328 