### PR TITLE
HTTP Multipart content mode

### DIFF
--- a/http-protocol-binding.md
+++ b/http-protocol-binding.md
@@ -83,8 +83,8 @@ In the _batched_ content mode several events are batched into a single HTTP
 request or response body using an [event format](#14-event-formats) that
 supports batching.
 
-In the _multipart_ content mode several events are sent into a single HTTP
-request or response body allowing to represent, on each part, an event or in 
+In the _multipart_ content mode several events are sent in a single HTTP
+request or response body allowing to represent, on each part, an event in 
 binary mode or in structured mode.
 
 ### 1.4. Event Formats
@@ -447,9 +447,9 @@ Content-Length: nnnn
 
 ### 3.4. Multipart Content Mode
 
-In the _multipart_ content mode several events are sent into a single HTTP multipart
+In the _multipart_ content mode several events are sent in a single HTTP multipart
 request or response as described in [RFC2046, section 5.1][rfc2046-section-5.1]. 
-The _multipart_  content mode maps one event per part. Because each part consists in an 
+The _multipart_  content mode maps one event per part. Because each part consists in a 
 group of headers and a body, an event could be encoded following the same rules that applies
 to [Structured Content Mode](#32-structured-content-mode) and [Binary Content Mode](#31-binary-content-mode)
 within the part, respectively named _structured part_ and _binary part_.
@@ -459,7 +459,7 @@ Every part of the HTTP envelope MUST be or a _structured part_ or a _binary part
 #### 3.4.1. HTTP Content-Type
 
 The [HTTP `Content-Type`][content-type] header MUST be set to the media type of `multipart/cloudevents` 
-and must include the [boundary parameter](https://tools.ietf.org/html/rfc2046#section-5.1.1)
+and MUST include the [boundary parameter](https://tools.ietf.org/html/rfc2046#section-5.1.1)
 
 ```text
 Content-Type: multipart/cloudevents; boundary=12345
@@ -467,15 +467,15 @@ Content-Type: multipart/cloudevents; boundary=12345
 
 #### 3.4.2. Structured Part
 
-All rules defined in [Structured Content Mode](#32-structured-content-mode) applies from the beginning of the 
-part up to the end of the part, outlined by the boundary delimiter.
+A _structured part_ MUST conform to all rules defined by [Structured Content Mode](#32-structured-content-mode)
+from the beginning up to to the end of the part, outlined by the boundary delimiter.
 
 More [event formats](#14-event-formats) for several parts in the same envelope are allowed.
 
 #### 3.4.3. Binary Part
 
-All rules defined in [Binary Content Mode](#31-binary-content-mode) applies from the beginning of the 
-part up to the end of the part, outlined by the boundary delimiter.
+A _binary part_ MUST conform to all rules defined by [Binary Content Mode](#31-binary-content-mode)
+from the beginning up to to the end of the part, outlined by the boundary delimiter.
 
 #### 3.4.4. Distinguish between structured and binary part
 

--- a/http-protocol-binding.md
+++ b/http-protocol-binding.md
@@ -439,6 +439,57 @@ Content-Length: nnnn
 
 ```
 
+### 3.4. Multipart Binary Content Mode
+
+In the _multipart binary_ content mode several events are sent into a single HTTP multipart
+request or response body and they can be named. A multipart binary mode contains one event per part, 
+encoded in a similar fashion to [binary content mode]().
+The _multipart binary_ content mode is based on [RFC2046][rfc2046].
+
+#### 3.4.1. HTTP Content-Type
+
+The [HTTP `Content-Type`][content-type] header MUST be set to the media type of `multipart/cloudevents` 
+and must include the [boundary parameter](https://tools.ietf.org/html/rfc2046#section-5.1.1)
+
+```text
+Content-Type: multipart/cloudevents; boundary=12345
+```
+
+#### 3.4.2 Examples
+
+```text
+
+POST /myresource HTTP/1.1
+Host: webhook.example.com
+Content-Type: multipart/cloudevents; boundary=12345
+
+--12345
+ce-specversion: 1.0
+ce-type: com.example.someevent
+ce-time: 2018-04-05T03:56:24Z
+ce-id: 1234-1234-1234
+ce-source: /mycontext/subcontext
+    .... further attributes ...
+Content-Type: application/json; charset=utf-8
+
+{
+    ... application data ...
+}
+--12345
+ce-specversion: 1.0
+ce-type: com.example.anotherevent
+ce-time: 2018-04-05T03:56:24Z
+ce-id: 1234-1234-1234
+ce-source: /mycontext/subcontext
+    .... further attributes ...
+Content-Type: application/json; charset=utf-8
+
+{
+    ... application data ...
+}
+--12345
+```
+
 ## 4. References
 
 - [RFC2046][rfc2046] Multipurpose Internet Mail Extensions (MIME) Part Two:

--- a/http-protocol-binding.md
+++ b/http-protocol-binding.md
@@ -454,7 +454,7 @@ group of headers and a body, an event could be encoded following the same rules 
 to [Structured Content Mode](#32-structured-content-mode) and [Binary Content Mode](#31-binary-content-mode)
 within the part, respectively named _structured part_ and _binary part_.
 
-Every part of the HTTP envelope MUST be or a _structured part_ or a _binary part_.
+Every part of the HTTP envelope MUST be either a _structured part_ or a _binary part_.
 
 #### 3.4.1. HTTP Content-Type
 


### PR DESCRIPTION
This PR merges the work done in #592 and #593 into a single content mode.

The goal of this proposal is to allow mapping efficiently more events inside an HTTP envelope without the need to parse a huge JSON (batched mode). For more details on the rationale also look at #574. 

This proposal defines a new `multipart` content type called `multipart/cloudevents`, compliant to [RFC2046](https://tools.ietf.org/html/rfc2046#section-5.1). 
Because each part has an Header and a Body section, it can encode the event as structured or binary mode similar to how the spec already defines these two content modes.

This content mode, similar to batching, doesn't define any semantic meaning between the different events sent in the same envelope. This means that is up to the user to give them a meaning or just treat them as independent between each other.

## Features

* Allows unbuffered dispatch of the events and other optimizations
* Because it already reuses the same concepts of binary and structured mode, the implementation is relatively easy for the SDKs (look below)
* The multipart envelopes are potentially infinite, allowing to use this content mode as a sort of "streaming" of events

## Experimental implementation

A sample implementation for sdk-go lives here: https://github.com/slinkydeveloper/sdk-go/commits/multipart_experiment

For reading multipart request/responses, the client directly leverage the already existing parsing logic for structured and binary mode: https://github.com/slinkydeveloper/sdk-go/commit/355a3cec5f624b732fc7f3ff67c09900e20d07e4#diff-584b2042f74d673322bd7a717e3d66b3R58

For writing the multipart request/response the client loops among the several messages of the `MultiMessage` interface and writes the single parts reusing the `binding.Write` function, used in the sdk to write all kind of messages: https://github.com/slinkydeveloper/sdk-go/commit/355a3cec5f624b732fc7f3ff67c09900e20d07e4#diff-e9340c4352f2c852878f7b66bba5967cR29 

In particular, there are three examples to test it:

* [Send/Receive](https://github.com/slinkydeveloper/sdk-go/blob/355a3cec5f624b732fc7f3ff67c09900e20d07e4/v2/cmd/samples/http_multipart/random_multi_event_send_receive/main.go): Demo of a server and a client which sends several events and, without any event parsing, applies some transformations, replying with transformed events
* [Send](https://github.com/slinkydeveloper/sdk-go/blob/355a3cec5f624b732fc7f3ff67c09900e20d07e4/v2/cmd/samples/http_multipart/random_multi_event_send/main.go): HTTP client that sends 5 random events
* [Reply with N events](https://github.com/slinkydeveloper/sdk-go/blob/355a3cec5f624b732fc7f3ff67c09900e20d07e4/v2/cmd/samples/http_multipart/random_multi_event_response/main.go): HTTP server (with upgrade to HTTP/2) that replies with N events

A sample curl response with multipart/cloudevents (including HTTP/2 upgrade):

```
% curl localhost:8080\?num=3 --http2 -v                                                                                                                                                                                            
> GET /?num=3 HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.69.1
> Accept: */*
> Connection: Upgrade, HTTP2-Settings
> Upgrade: h2c
> HTTP2-Settings: AAMAAABkAAQCAAAAAAIAAAAA
> 
< HTTP/1.1 101 Switching Protocols
< Connection: Upgrade
< Upgrade: h2c
< HTTP/2 200 
< content-type: multipart/cloudevents; boundary=63a561a72502161512131752ba061292d5948dbbceba58953f12c6ebc938
< content-length: 1153
< date: Thu, 09 Apr 2020 09:21:22 GMT
< 
--63a561a72502161512131752ba061292d5948dbbceba58953f12c6ebc938
Content-Type: application/cloudevents+json

{"data":{"id":0,"message":"hello world"},"datacontenttype":"application/json","id":"06dda122-2430-4199-b3de-980b9891632f","source":"https://github.com/cloudevents/sdk-go/v2/cmd/samples/http_multipart/random_multi_event_response","specversion":"1.0","type":"com.cloudevents.multipart.sample"}
--63a561a72502161512131752ba061292d5948dbbceba58953f12c6ebc938
Ce-Id: 4f647dbe-7dfd-4e8f-a8fe-09dafbb45238
Ce-Source: https://github.com/cloudevents/sdk-go/v2/cmd/samples/http_multipart/random_multi_event_response
Ce-Specversion: 1.0
Ce-Type: com.cloudevents.multipart.sample
Content-Type: application/json

{"id":1,"message":"hello world"}
--63a561a72502161512131752ba061292d5948dbbceba58953f12c6ebc938
Content-Type: application/cloudevents+json

{"data":{"id":2,"message":"hello world"},"datacontenttype":"application/json","id":"de8ca4b6-72a0-4f37-afbc-0da7beb9914c","source":"https://github.com/cloudevents* Connection #0 to host localhost left intact
/sdk-go/v2/cmd/samples/http_multipart/random_multi_event_response","specversion":"1.0","type":"com.cloudevents.multipart.sample"}%  
```

## TODO

* [ ] Should this content mode (maybe together with batching) live in another subspec, like _HTTP multi event binding spec_?
* [ ] Investigate HTTP Headers packing (https://github.com/cloudevents/spec/pull/593#discussion_r396489323)