### PR TITLE
[WIP] Cloudevents avro improvement proposal

### DIFF
--- a/spec.avsc
+++ b/spec.avsc
@@ -1,22 +1,56 @@
 {
-  "namespace":"io.cloudevents",
+  "namespace": "io.cloudevents.avro",
   "type":"record",
   "name":"CloudEvent",
   "version":"1.0",
   "doc":"Avro Event Format for CloudEvents",
   "fields":[
     {
-      "name":"attribute",
-      "type":{
-        "type":"map",
-        "values":[
-          "null",
-          "boolean",
-          "int",
-          "string",
-          "bytes"
-        ]
-      }
+      "name": "specversion",
+      "type": "string",
+      "default": "1.0"
+    },
+    {
+      "name": "type",
+      "type": "string"
+    },
+    {
+      "name": "source",
+      "type": "string"
+    },
+    {
+      "name": "id",
+      "type": "string",
+      "logicalType": "uuid"
+    },
+    {
+      "name": "time",
+      "type": "string",
+      "logicalType": "timestamp-millis"
+    },
+    {
+      "name": "dataschema",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "datacontenttype",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "subject",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
     },
     {
       "name": "data",


### PR DESCRIPTION
Proposal to change the Avro CloudEvent format for better field validation and better use with SDKs

### Changes

#### Changing namespace
There is potential namespace collision because of the currently used namespace is and can be used in SDKs for an other non Avro CloudEvent  class

For example the Java SDK (`io.cloudevents:cloudevents-api:1.3.0`)  has a CloudEvent on the same location than the avro CloudEvent class, meaning that using avro code generation with this SDK is difficult, 

#### Using mandatory fields instead of a mapping
as mentioned in this [issue](https://github.com/cloudevents/spec/issues/575),  the mapping of value was selected to support forward and backward compatibility, however it causes problem since mandatory fields could be absent and no field validation is present.

using mandatory fields with defaults allow to have forward and backward compatibility and type verification.  

#### Use of builtin logical types
Avro support some builtin logical type `timestamp-millis` and `uuid`  for some extra validation. Since the resulting serialized message does not change, it does not cause any forward/backward compatibility problems 

Thanks for the consideration :) 