### PR TITLE
Adding link to Pub/Sub binding

### DIFF
--- a/proprietary-specs.md
+++ b/proprietary-specs.md
@@ -5,3 +5,4 @@ ensure that they are up to date with the current version of CloudEvents. That is
 the responsibility of the respective project maintainers.
 
 - [Apache RocketMQ Transport Binding](https://github.com/apache/rocketmq-externals/blob/master/rocketmq-cloudevents-binding/rocketmq-transport-binding.md)
+- [Google Cloud Pub/Sub Protocol Binding](https://github.com/google/knative-gcp/blob/master/docs/spec/pubsub-protocol-binding.md)


### PR DESCRIPTION
- Adding link to Google Cloud Pub/Sub binding in the proprietary specs file.