### PR TITLE
Fix distributed tracing example.

### DIFF
--- a/extensions/distributed-tracing.md
+++ b/extensions/distributed-tracing.md
@@ -32,7 +32,7 @@ MUST be encoded over HTTP(S) as headers. E.g.
 ```bash
 CURL -X POST example/webhook.json \
 -H 'traceparent:  00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01' \
--H 'tracestate: rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4=` \
+-H 'tracestate: rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4` \
 -H 'content-type: application/cloudevents+json' \
 -d '@sample-event.json'
 ```


### PR DESCRIPTION
Per https://w3c.github.io/trace-context/#value, tracestate values must
not contain (,) or (=) characters.

Signed-off-by: Ian Milligan <ianmllgn@gmail.com>