### PR TITLE
Fix ordering of elements for id attribute. Make consistent with rest …

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -249,13 +249,13 @@ The following attributes are REQUIRED to be present in all CloudEvents:
   is unique for each distinct event. If a duplicate event is re-sent (e.g. due
   to a network error) it MAY have the same `id`. Consumers MAY assume that
   Events with identical `source` and `id` are duplicates.
-- Examples:
-  - An event counter maintained by the producer
-  - A UUID
 - Constraints:
   - REQUIRED
   - MUST be a non-empty string
   - MUST be unique within the scope of the producer
+- Examples:
+  - An event counter maintained by the producer
+  - A UUID
 
 #### source
 


### PR DESCRIPTION
…of spec.

Signed-off-by: Mike Helmick <helmick@google.com>

All of the other attributes have example after constraints, ID had examples before constraints.