### PR TITLE
Fix invalid example in subscriptions-api-openapi.yaml

### DIFF
--- a/subscriptions-api-openapi.yaml
+++ b/subscriptions-api-openapi.yaml
@@ -116,7 +116,6 @@ components:
             - $ref: "#/components/schemas/NATSSettings"
             - $ref: "#/components/schemas/ApacheKafkaSettings"
           description: OPTIONAL. A set of settings specific to the selected delivery protocol provider.
-          example: null
         sink:
           type: string
           format: url


### PR DESCRIPTION
Remove `example: null` to enable it in Azure API Management import.
Fix for issue #606

Signed-off-by: Thomas Weingartner <thomas.weingartner@gmx.ch>