### PR TITLE
Discovery Revamp

### DIFF
--- a/discovery.md
+++ b/discovery.md
@@ -144,6 +144,7 @@ Service:
 ```
 {
   "url": "[unique URL to this service]",
+  "name": "[unique name for this services]",
   "description": "[human string]", ?
   "docsurl": "[URL reference for human documentation]", ?
   "specversion": "[ce-specversion value]",
@@ -177,7 +178,7 @@ An example:
 ```json
 {
   "url": "https://example.com/services/widgetService",
-  "specversion": "v1.0",
+  "specversion": "1.0",
   "subscriptionurl": "https://events.example.com",
   "protocols": [ "HTTP" ],
   "type": [
@@ -369,14 +370,24 @@ entity.
 
 ###### extensions
 
-- Type: `Map` of `String` to `String`
-- Description: Associative map of CloudEvents
+- Type: `Array` of structures
+- Description: An array or CloudEvents
   [Extension Context Attributes](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes)
-  that are used for this event `type`. Keys MUST be confirm to the extension
-  context attributes naming rules and value are the type of the extension
-  attribute, conforming to the CloudEvents [type system](./spec.md#type-system).
+  that are used for this event `type`. The structure contains the following
+  attributes:
+  - `name` - the CloudEvents context attribute name used by this extension.
+    It MUST adhere to the CloudEvents context attrbibute naming rules
+  - `type` - the data type of the extension attribute. It MUST adhere to the
+    CloudEvents [type system](./spec.md#type-system)
+  - `specurl` - an attribute pointing to the specification that
+    defines the extension
 - Constraints:
   - OPTIONAL
+  - if present, the `name` attribute in the structure is REQUIRED
+  - if present, the `type` attribute in the structure is REQUIRED
+  - if present, the `specurl` attribute in the structure is OPTIONAL
+- Examples:
+  - `{ "name": "dataref", "type": "URI-reference", "specurl": "https://github.com/cloudevents/spec/blob/master/extensions/dataref.md" }`
 
 #### Service Examples
 
@@ -465,7 +476,7 @@ whose `name` attribute contains the `search term` value (case insensitive).
 * Type: `string`
 * Description: Search term that provides case insensitive match against
   the Service's `name` attribute. The parameter can match any portion
-  of the service's `description` value.
+  of the service's `name` value.
 * Constraints:
   * OPTIONAL
   * If present, MUST be non-empty

--- a/discovery.md
+++ b/discovery.md
@@ -3,8 +3,8 @@
 ## Abstract
 
 CloudSubscriptions Discovery API is a vendor-neutral API specification for
-determining what events an Event Producer has available, as well as how to
-subscribe to those events.
+determining what events are available from a particular system, as well as
+how to subscribe to those events.
 
 ## Status of this document
 
@@ -21,33 +21,45 @@ version.
 
 ## Overview
 
-The goal of the CloudDiscovery API is to enable connections between consumers of
-events and Event producers to facilitate the creation of a
-CloudSubscription. Note that whether an Event producer is a single entity,
-an aggregator/broker of multiple event producers, or an intermediary is an
-implementation detail of the producer and does not change how an event
-consumer interacts with a specification compliant producer.
+In order for consumers to receive events from event producers, they need
+to first subscribe, or ask for, events from those producers. To do so, there
+is often a process necessary that involves steps such as discovering which
+event producer is of interest, what events it generates and how to create the
+subscription for those events.
 
-Discovery allows for an event producer to
-advertise the event types that are available, provide the necessary information
-to consume that event (schema / delivery protocol options), and the necessary
-information to create a subscription. The output of the API ought to be such
-that tooling can be built where all possible event producers and types aren’t
-known in advance.
+This specification defines a set of APIs to allow for consumers to perform
+these queries against a "Discovery Endpoint". A Discovery Endpoint acts
+as a catalog of:
+  - [Services](#service)
+  - [Event Producers](#producer-ce)
+  - Event Types
+overwhich consumers can query to find the Event Producer of interest, and
+to which it can create a Cloud Subscription.
+
+Which means, once the Event Producer of interest is located, additional
+metadata is provided in order to consume and subscribe to events. The goal
+of this API is to be such that tooling can be built where all all possible
+event producers and event types aren't known in advance.
+
+The deployment relationship of a Discovery Endpoint to the Services and
+Event Producers that it advertises is out of scope of this specification.
+For example, a Discovery Endpoint could choose to be implemented as part of a
+Service, or Event Producer, or it could be acting as an independent aggregrator
+of this metadata. This implementation detail will be transparent to consumers.
 
 There are several discovery use cases to consider from the viewpoint of event
 consumers.
 
-1. What event sources are available, and what event types do they produce?
-2. What event types are available, and from which event sources?
+1. What event producers are available, and what event types do they generate?
+2. What event types are available, and from which event producers?
 
-The second case becomes relevant if multiple sources support the same event
+The second case becomes relevant if multiple producers support the same event
 types. Use case 1 is likely the dominant use case. Given the example of a public
-cloud provider where all producers produce events, there might be dozens of
+cloud provider where all producers generate events, there might be dozens of
 sources (producer systems) and hundreds of event types. The discovery funnel of
-producer first, then event types helps users navigate without having to see large
-lists of event types. Both of these cases show the importance of using filters
-in the discovery API to narrow down the selection of available events.
+producer first, then event types helps users navigate without having to see
+large lists of event types. Both of these cases show the importance of using
+filters in the discovery API to narrow down the selection of available events.
 
 The CloudEvent `source` attribute is a potential cause of high fanout. For
 example, consider a blob storage system where each directory constitutes a
@@ -75,10 +87,18 @@ and the CloudEvents version takes precendence.
 
 This specification defines the following terms:
 
+#### Discovery Endpoint
+
+A compliant implementation of this specification that advertises the set
+of Services, Event Types and other metadata to aid in the creation of an
+Event Subcription.
+
 #### Service
 
 A "service" represents the entity which manages one or more event
-[sources](#source-ce).
+[sources](#source-ce) and is associated with [producers](#producer-ce)
+that generate events.
+
 For example, an Object Store service might have a set of event sources
 where each event source maps to a bucket.
 
@@ -111,103 +131,88 @@ to execute some logic, which might lead to the occurrence of new events.
 
 The request for events from an Event Producer system.
 
+
 ## API Specification
 
-This API is specified as a REST API with well defined entities and relationships
-between those entities.
+This API is specified as a REST API with well defined entities and
+relationships between those entities.
 
-To help explain the data model, the following non-normative pseudo yaml shows
-its basic conceptual structure:
+### Services
+
+At the core of the data model is the concept of a [Service](#service). The
+API then exposes multiple ways to query over a list of Services. To help
+explain the Service resource, the following non-normative pseudo yaml shows
+its basic structure:
 
 ( `*` means zero or more, `+` means one or more, `?` means optional)
 
+Service:
 ```
-- services: *
-  - service: [unique identifier for producer of the specified event types]
-    description: [human string] ?
-    uri: [URI reference for human documentation] ?
-    specversion: [ce-speciversion value] ? (required?)
-    subscriptionuri: [URI to which the Subscribe request will be sent]
-    subscriptionconfig: *
-    authscope: [string] ?  (explain)
-    protocols: +
-    - protocol: [string]
-    types: *
-    - type: [ce-type value]
-      description: [human string] ?
-      datacontenttype: [ce-datacontenttype value] ?
-      dataschema: [ce-dataschema URI] ?
-      dataschematype: [string per RFC 2046] ?
-      dataschemacontent: [schema] ?
-      dataschemacontent:
-      extensions: *
-      - name: [CE context attribute name]
-        type: [CE type string]
-        spec: [URI to specification defining the extension] ?
+id: [unique URI]
+description: [human string] ?
+docsuri: [URI reference for human documentation] ?
+specversion: [ce-speciversion value] ? (required?)
+subscriptionuri: [URI to which the Subscribe request will be sent]
+subscriptionconfig: *
+authscope: [string] ?  (explain)
+protocols: +
+- protocol: [string]
+types: *
+- type: [ce-type value]
+  description: [human string] ?
+  datacontenttype: [ce-datacontenttype value] ?
+  dataschema: [ce-dataschema URI] ?
+  dataschematype: [string per RFC 2046] ?
+  dataschemacontent: [schema] ?
+  dataschemacontent:
+  extensions: *
+  - name: [CE context attribute name]
+    type: [CE type string]
+    spec: [URI to specification defining the extension] ?
 ```
 
 An example:
 ```
-- services:
-  - service: example.com
-    subscriptionuri: https://events.example.com
-    protocols:
-    - protocol: HTTP
-    types:
-    - type: com.example.widget.create
-    - type: com.example.widget.delete
+id: example.com
+subscriptionuri: https://events.example.com
+protocols:
+- protocol: HTTP
+types:
+- type: com.example.widget.create
+- type: com.example.widget.delete
 ```
 
 Note: the above is just a sample and implementations are free to use any
 internal model they wish to store the data as long as they are compliant
 with the wire format/API defined by this specification.
 
-### Entities in the API
+#### Service Attributes
 
-1. `Service`
-2. `Type`
-3. `Producer`
+The following sections define the attributes that appear on a Service
+entity.
 
-The `Service` and `Type` entities form the basis of the directory and can
-be used to build user experiences around discovery. The `Producer` entity is
-keyed off of `{Service.Name, Type.Name}` and provides the necessary
-details to create a subscription for events of that `ce-type` from the selected
-`Service`.
+##### id
 
-### Entity Specifications
-
-This section details the fields that make up each of the entities referenced
-earlier in this document.
-
-#### `service` entity
-
-Used in discovery for enumerating the different services represented in this
-discovery system.
-
-##### `service` entity attributes
-
-###### name
-
-- Type: `String`
-- Description: The `name` attribute SHOULD be human readable and can identify a
-  top level service.
+- Type: `URI`
+- Description: A unique, within the scope of this Discovery Endpoint, URI
+  that identifies the Service.
 - Constraints:
   - REQUIRED
-  - MUST be a non-empty string
+  - MUST be a non-empty URI
 - Examples:
-  - "GitHub"
-  - "Awesome Cloud Storage"
+  - cloudstorage.com
+  - github.com
   - "com.example.microservices.userlogin"
 
-###### description
+##### description (Service)
 
 - Type: `String`
-- Description: Human readable description .
+- Description: Human readable description.
 - Constraints:
   - OPTIONAL
   - If present, MUST be a non-empty string
 
-###### service_uri
+##### docsuri
 
 - Type: `URI`
 - Description: Absolute URI that provides a link back to the producer, or
@@ -219,165 +224,6 @@ discovery system.
 - Examples:
   - "http://cloud.example.com/docs/blobstorage"
 
-
-##### `service` entity examples
-
-```json
-{
-  "name": "Cloud Storage Service",
-  "description": "Blob storage in the cloud",
-  "service_uri": "https://cloud.example.com/docs/storage"
-}
-```
-
-And a list of valid `service` entities.
-
-```json
-[
-  {
-    "name": "Cloud Storage Service",
-    "description": "Blob storage in the cloud",
-    "service_uri": "https://cloud.example.com/docs/storage"
-  },
-  {
-    "name": "Cloud MySQL"
-  },
-  {
-    "name": "Cloud OtherSQL",
-    "description": "Highly scalable SQL service"
-  }
-]
-```
-
-#### `type` entity
-
-Used in discovery for enumerating the different CloudEvent `type`s represented
-in this discovery system.
-
-##### `type` entity attributes
-
-###### type
-
-- Type: `String`
-- Description: CloudEvents [`type`](https://github.com/cloudevents/spec/blob/master/spec.md#type)
-  attribute.
-- Constraints:
-  - REQUIRED
-  - MUST be a non-empty string, following the constraints as defined in the
-    CloudEvents spec.
-- Examples:
-  - "com.github.pull.create"
-  - "com.example.object.delete.v2"
-
-###### datacontenttype
-
-- Type: `String`
-- Description: CloudEvents [`datacontenttype`](https://github.com/cloudevents/spec/blob/master/spec.md#datacontenttype)
-  attribute. Indicating how the `data` attribute of subscribed events will be
-  encoded.
-- Constraints:
-  - OPTIONAL
-  - If present, MUST adhere to the format specified in
-    [RFC 2046](https://tools.ietf.org/html/rfc2046)
-
-###### dataschema
-
-- Type: `URI`
-- Description: CloudEvents [`datacontenttype`](https://github.com/cloudevents/spec/blob/master/spec.md#dataschema)
-  attribute. This identifies the canonical storage location of the schema of
-  the `data` attribute of subscribed events.
-- Constraints:
-  - OPTIONAL
-  - If present, MUST be a non-empty URI
-
-###### dataschematype
-
-- Type: `String` per [RFC 2046](https://tools.ietf.org/html/rfc2046)
-- Description: If using `dataschemacontent` for inline schema storage, the
-  `dataschematype` indicates the type of schema represented there.
-- Constraints:
-  - OPTIONAL
-  - If present, MUST adhere to the format specified in
-    [RFC 2046](https://tools.ietf.org/html/rfc2046)
-- Examples:
-  - "application/json"
-  -
-
-###### dataschemacontent
-
-- Type: `String`
-- Description: An inline representation of the schema of the `data` attribute
-  encoding mechanism. This is an alternative to using the `dataschema`
-  attribute.
-- Constraints:
-  - OPTIONAL
-  - If present, MUST be a non-empty string containing a schema compatible with
-    the `datacontenttype`.
-  - If `dataschama` is present, this field MUST NOT be present.
-
-##### `type` entity examples
-
-A single `type` entity.
-
-```json
-{
-  "type": "com.example.storage.object.create",
-  "specversion": "1.x-wip",
-  "datacontenttype": "application/json",
-  "dataschema": "http://schemas.example.com/download/com.example.storage.object.create.json"
-}
-```
-
-#### `producer` entity
-
-Once discovery narrows down to a specific event `type` that we want to subscribe
-to from a specific `service`, the appropriate `producer` entity can be
-retrieved by key. The key is a composite key of the `service` and `type` names.
-
-##### `producer` entity Attributes
-
-The `Service` entity is the main component of the discovery API. This section
-covers the structure of that entity and the next section describes the
-requirements for the query API.
-
-###### service
-
-- Type: `String`
-- Description: Identifies the service of which the event is related. The
-  `service` string SHOULD be human readable and can identify a top level
-  producer system.
-- Constraints:
-  - REQUIRED
-  - MUST be a non-empty string
-- Examples:
-  - "GitHub.com"
-  - "Awesome Cloud Storage"
-  - "com.example.microservices.userlogin"
-
-###### produceruri
-
-- Type: `URI`
-- Description: Absolute URI that provides a link back to the producer, or
-  documentation about the producer. This is for human consumption.
-- Constraints:
-  - OPTIONAL
-  - If present, MUST be a non-empty URI
-- Examples:
-  - "http://cloud.example.com/docs/blobstorage"
-
-###### type
-
-- Type: `String`
-- Description: CloudEvents [`type`](https://github.com/cloudevents/spec/blob/master/spec.md#type)
-  attribute.
-- Constraints:
-  - REQUIRED
-  - MUST be a non-empty string, following the constraints as defined in the
-    CloudEvents spec.
-- Examples:
-  - "com.github.pull.create"
-  - "com.example.object.delete.v2"
-
 ###### specversion
 
 - Type: `String` per [RFC 2046](https://tools.ietf.org/html/rfc2046)
@@ -388,77 +234,7 @@ requirements for the query API.
   - REQUIRED
   - MUST be a non-empty string
 
-###### datacontenttype
-
-- Type: `String`
-- Description: CloudEvents [`datacontenttype`](https://github.com/cloudevents/spec/blob/master/spec.md#datacontenttype)
-  attribute. Indicating how the `data` attribute of subscribed events will be
-  encoded.
-- Constraints:
-  - OPTIONAL
-  - If present, MUST adhere to the format specified in [RFC 2046](https://tools.ietf.org/html/rfc2046)
-
-###### dataschema
-
-- Type: `URI`
-- Description: CloudEvents [`datacontenttype`](https://github.com/cloudevents/spec/blob/master/spec.md#dataschema)
-  attribute. This identifies the canonical storage location of the schema of
-  the `data` attribute of subscribed events.
-- Constraints:
-  - OPTIONAL
-  - If present, MUST be a non-empty URI
-
-###### dataschematype
-
-- Type: `String` per [RFC 2046](https://tools.ietf.org/html/rfc2046)
-- Description: If using `dataschemacontent` for inline schema storage, the
-  `dataschematype` indicates the type of schema represented there.
-- Constraints:
-  - OPTIONAL
-  - If present, MUST adhere to the format specified in [RFC 2046](https://tools.ietf.org/html/rfc2046)
-- Examples:
-  - "application/json"
-  -
-
-###### dataschemacontent
-
-- Type: `String`
-- Description: An inline representation of the schema of the `data` attribute
-  encoding mechanism. This is an alternative to using the `dataschema`
-  attribute.
-- Constraints:
-  - OPTIONAL
-  - If present, MUST be a non-empty string containing a schema compatible with
-    the `datacontenttype`.
-  - If `dataschama` is present, this field MUST NOT be present.
-
-###### protocols
-
-- Type: `List` of `String`
-- Description: This field describes the different values that might be passed
-  in the `protocol` field of the CloudSubscriptions API. The protocols with
-  existing CloudEvents bindings are identified as AMQP, MQTT3, MQTT5, HTTP,
-  KAFKA, and NATS. An implementation MAY add support for further
-  protocols. All producers MUST support at least one delivery protocol, and MAY
-  support additional protocols.
-- Constraints:
-  - REQUIRED
-  - MUST be non-empty.
-- Examples:
-  - ["HTTP"]
-  - ["HTTP", "AMQP", "KAFKA"]
-
-###### extensions
-
-- Type: `Map` of `String` to `String`
-- Description: Associative map of CloudEvents [Extension Context Attributes](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes)
-  that are used for this event `type`. Keys MUST be confirm to the extension
-  context attributes naming rules and value are the type of the extension
-  attribute, conforming to the CloudEvents [type system](./spec.md#type-system).
-- Constraints:
-  - OPTIONAL
-
-###### subscriptionendpoint
+###### subscriptionuri
 
 - Type: `URI-reference`
 - Description: URI indicating where CloudSubscriptions `subscribe` API calls
@@ -488,22 +264,163 @@ requirements for the query API.
 - Example:
   - "storage.read"
 
+###### protocols
+
+- Type: `List` of `String`
+- Description: This field describes the different values that might be passed
+  in the `protocol` field of the CloudSubscriptions API. The protocols with
+  existing CloudEvents bindings are identified as AMQP, MQTT3, MQTT5, HTTP,
+  KAFKA, and NATS. An implementation MAY add support for further
+  protocols. All producers MUST support at least one delivery protocol, and MAY
+  support additional protocols.
+- Constraints:
+  - REQUIRED
+  - MUST be non-empty.
+- Examples:
+  - ["HTTP"]
+  - ["HTTP", "AMQP", "KAFKA"]
+
+##### type
+
+- Type: `String`
+- Description: CloudEvents [`type`](https://github.com/cloudevents/spec/blob/master/spec.md#type)
+  attribute.
+- Constraints:
+  - REQUIRED
+  - MUST be a non-empty string, following the constraints as defined in the
+    CloudEvents spec.
+- Examples:
+  - "com.github.pull.create"
+  - "com.example.object.delete.v2"
+
+##### description (Type)
+
+- Type: `String`
+- Description: Human readable description.
+- Constraints:
+  - OPTIONAL
+  - If present, MUST be a non-empty string
+
+##### datacontenttype
+
+- Type: `String`
+- Description: CloudEvents [`datacontenttype`](https://github.com/cloudevents/spec/blob/master/spec.md#datacontenttype)
+  attribute. Indicating how the `data` attribute of subscribed events will be
+  encoded.
+- Constraints:
+  - OPTIONAL
+  - If present, MUST adhere to the format specified in
+    [RFC 2046](https://tools.ietf.org/html/rfc2046)
+
+##### dataschema
+
+- Type: `URI`
+- Description: CloudEvents [`datacontenttype`](https://github.com/cloudevents/spec/blob/master/spec.md#dataschema)
+  attribute. This identifies the canonical storage location of the schema of
+  the `data` attribute of subscribed events.
+- Constraints:
+  - OPTIONAL
+  - If present, MUST be a non-empty URI
+
+##### dataschematype
+
+- Type: `String` per [RFC 2046](https://tools.ietf.org/html/rfc2046)
+- Description: If using `dataschemacontent` for inline schema storage, the
+  `dataschematype` indicates the type of schema represented there.
+- Constraints:
+  - OPTIONAL
+  - If present, MUST adhere to the format specified in
+    [RFC 2046](https://tools.ietf.org/html/rfc2046)
+- Examples:
+  - "application/json"
+
+##### dataschemacontent
+
+- Type: `String`
+- Description: An inline representation of the schema of the `data` attribute
+  encoding mechanism. This is an alternative to using the `dataschema`
+  attribute.
+- Constraints:
+  - OPTIONAL
+  - If present, MUST be a non-empty string containing a schema compatible with
+    the `datacontenttype`.
+  - If `dataschama` is present, this field MUST NOT be present.
+
+###### extensions
+
+- Type: `Map` of `String` to `String`
+- Description: Associative map of CloudEvents [Extension Context Attributes](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes)
+  that are used for this event `type`. Keys MUST be confirm to the extension
+  context attributes naming rules and value are the type of the extension
+  attribute, conforming to the CloudEvents [type system](./spec.md#type-system).
+- Constraints:
+  - OPTIONAL
+
+#### Service Examples
+
+```json
+{
+  "id": "com.example.storage",
+  "description": "Blob storage in the cloud",
+  "service_uri": "https://cloud.example.com/docs/storage",
+  "types": [
+    "type": "com.example.storage.object.create",
+    "specversion": "1.x-wip",
+    "datacontenttype": "application/json",
+    "dataschema": "http://schemas.example.com/download/com.example.storage.object.create.json"
+  ]
+}
+```
+
+
 ### REST Paths
 
 Each path in the REST API represents either represents a list (or search) over
 and entity class, or the retrieval of an individual entity by name. Each of
 these operations MUST be supported by compliant discovery implementations.
 
-#### `/services?matching=[search term]`
+#### Services
 
-Returns a list of all services in the discovery system, optionally filtering on
-a provided search term (`matching`).
+The following API query patterns are defined.
 
-##### matching
+For each, upon succesful processing, the response MUST be a JSON array with
+zero or more Service entities.
+
+When encoded in JSON, the format MUST adhere to the following:
+
+```
+[
+  {
+    "id": "SERVICE-ID",
+    ... remainder of Service attributes ...
+  },
+  ...
+]
+```
+
+#### `/services`
+
+This MUST return an array of zero or more Services. The list MUST contain
+all Services that the client is authorized to see. The list MUST NOT contain
+any Services that the client is not authorized to see.
+
+##### `/services/{id}`
+
+Same as `/services` but the array MUST be limited to at most one, the entity
+whose `id` matches the value specified.
+
+##### `/services?matching=[search term]`
+
+Same as `/services` but the array MUST be limited to just those Services
+whose `description` attribute contains the `search term` value (case
+insensitive).
+
+###### matching
 
 * Type: `string`
 * Description: Search term that provides case insensitive match against
-  `service` names. The parameter can match any portion of the service name.
+  the Service's `description` attribute. The parameter can match any portion
+  of the service's `description` value.
 * Constraints:
   * OPTIONAL
   * If present, MUST be non-empty
@@ -514,41 +431,51 @@ a provided search term (`matching`).
       * `"File storage system"`
       * `"storage Storage STORAGE"`
 
-##### Returns
 
-Upon successful processing, the response MUST be a JSON array of `service`
-entities.
+#### Types
 
-#### `/services/{name}`
+The following API query patterns are defined.
 
-Retrieves an individual service entity by exact match on the `service` name.
+For each, upon succesful processing, the response MUST be a JSON array with
+zero or more Type values, each with the list of Service entities that
+support that Type.
 
-##### Returns
+When encoded in JSON, the format MUST adhere to the following:
 
-Upon successful processing, the response MUST be a JSON object that is a single
-`service` entity.
+```
+[
+  "TYPE-VALUE": {
+    "id": "SERVICE-ID",
+    ... remainder of Service attributes ...
+  },
+  ...
+]
+```
 
-#### `/services/{name}/types`
+##### `/types`
 
-Retrieves the details about the types that are offered by the specified
-`service`.
+This MUST return an array of zero or more Types values. The list MUST contain
+all Types values from all Services that the client is authorized to see. It
+MUST NOT container Type values from Services that the client is not authorized
+to see.
 
-##### Returns
+##### `/types/{type}`
 
-Upon successful processing, the response MUST be a JSON array of `type` entity
-objects.
+Retrieves an individual type entity by exact match on the `type` value. Type
+values MUST conform to the [CloudEvents type](./spec.md#type) attribute
+specification.
 
-#### `/types?matching=[search term]`
 
-MUST return a list of all Types in the discovery system. If the matching query
-parameter is specified then the returned list MUST only include Types that match
-the search term value.
+##### `/types?matching=[search term]`
 
-##### matching
+Same as `/types` but the array MUST be limited to just those Types
+whose value contains the `search term` value (case insensitive).
+
+###### matching
 
 * Type: `string`
-* Description: Search term that provides case insensitive match against `type`
-  names. The parameter can match any portion of the type name.
+* Description: Search term that provides case insensitive match against
+  the Type's value. The parameter can match any portion of the value.
 * Constraints:
   * OPTIONAL
   * If present, MUST be non-empty
@@ -567,39 +494,6 @@ the search term value.
     * matches:
       * `"com.storage.object.create"`
 
-##### Returns
-
-A JSON array of `type` entities.
-
-#### `/types/{name}`
-
-Retrieves an individual type entity by exact match on the `type` name. Type
-names MUST conform to the [CloudEvents type](./spec.md#type)
-attribute specification.
-
-##### Returns
-
-A `type` entity as a JSON object.
-
-#### `/types/{name}/services`
-
-Retrieves the details about services that offer the specified `type`.
-
-##### Returns
-
-A JSON array of `service` entities.
-
-#### `/producer/{service.name}/{type.name}`
-
-Retrieves the `producer` entity that specifies the information necessary to
-create subscriptions and to consume the events. The `service.name` and
-`type.name` items in the request path make up the composite key for the
-information that can be obtained via the `/service` and `/type` API calls.
-
-##### Returns
-
-A `producer` entity as a JSON object.
-
 
 ## Protocol Bindings
 
@@ -607,17 +501,17 @@ The discovery API can be implemented over different API systems. We provide
 API schema definitions for implementing this API using OpenAPI and gRPC as
 illustrative examples.
 
-### REST, JSON HTTP API
+### HTTP Binding
 
-All responses will have a content-type of `application/json` and are either
-a single JSON encoded object or an array of objects.
+When using JSON, the HTTP `Content-Type` value MUST be `application/json`.
 
 ### OpenAPI
 
-**TODO**
+...
 
 ## Privacy and Security
 
-The CloudDiscovery API does not place restrictions on producers choice of an
-authentication and authorization mechanism. Discovery output MAY be different
-for different principals.
+The CloudDiscovery API does not place restrictions on implementation's choice
+of an authentication and authorization mechanism. While the list of entities
+returned from each query MAY differ, the format of the output MUST adhere
+to this specification.

--- a/discovery.md
+++ b/discovery.md
@@ -3,7 +3,7 @@
 ## Abstract
 
 CloudSubscriptions Discovery API is a vendor-neutral API specification for
-determining what events are available from a particular system, as well as
+determining what events are available from a particular service, as well as
 how to subscribe to those events.
 
 ## Status of this document
@@ -21,10 +21,10 @@ version.
 
 ## Overview
 
-In order for consumers to receive events from event producers, they need
-to first subscribe, or ask for, events from those producers. To do so, there
+In order for consumers to receive events from services, they need
+to first subscribe, or ask for, events from those services. To do so, there
 is often a process necessary that involves steps such as discovering which
-event producer is of interest, what events it generates and how to create the
+service is of interest, what events it generates and how to create the
 subscription for those events.
 
 This specification defines a set of APIs to allow for consumers to perform
@@ -33,7 +33,7 @@ as a catalog of [Services](#service) (event producers), that consumers can
 query to find the ones of interest. Once found, additional metadata is
 provided in order to consume and subscribe to events. The goal
 of this API is to be such that tooling can be built where all all possible
-event producers and event types aren't known in advance.
+services and event types aren't known in advance.
 
 The deployment relationship of a Discovery Endpoint to the Services and
 Event Producers that it advertises is out of scope of this specification.
@@ -50,8 +50,8 @@ consumers.
 The second case becomes relevant if multiple services support the same event
 types. Use case 1 is likely the dominant use case. Given the example of a public
 cloud provider where all services generate events, there might be dozens of
-sources (producer systems) and hundreds of event types. The discovery funnel of
-serviecs first, then event types helps users navigate without having to see
+sources and hundreds of event types. The discovery funnel of
+services first, then event types helps users navigate without having to see
 large lists of event types. Both of these cases show the importance of using
 filters in the discovery API to narrow down the selection of available events.
 
@@ -147,7 +147,7 @@ Service:
   "name": "[unique name for this services]",
   "description": "[human string]", ?
   "docsurl": "[URL reference for human documentation]", ?
-  "specversion": "[ce-specversion value]",
+  "specversions": [ "[ce-specversion value]" + ],
   "subscriptionurl": "[URL to which the Subscribe request will be sent]",
   "subscriptionconfig": { ?
     "[key]": "[value]", *
@@ -178,7 +178,7 @@ An example:
 ```json
 {
   "url": "https://example.com/services/widgetService",
-  "specversion": "1.0",
+  "specversions": [ "1.0" ],
   "subscriptionurl": "https://events.example.com",
   "protocols": [ "HTTP" ],
   "type": [
@@ -245,14 +245,14 @@ entity.
 - Examples:
   - `http://cloud.example.com/docs/blobstorage`
 
-###### specversion
+###### specversions
 
-- Type: `String` per [RFC 2046](https://tools.ietf.org/html/rfc2046)
-- Description: CloudEvents [`specversion`](https://github.com/cloudevents/spec/blob/master/spec.md#specversion)
-  that will be used for events published for this service.
+- Type: Array of `Strings` per [RFC 2046](https://tools.ietf.org/html/rfc2046)
+- Description: CloudEvents [`specversions`](https://github.com/cloudevents/spec/blob/master/spec.md#specversion)
+  that can be used for events published for this service.
 - Constraints:
   - REQUIRED
-  - MUST be a non-empty string
+  - MUST be a non-empty array or non-empty strings
 
 ###### subscriptionurl
 
@@ -400,7 +400,7 @@ entity.
   "types": [
     {
       "type": "com.example.storage.object.create",
-      "specversion": "1.x-wip",
+      "specversions": [ "1.x-wip" ],
       "datacontenttype": "application/json",
       "dataschema": "http://schemas.example.com/download/com.example.storage.object.create.json"
     }

--- a/discovery.md
+++ b/discovery.md
@@ -29,15 +29,9 @@ subscription for those events.
 
 This specification defines a set of APIs to allow for consumers to perform
 these queries against a "Discovery Endpoint". A Discovery Endpoint acts
-as a catalog of:
-  - [Services](#service)
-  - [Event Producers](#producer-ce)
-  - Event Types
-overwhich consumers can query to find the Event Producer of interest, and
-to which it can create a Cloud Subscription.
-
-Which means, once the Event Producer of interest is located, additional
-metadata is provided in order to consume and subscribe to events. The goal
+as a catalog of [Services](#service) (event producers), that consumers can
+query to find the ones of interest. Once found, additional metadata is
+provided in order to consume and subscribe to events. The goal
 of this API is to be such that tooling can be built where all all possible
 event producers and event types aren't known in advance.
 
@@ -50,14 +44,14 @@ of this metadata. This implementation detail will be transparent to consumers.
 There are several discovery use cases to consider from the viewpoint of event
 consumers.
 
-1. What event producers are available, and what event types do they generate?
-2. What event types are available, and from which event producers?
+1. What services are available, and what event types do they generate?
+2. What event types are available, and from which services?
 
-The second case becomes relevant if multiple producers support the same event
+The second case becomes relevant if multiple services support the same event
 types. Use case 1 is likely the dominant use case. Given the example of a public
-cloud provider where all producers generate events, there might be dozens of
+cloud provider where all services generate events, there might be dozens of
 sources (producer systems) and hundreds of event types. The discovery funnel of
-producer first, then event types helps users navigate without having to see
+serviecs first, then event types helps users navigate without having to see
 large lists of event types. Both of these cases show the importance of using
 filters in the discovery API to narrow down the selection of available events.
 
@@ -97,7 +91,7 @@ Event Subcription.
 
 A "service" represents the entity which manages one or more event
 [sources](#source-ce) and is associated with [producers](#producer-ce)
-that generate events.
+that are responsible for the generatation of events.
 
 For example, an Object Store service might have a set of event sources
 where each event source maps to a bucket.
@@ -129,7 +123,7 @@ to execute some logic, which might lead to the occurrence of new events.
 
 #### Subscription
 
-The request for events from an Event Producer system.
+The request for events from a Service.
 
 
 ## API Specification
@@ -141,45 +135,58 @@ relationships between those entities.
 
 At the core of the data model is the concept of a [Service](#service). The
 API then exposes multiple ways to query over a list of Services. To help
-explain the Service resource, the following non-normative pseudo yaml shows
+explain the Service resource, the following non-normative pseudo json shows
 its basic structure:
 
-( `*` means zero or more, `+` means one or more, `?` means optional)
+(`*` means zero or more, `+` means one or more, `?` means optional)
 
 Service:
 ```
-id: [unique URI]
-description: [human string] ?
-docsuri: [URI reference for human documentation] ?
-specversion: [ce-speciversion value] ? (required?)
-subscriptionuri: [URI to which the Subscribe request will be sent]
-subscriptionconfig: *
-authscope: [string] ?  (explain)
-protocols: +
-- protocol: [string]
-types: *
-- type: [ce-type value]
-  description: [human string] ?
-  datacontenttype: [ce-datacontenttype value] ?
-  dataschema: [ce-dataschema URI] ?
-  dataschematype: [string per RFC 2046] ?
-  dataschemacontent: [schema] ?
-  dataschemacontent:
-  extensions: *
-  - name: [CE context attribute name]
-    type: [CE type string]
-    spec: [URI to specification defining the extension] ?
+{
+  "url": "[unique URL to this service]",
+  "description": "[human string]", ?
+  "docsurl": "[URL reference for human documentation]", ?
+  "specversion": "[ce-specversion value]",
+  "subscriptionurl": "[URL to which the Subscribe request will be sent]",
+  "subscriptionconfig": { ?
+    "[key]": "[value]", *
+  },
+  "authscope": "[string]", ?
+  "protocols": [ "[string]" + ],
+  "types": [ ?
+    { *
+      "type": "[ce-type value]",
+      "description": "[human string]", ?
+      "datacontenttype": "[ce-datacontenttype value]", ?
+      "dataschema": "[ce-dataschema URI]", ?
+      "dataschematype": "[string per RFC 2046]", ?
+      "dataschemacontent": "[schema]", ?
+      "extensions": [ ?
+        { *
+          "name": "[CE context attribute name]",
+          "type": "[CE type string]",
+          "specurl": "[URL to specification defining the extension]" ?
+        }
+      ]
+    }
+  ]
+}
 ```
 
 An example:
-```
-id: example.com
-subscriptionuri: https://events.example.com
-protocols:
-- protocol: HTTP
-types:
-- type: com.example.widget.create
-- type: com.example.widget.delete
+```json
+{
+  "url": "https://example.com/services/widgetService",
+  "specversion": "v1.0",
+  "subscriptionurl": "https://events.example.com",
+  "protocols": [ "HTTP" ],
+  "type": [
+    {
+      "type": "com.example.widget.create",
+      "type": "com.example.widget.delete"
+    }
+  ]
+}
 ```
 
 Note: the above is just a sample and implementations are free to use any
@@ -188,21 +195,34 @@ with the wire format/API defined by this specification.
 
 #### Service Attributes
 
-The following sections define the attributes that appear on a Service
+The following sections define the attributes that appear in a Service
 entity.
 
-##### id
-
-- Type: `URI`
-- Description: A unique, within the scope of this Discovery Endpoint, URI
-  that identifies the Service.
+##### name
+- Type: `String`
+- Description: A unique identifier for this Service. This value MUST be
+  unique within the scope of this Discovery Endpoint.
 - Constraints:
   - REQUIRED
-  - MUST be a non-empty URI
+  - MUST be a valid `fsegment` per RFC1738.
 - Examples:
-  - cloudstorage.com
-  - github.com
-  - "com.example.microservices.userlogin"
+  - `storage`
+  - `github`
+
+##### url
+
+- Type: `URL`
+- Description: A URL that references this Service. This value MUST
+  be usable in subsequent requests, by authorized clients, to retrieve this
+  Service entity.
+- Constraints:
+  - REQUIRED
+  - MUST be a non-empty URL
+  - MUST end with `fsegments` (per RFC1738) of: `/services/{name}` where
+    `name` is the Service's `name` attribute.
+- Examples:
+  - `http://example.com/services/storage`
+  - `http://discovery.github.com/services/github`
 
 ##### description (Service)
 
@@ -212,33 +232,32 @@ entity.
   - OPTIONAL
   - If present, MUST be a non-empty string
 
-##### docsuri
+##### docsurl
 
-- Type: `URI`
-- Description: Absolute URI that provides a link back to the producer, or
-  documentation about the producer. This is intended for a developer to
-  use in order to learn more about this service events produced.
+- Type: `URL`
+- Description: Absolute URL that provides a link to additional documentation
+  about the service.  This is intended for a developer to
+  use in order to learn more about this service's events produced.
 - Constraints:
   - OPTIONAL
   - If present, MUST be a non-empty absolute URI
 - Examples:
-  - "http://cloud.example.com/docs/blobstorage"
+  - `http://cloud.example.com/docs/blobstorage`
 
 ###### specversion
 
 - Type: `String` per [RFC 2046](https://tools.ietf.org/html/rfc2046)
 - Description: CloudEvents [`specversion`](https://github.com/cloudevents/spec/blob/master/spec.md#specversion)
-  that will be used for events published for this producer, event type
-  combination.
+  that will be used for events published for this service.
 - Constraints:
   - REQUIRED
   - MUST be a non-empty string
 
-###### subscriptionuri
+###### subscriptionurl
 
-- Type: `URI-reference`
-- Description: URI indicating where CloudSubscriptions `subscribe` API calls
-  MUST be sent to.
+- Type: `URL`
+- Description: An absolute URL indicating where CloudSubscriptions `subscribe`
+  API calls MUST be sent to.
 - Constraints:
   - REQUIRED
 
@@ -253,16 +272,17 @@ entity.
 - Constraints:
   - OPTIONAL
 - Examples:
+  - ??
 
 ###### authscope
 
 - Type: `String`
 - Description: Authorization scope needed for creating subscriptions.
-  The actual meaning of this field is determined on a per-producer basis.
+  The actual meaning of this field is determined on a per-service basis.
 - Constraints:
   - OPTIONAL
 - Example:
-  - "storage.read"
+  - `storage.read`
 
 ###### protocols
 
@@ -271,27 +291,28 @@ entity.
   in the `protocol` field of the CloudSubscriptions API. The protocols with
   existing CloudEvents bindings are identified as AMQP, MQTT3, MQTT5, HTTP,
   KAFKA, and NATS. An implementation MAY add support for further
-  protocols. All producers MUST support at least one delivery protocol, and MAY
+  protocols. All services MUST support at least one delivery protocol, and MAY
   support additional protocols.
 - Constraints:
   - REQUIRED
   - MUST be non-empty.
 - Examples:
-  - ["HTTP"]
-  - ["HTTP", "AMQP", "KAFKA"]
+  - `[ "HTTP" ]`
+  - `[ "HTTP", "AMQP", "KAFKA" ]`
 
 ##### type
 
 - Type: `String`
-- Description: CloudEvents [`type`](https://github.com/cloudevents/spec/blob/master/spec.md#type)
+- Description: CloudEvents
+  [`type`](https://github.com/cloudevents/spec/blob/master/spec.md#type)
   attribute.
 - Constraints:
   - REQUIRED
   - MUST be a non-empty string, following the constraints as defined in the
     CloudEvents spec.
 - Examples:
-  - "com.github.pull.create"
-  - "com.example.object.delete.v2"
+  - `com.github.pull.create`
+  - `com.example.object.delete.v2`
 
 ##### description (Type)
 
@@ -332,7 +353,7 @@ entity.
   - If present, MUST adhere to the format specified in
     [RFC 2046](https://tools.ietf.org/html/rfc2046)
 - Examples:
-  - "application/json"
+  - `application/json`
 
 ##### dataschemacontent
 
@@ -349,7 +370,8 @@ entity.
 ###### extensions
 
 - Type: `Map` of `String` to `String`
-- Description: Associative map of CloudEvents [Extension Context Attributes](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes)
+- Description: Associative map of CloudEvents
+  [Extension Context Attributes](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes)
   that are used for this event `type`. Keys MUST be confirm to the extension
   context attributes naming rules and value are the type of the extension
   attribute, conforming to the CloudEvents [type system](./spec.md#type-system).
@@ -360,14 +382,17 @@ entity.
 
 ```json
 {
-  "id": "com.example.storage",
+  "url": "https://storage.example.com/service/storage",
+  "name": "storage",
   "description": "Blob storage in the cloud",
   "service_uri": "https://cloud.example.com/docs/storage",
   "types": [
-    "type": "com.example.storage.object.create",
-    "specversion": "1.x-wip",
-    "datacontenttype": "application/json",
-    "dataschema": "http://schemas.example.com/download/com.example.storage.object.create.json"
+    {
+      "type": "com.example.storage.object.create",
+      "specversion": "1.x-wip",
+      "datacontenttype": "application/json",
+      "dataschema": "http://schemas.example.com/download/com.example.storage.object.create.json"
+    }
   ]
 }
 ```
@@ -375,51 +400,71 @@ entity.
 
 ### REST Paths
 
-Each path in the REST API represents either represents a list (or search) over
-and entity class, or the retrieval of an individual entity by name. Each of
+Each path in the REST API represents either a list (or search) over
+the Discovery Endpoint, or the retrieval of an individual entity. All of
 these operations MUST be supported by compliant discovery implementations.
 
+Note: the relative paths specified below are NOT REQUIRED to be at the root
+of the `fpath` (per RFC1738). However, they are REQUIRED to match the end
+of it. For example, the follow are valid URLs/paths:
+
+```
+https://example.com/services
+https://example.com/myAggregator/services
+```
+
+Note: for each query if the client is not authorized to see any particular
+entity then that entity MUST be excluded from the response. In cases where
+response is a single entity, then the response MUST result in an error
+as if the entity did not exist (e.g. for HTTP the response would be 
+`404 Not Found`). In cases where the response is an array, then the response
+MUST return a successful status with an array, even if that array is empty.
+
 #### Services
-
-The following API query patterns are defined.
-
-For each, upon succesful processing, the response MUST be a JSON array with
-zero or more Service entities.
-
-When encoded in JSON, the format MUST adhere to the following:
-
-```
-[
-  {
-    "id": "SERVICE-ID",
-    ... remainder of Service attributes ...
-  },
-  ...
-]
-```
 
 #### `/services`
 
 This MUST return an array of zero or more Services. The list MUST contain
-all Services that the client is authorized to see. The list MUST NOT contain
-any Services that the client is not authorized to see.
+all Services available via this Discovery Enpoint.
 
-##### `/services/{id}`
+When encoded in JSON, the response format MUST adhere to the following:
 
-Same as `/services` but the array MUST be limited to at most one, the entity
-whose `id` matches the value specified.
+```
+[
+  {
+    "url": "SERVICE-URL",
+    "name": "{name}",
+    ... remainder of Service attributes ...
+  }
+  ...
+]
+```
+
+##### `/services/{name}`
+
+If this refers to a valid Service, then this MUST return that single
+Service entity.
+
+When encoded in JSON, the response format MUST adhere to the following:
+
+```
+{
+  "url": "SERVICE-URL",
+  "name": "{name}",
+  ... remainder of Service attributes ...
+}
+```
 
 ##### `/services?matching=[search term]`
 
 Same as `/services` but the array MUST be limited to just those Services
-whose `description` attribute contains the `search term` value (case
-insensitive).
+whose `name` attribute contains the `search term` value (case insensitive).
 
 ###### matching
 
 * Type: `string`
 * Description: Search term that provides case insensitive match against
-  the Service's `description` attribute. The parameter can match any portion
+  the Service's `name` attribute. The parameter can match any portion
   of the service's `description` value.
 * Constraints:
   * OPTIONAL
@@ -434,37 +479,47 @@ insensitive).
 
 #### Types
 
-The following API query patterns are defined.
+##### `/types`
 
-For each, upon succesful processing, the response MUST be a JSON array with
-zero or more Type values, each with the list of Service entities that
-support that Type.
+This MUST return an array of zero or more Types values, where each Type's
+value is an array of Services that support that Type.
 
-When encoded in JSON, the format MUST adhere to the following:
+When encoded in JSON, the response format MUST adhere to the following:
 
 ```
 [
-  "TYPE-VALUE": {
-    "id": "SERVICE-ID",
-    ... remainder of Service attributes ...
-  },
+  "TYPE-VALUE": [
+    {
+      "url": "SERVICE-url",
+      "name: "{name}",
+      ... remainder of Service attributes ...
+    }
+    ...
+  ]
   ...
 ]
 ```
 
-##### `/types`
-
-This MUST return an array of zero or more Types values. The list MUST contain
-all Types values from all Services that the client is authorized to see. It
-MUST NOT container Type values from Services that the client is not authorized
-to see.
-
 ##### `/types/{type}`
 
-Retrieves an individual type entity by exact match on the `type` value. Type
-values MUST conform to the [CloudEvents type](./spec.md#type) attribute
-specification.
+This MUST returns an array of one or more Services that support the Type value
+specified. Type value MUST conform to the [CloudEvents type](./spec.md#type)
+attribute specification.
 
+When encoded in JSON, the response format MUST adhere to the following:
+
+```
+{
+  "TYPE-VALUE": [
+    {
+      "url": "SERVICE-url",
+      "name: "{name}",
+      ... remainder of Service attributes ...
+    }
+    ...
+  ]
+}
+```
 
 ##### `/types?matching=[search term]`
 
@@ -504,6 +559,8 @@ illustrative examples.
 ### HTTP Binding
 
 When using JSON, the HTTP `Content-Type` value MUST be `application/json`.
+
+...
 
 ### OpenAPI
 


### PR DESCRIPTION
- Restructued things so that it didn't feel like we were repeating the
      definition of the attributes. For example, we now just define Service
      and its attributes once and then simply point back to that, and its
      serialization, from the Query section
- got rid of "provider" in the model. Technically, that's an impl detail
      and consumers should not care what generated the CE - it's things like
      the source and service that they'll care about (or even know about)
- introduced the term "Discovery Endpoint" as the "thing" that implements
      the spec
- started an JSON encoding definition
- Modified the query stuff so that all data is returned in one shot.
      I believe the current spec implied that people would need to do one
      query to get the list of Types of interest and then another one to pull
      back the details of each Service. I think it's more natural to do it all
      in one. If this is too large then we should consider query flags to
      indicate if people want the deep result-set or an shallow result-set.
    - I made Service and Type have a non-human friendly main keys since names
      will change over time but these keys need to be static and therefore
      machine usable. `description` can be used for human readable names.
    
Probably other minor things that I can't remember. I basically just
went from top to bottom touching stuff that felt odd as I was reading
but I think it's closer now to being something that someone could
sit down and implement w/o too many gaps.
    
Signed-off-by: Doug Davis <dug@us.ibm.com>