### PR TITLE
"Stand-alone event format" instead of "in-memory format"

### DIFF
--- a/documented-extensions.md
+++ b/documented-extensions.md
@@ -34,7 +34,7 @@ Extensions attributes, while not defined by the core CloudEvents specifications,
 MUST follow the same serialization rules as defined by the format and protocol
 binding specifications. See 
 [Extension Context Attributes](spec.md#extension-context-attributes) for more
- information.
+information.
 
 ## Known Extensions
 

--- a/documented-extensions.md
+++ b/documented-extensions.md
@@ -30,15 +30,15 @@ Support for any extension is OPTIONAL. When an extension definition uses
 [RFC 2199](https://www.ietf.org/rfc/rfc2119.txt) keywords (e.g. MUST, SHOULD,
 MAY), this usage only applies to events that use the extension.
 
-Extensions always follow a common placement strategy for in-memory formats (e.g.
-[JSON](json-format.md), XML) that are decided by those
+Extensions always follow a common placement strategy for stand-alone event
+formats (e.g. [JSON](json-format.md), XML) that are decided by those
 representations. Protocol bindings (e.g. [HTTP](http-protocol-binding.md),
-[MQTT](mqtt-protocol-binding.md), [AMPQ](amqp-protocol-binding.md),
+[MQTT](mqtt-protocol-binding.md), [AMQP](amqp-protocol-binding.md),
 [NATS](nats-protocol-binding.md)) provide default placement for extensions, but
-an extension MAY require special secondary representation when transported (e.g. tracing
-standards that require specific headers). Extension authors SHOULD only require
-special representation in protocol bindings where extensions integrate with
-pre-existing specs; extensions with custom protocol bindings are much more
+an extension MAY require special secondary representation when transported (e.g.
+tracing standards that require specific headers). Extension authors SHOULD only
+require special representation in protocol bindings where extensions integrate
+with pre-existing specs; extensions with custom protocol bindings are much more
 likely to be dropped by middleware that does not understand the extension.
 
 As a convention, extensions of scalar types (e.g. `String`, `Binary`,

--- a/documented-extensions.md
+++ b/documented-extensions.md
@@ -32,7 +32,9 @@ MAY), this usage only applies to events that use the extension.
 
 Extensions attributes, while not defined by the core CloudEvents specifications,
 MUST follow the same serialization rules as defined by the format and protocol
-binding specifications. See [Extension Context Attributes](spec.md#extension-context-attributes) for more information.
+binding specifications. See 
+[Extension Context Attributes](spec.md#extension-context-attributes) for more
+ information.
 
 ## Known Extensions
 

--- a/documented-extensions.md
+++ b/documented-extensions.md
@@ -30,20 +30,9 @@ Support for any extension is OPTIONAL. When an extension definition uses
 [RFC 2199](https://www.ietf.org/rfc/rfc2119.txt) keywords (e.g. MUST, SHOULD,
 MAY), this usage only applies to events that use the extension.
 
-Extensions always follow a common placement strategy for stand-alone event
-formats (e.g. [JSON](json-format.md), XML) that are decided by those
-representations. Protocol bindings (e.g. [HTTP](http-protocol-binding.md),
-[MQTT](mqtt-protocol-binding.md), [AMQP](amqp-protocol-binding.md),
-[NATS](nats-protocol-binding.md)) provide default placement for extensions, but
-an extension MAY require special secondary representation when transported (e.g.
-tracing standards that require specific headers). Extension authors SHOULD only
-require special representation in protocol bindings where extensions integrate
-with pre-existing specs; extensions with custom protocol bindings are much more
-likely to be dropped by middleware that does not understand the extension.
-
-As a convention, extensions of scalar types (e.g. `String`, `Binary`,
-`URI-reference`, `Number`) document their `Value` and structured types document
-their `Attributes`.
+Extensions attributes, while not defined by the core CloudEvents specifications,
+MUST follow the same serialization rules as defined by the format and protocol
+binding specifications. See [Extension Context Attributes](spec.md#extension-context-attributes) for more information.
 
 ## Known Extensions
 

--- a/extensions/distributed-tracing.md
+++ b/extensions/distributed-tracing.md
@@ -26,10 +26,10 @@ Prometheus are built.
 
 ## Encoding
 
-### In-memory formats
+### Stand-alone event formats
 
 The Distributed Tracing extension uses the key `distributedtracing` for
-in-memory formats
+stand-alone event formats.
 
 ### HTTP
 

--- a/extensions/distributed-tracing.md
+++ b/extensions/distributed-tracing.md
@@ -24,14 +24,7 @@ Prometheus are built.
 - Constraints
   - OPTIONAL
 
-## Encoding
-
-### Stand-alone event formats
-
-The Distributed Tracing extension uses the key `distributedtracing` for
-stand-alone event formats.
-
-### HTTP
+## HTTP encoding
 
 To integrate with existing tracing libraries, the Distributed Tracing attributes
 MUST be encoded over HTTP(S) as headers. E.g.
@@ -46,10 +39,10 @@ CURL -X POST example/webhook.json \
 
 ## Conflicts
 
-Since this extension defines secondary, special, seialization that differs
+Since this extension defines secondary, special, serialization that differs
 from other CloudEvents attributes, it is possible that the values of these two
 could differ by the time the event is received at a destination. In those
 cases, the serialization that followed the "general CloudEvents serialization
-rules" MUST be used as the CloudEvents attribute. The other, secodary,
+rules" MUST be used as the CloudEvents attribute. The other, secondary,
 mapping MAY be picked-up and offered to the receiving application as
 "additional" metadata.

--- a/extensions/partitioning.md
+++ b/extensions/partitioning.md
@@ -26,15 +26,3 @@ same bucket are done so by using the same partition key on those events.
 * Constraints:
   * REQUIRED
   * MUST be a non-empty string
-
-## Encoding
-
-### Stand-alone event formats
-
-The partitionkey attribute extension uses the key `partitionkey` for
-stand-alone event formats.
-
-### Protocol format
-
-The Partitioning extension does not customize any protocol binding's storage for
-extensions.

--- a/extensions/partitioning.md
+++ b/extensions/partitioning.md
@@ -1,15 +1,14 @@
 # Partitioning extension
 
-This extension defines an attribute for use by message brokers and their
-clients that support partitioning of events, typically for the purpose of
-scaling.
+This extension defines an attribute for use by message brokers and their clients
+that support partitioning of events, typically for the purpose of scaling.
 
-Often in large scale systems, during times of heavy load, events being received need to be
-partitioned into multiple buckets so that each bucket can be separately processed in order
-for the system to manage the incoming load. A partitioning key can be used to determine
-which bucket each event goes into. The entity sending the events can ensure that events
-that need to be placed into the same bucket are done so by using the same partition key on
-those events.
+Often in large scale systems, during times of heavy load, events being received
+need to be partitioned into multiple buckets so that each bucket can be
+separately processed in order for the system to manage the incoming load. A
+partitioning key can be used to determine which bucket each event goes into. The
+entity sending the events can ensure that events that need to be placed into the
+same bucket are done so by using the same partition key on those events.
 
 ## Attributes
 
@@ -30,13 +29,12 @@ those events.
 
 ## Encoding
 
-### In-memory formats
+### Stand-alone event formats
 
 The partitionkey attribute extension uses the key `partitionkey` for
-in-memory formats.
+stand-alone event formats.
 
 ### Protocol format
 
 The Partitioning extension does not customize any protocol binding's storage for
 extensions.
-

--- a/extensions/sampled-rate.md
+++ b/extensions/sampled-rate.md
@@ -30,9 +30,9 @@ they impose additional sampling.
 
 ## Encoding
 
-### In-memory formats
+### Stand-alone event formats
 
-The Sampling extension uses the key `sampledrate` for in-memory formats.
+The Sampling extension uses the key `sampledrate` for stand-alone event formats.
 
 ### Protocol bindings
 

--- a/extensions/sampled-rate.md
+++ b/extensions/sampled-rate.md
@@ -27,14 +27,3 @@ they impose additional sampling.
   extension not being used at all.
 - Constraints
   - The rate MUST be greater than zero.
-
-## Encoding
-
-### Stand-alone event formats
-
-The Sampling extension uses the key `sampledrate` for stand-alone event formats.
-
-### Protocol bindings
-
-The Sampling extension does not customize any protocol binding's storage for
-extensions.


### PR DESCRIPTION
As we recently added a definition for _event format_ that mentions _stand-alone event formats_ to the spec, I changed the wording in the descriptions of extensions from _in-memory_ format to "stand-alone event format" to better reflect this.
@alanconway What do think?