### PR TITLE
[DRAFT][WIP] Multipart Binary proposal

### DIFF
--- a/http-protocol-binding.md
+++ b/http-protocol-binding.md
@@ -429,6 +429,57 @@ Content-Length: nnnn
 
 ```
 
+### 3.4. Multipart Binary Content Mode
+
+In the _multipart binary_ content mode several events are sent into a single HTTP multipart
+request or response body and they can be named. A multipart binary mode contains one event per part, 
+encoded in a similar fashion to [binary content mode]().
+The _multipart binary_ content mode is based on [RFC2046][rfc2046].
+
+#### 3.4.1. HTTP Content-Type
+
+The [HTTP `Content-Type`][content-type] header MUST be set to the media type of `multipart/cloudevents` 
+and must include the [boundary parameter](https://tools.ietf.org/html/rfc2046#section-5.1.1)
+
+```text
+Content-Type: multipart/cloudevents; boundary=12345
+```
+
+#### 3.4.2 Examples
+
+```text
+
+POST /myresource HTTP/1.1
+Host: webhook.example.com
+Content-Type: multipart/cloudevents; boundary=12345
+
+--12345
+ce-specversion: 1.0
+ce-type: com.example.someevent
+ce-time: 2018-04-05T03:56:24Z
+ce-id: 1234-1234-1234
+ce-source: /mycontext/subcontext
+    .... further attributes ...
+Content-Type: application/json; charset=utf-8
+
+{
+    ... application data ...
+}
+--12345
+ce-specversion: 1.0
+ce-type: com.example.anotherevent
+ce-time: 2018-04-05T03:56:24Z
+ce-id: 1234-1234-1234
+ce-source: /mycontext/subcontext
+    .... further attributes ...
+Content-Type: application/json; charset=utf-8
+
+{
+    ... application data ...
+}
+--12345
+```
+
 ## 4. References
 
 - [RFC2046][rfc2046] Multipurpose Internet Mail Extensions (MIME) Part Two:


### PR DESCRIPTION
This PR is a draft to explain some ideas from #574 

The goal of this proposal is to allow to efficiently send events inside an HTTP envelope and identify them without the need to parse a huge JSON (batched mode)

This proposal defines a new `multipart` content type, compliant to [RFC2046](https://tools.ietf.org/html/rfc2046#section-5.1). Events are sent inside each part in a similar fashion to the binary mode

See #592, #594 for the alternatives

Pros:

* Allows reading the attributes of the event without parsing a full JSON
* Allows identification of the events reusing attributes/extensions
* Allows unbuffered dispatch of the events and other optimizations

Cons:

* Harder to implement than https://github.com/cloudevents/spec/pull/592 because most HTTP server/clients, even if they claim to support multipart bodies, supports only the RFC7578. That means that they strip out all headers from the parts, except the content type and content disposition. Even so, implementing a multipart parser is not hard and most of tools out there can be reused. (this requires further investigation) 

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>