### PR TITLE
Remove unused 'subscriber'

### DIFF
--- a/discovery.md
+++ b/discovery.md
@@ -104,14 +104,6 @@ to execute some logic, which might lead to the occurrence of new events.
 
 The request for events from an Event Producer system.
 
-#### Event Subscriber
-
-The entity managing the lifecycle of a Subscription on behalf of an Event
-Consumer. In some instances this might be the same entity as the Event Consumer.
-
-For example, a UI for connecting eventing producers to event consumers would
-be considered an event subscriber and a target user of this API.
-
 ## API Specification
 
 This API is specified as a REST API with well defined entities and relationships


### PR DESCRIPTION
Closes: #622 

Clean-up - Just removing a term that is unused - we can add it back later if needed.

Signed-off-by: Doug Davis <dug@us.ibm.com>