### PR TITLE
SDK governance draft

### DIFF
--- a/governance/SDK.md
+++ b/governance/SDK.md
@@ -30,13 +30,13 @@ We define an SDK project _healthy_ if:
 
 We define a project `cloudevents/sdk-x` _not actively maintained_ if:
 
-6. No commits on master from `sdk-x-maintainers` since 4 months
-7. Issues and/or PRs are not being triaged from `sdk-x-mantainers` since 2
-   months
-8. Security patches are not being **released** from `sdk-x-mantainers` since 1
+6. No commits on master from `sdk-x-maintainers` for 4 months
+7. Issues and/or PRs are not being triaged from `sdk-x-mantainers` for 2 months
+8. Security patches are not being **released** from `sdk-x-mantainers` for 1
    months from CVE disclosures
 
-To prevent the project from becoming _not actively maintained_, the community MAY takes the following actions:
+To prevent the project from becoming _not actively maintained_, the community
+MAY takes the following actions:
 
 - Temporary security patches delivered by an _sdk maintainer_ not part of
   `sdk-x-maintainers` group
@@ -51,8 +51,9 @@ in criteria 8, the community could decide to entitle one or more members from
 the larger _sdk maintainers_ group to perform security patches and release new
 minor versions of the project.
 
-Because the people entitled to perform security patches need write permissions on the repository, the community MUST temporarily grant these permissions.
-After the release of the patch, these permissions MUST be revoked.
+Because the people entitled to perform security patches need write permissions
+on the repository, the community must temporarily grant these permissions. After
+the release of the patch, these permissions must be revoked.
 
 Because of the urgent nature of security patches, an _informal_ vote during the
 CloudEvents SDK meeting is enough to assign the security patch to the _sdk
@@ -63,36 +64,42 @@ enhancements.
 
 ### Handover to a new maintainer/group of maintainers
 
-If a project is not meeting the criteria 1, 2, 4, 5, 6, 7, 8, the community
-MAY decides to handover the project to a new maintainer/group of
-maintainers. The community can perform the handover to a new maintainer
-if all the following conditions are met:
+If a project is not meeting the criteria 1, 2, 4, 5, 6, 7, 8, the community MAY
+decides to handover the project to a new maintainer/group of maintainers. The
+community can perform the handover to a new maintainer if all the following
+conditions are met:
 
-* A vote to add the new maintainer MUST have **already taken place** with
-  all people entitled to vote abstaining.
-* One of the following conditions had been met:
-  * The new maintainer(s) already meet the requirements enlisted in [New maintainers section](#new-maintainers)
-  * The new maintainer(s) performed the required PRs, Reviews and Code changes to meet the [New maintainers criteria](#new-maintainers) but they were unable to merge them due to inactivity of the current maintainer(s).
+- A vote to add the new maintainer must have **already taken place** with all
+  people entitled to vote abstaining.
+- One of the following conditions had been met:
+  - The new maintainer(s) already meet the requirements enlisted in
+    [New maintainers section](#new-maintainers)
+  - The new maintainer(s) performed the required PRs, Reviews and Code changes
+    to meet the [New maintainers criteria](#new-maintainers) but they were
+    unable to merge them due to inactivity of the current maintainer(s).
 
 The new maintainer must show the good will to keep the project healthy and
 community could ask for an eventual plan to improve the quality of the project.
 
-Once a new maintainer is identified, the community can proceed with a vote
-to handover the project using the
+Once a new maintainer is identified, the community can proceed with a vote to
+handover the project using the
 [Asynchronous voting process](#asynchronous-voting-process). If more than one
-new maintainer wants to handover the project, separate voting process must be
-done for all of them, and both of them must follow the same voting criteria (and
+new maintainer wants to maintain the project, separate voting process must be
+done for all of them, and all of them must follow the same voting criteria (and
 not the ones from [New maintainers section](#new-maintainers)).
 
 The voting criteria are:
 
 - 1 week to vote
-- 2/3 of the agreement to accept the vote
+- At least 2/3 of the votes cast agree to the proposal
 - All _sdk maintainers_ are entitled to vote
 
 ### Archive a project
 
-If a project is not following the criteria 1, 2, 4, 5, 6, 7, 8, the community MAY decides to archive the project. Prior to archiving, the community SHOULD first consider performing a search for a new maintainer to [handover the project](#handover-to-a-new-maintainergroup-of-maintainers).
+If a project is not following the criteria 1, 2, 4, 5, 6, 7, 8, the community
+MAY decides to archive the project. Prior to archiving, the community SHOULD
+first consider performing a search for a new maintainer to
+[handover the project](#handover-to-a-new-maintainergroup-of-maintainers).
 
 If no new maintainer is found, the community can proceed to archive the project
 using the [Asynchronous voting process](#asynchronous-voting-process).
@@ -100,7 +107,7 @@ using the [Asynchronous voting process](#asynchronous-voting-process).
 The voting criteria are:
 
 - 2 weeks to vote
-- 2/3 of the agreement to accept the vote
+- At least 2/3 of the votes cast agree to the proposal
 - All _sdk maintainers_ are entitled to vote
 
 ## Asynchronous voting process
@@ -114,13 +121,14 @@ The voting is defined by:
 - The set of people/groups entitled to vote
 - A voting period
 - The percentage of agreements required to accept the change
-- A voting manager, a member of the community entitled to manage the vote. The voting manager MUST be part of people entitled to vote.
+- A voting manager, a member of the community entitled to manage the vote. The
+  voting manager must be part of people entitled to vote.
 
 To start a vote, the voting manager opens an issue in the
 [CloudEvents Spec](https://github.com/cloudevents/spec/issues) with:
 
 - A binary question to be voted on
-- Tags of the entitled people/groups to vote (depending on the question)
+- Github IDs of people who are entitled to vote
 - The expiration date of the vote
 - The percentage of agreements to accept the change
 
@@ -145,16 +153,16 @@ ensure visibility to the voting, people should be remembered to vote during
 Serverless WG meetings and community channels (Slack, ...).
 
 At the end of the voting period, the voting manager will count the votes,
-writing on the issue the results. Votes after the expiration date MUST not be
+writing on the issue the results. Votes after the expiration date must not be
 considered; To calculate the agreement percentage, the voting manager should
 account the people who have expressed a vote, without taking in account the
 abstentions.
 
-If the vote passes, the voting manager should proceed with the change. If the vote
-does not pass, then a new vote for the same change MUST NOT happen for the
+If the vote passes, the voting manager should proceed with the change. If the
+vote does not pass, then a new vote for the same change must NOT happen for the
 next 6 months.
 
-This voting process MUST be used only to resolve the issues identified in this
+This voting process must be used only to resolve the issues identified in this
 document:
 
 - Change to the rules in this document

--- a/governance/SDK.md
+++ b/governance/SDK.md
@@ -30,10 +30,15 @@ We define an SDK project _healthy_ if:
 
 We define a project `cloudevents/sdk-x` _not actively maintained_ if:
 
-6. No commits on master from `sdk-x-maintainers` for 4 months
-7. Issues and/or PRs are not being triaged from `sdk-x-mantainers` for 2 months
-8. Security patches are not being **released** from `sdk-x-mantainers` for 1
+6. Issues and/or PRs are not being triaged from `sdk-x-mantainers` for 2 months
+7. Security patches are not being **released** from `sdk-x-mantainers` for 1
    months from CVE disclosures
+
+It may happen that there has been no necessary activity within the SDK for at
+least 4 months. The other SDK maintainers will evaluate what "no necessary
+activity" means, but often this could mean "no commits", or "no issue
+discussions". However, if the SDK is stable and does not need to be update then
+it might be determined that it current state is acceptable.
 
 To prevent the project from becoming _not actively maintained_, the community
 MAY takes the following actions:
@@ -47,7 +52,7 @@ MAY takes the following actions:
 
 If a project `cloudevents/sdk-x` meets _healthy_ criteria 1, 2, 4, but the
 `sdk-x-maintainers` group is not actively performing security patches as defined
-in criteria 8, the community could decide to entitle one or more members from
+in criteria 7, the community could decide to entitle one or more members from
 the larger _sdk maintainers_ group to perform security patches and release new
 minor versions of the project.
 
@@ -64,7 +69,7 @@ enhancements.
 
 ### Handover to a new maintainer/group of maintainers
 
-If a project is not meeting the criteria 1, 2, 4, 5, 6, 7, 8, the community MAY
+If a project is not meeting the criteria 1, 2, 4, 5, 6, 7, the community MAY
 decides to handover the project to a new maintainer/group of maintainers. The
 community can perform the handover to a new maintainer if all the following
 conditions are met:
@@ -96,9 +101,9 @@ The voting criteria are:
 
 ### Archive a project
 
-If a project is not following the criteria 1, 2, 4, 5, 6, 7, 8, the community
-MAY decides to archive the project. Prior to archiving, the community SHOULD
-first consider performing a search for a new maintainer to
+If a project is not following the criteria 1, 2, 4, 5, 6, 7, the community MAY
+decides to archive the project. Prior to archiving, the community SHOULD first
+consider performing a search for a new maintainer to
 [handover the project](#handover-to-a-new-maintainergroup-of-maintainers).
 
 If no new maintainer is found, the community can proceed to archive the project

--- a/governance/SDK.md
+++ b/governance/SDK.md
@@ -25,7 +25,7 @@ We define an SDK project _healthy_ if:
 2. It supports the latest versions of the integrated libraries/frameworks
 3. It receives security patches regularly
 4. It supports the last N-1 major versions of CloudEvents spec, as defined in
-   [Contribution Acceptance](../SDK.md#Contribution-Acceptance)
+   [Contribution Acceptance](../SDK.md#contribution-acceptance)
 5. Issues and PRs are triaged (labeled, commented, reviewed, etc) regularly
 
 We define a project `cloudevents/sdk-x` _not actively maintained_ if:

--- a/governance/SDK.md
+++ b/governance/SDK.md
@@ -1,0 +1,131 @@
+## SDK Community
+
+The community is organized as follows:
+
+* Every SDK has its own [Github Team](https://github.com/orgs/cloudevents/teams), for example `sdk-go-maintainers` is the group of mantainers for [cloudevents/sdk-go project](https://github.com/cloudevents/sdk-go)
+* The union of all the `sdk-*-maintainers` assembles the _sdk maintainers_ group
+
+## New maintainers
+
+TBD
+
+## Ensuring projects health
+
+In order to ensure the health of the SDK projects, we define the following actions.
+These are crucial to show the commitment of the community to develop and support these libraries, which are an important part of the CloudEvents ecosystem.
+
+We define an SDK project _healthy_ if:
+
+1. It works with the latest version of the programming language
+2. It supports the latest versions of the integrated libraries/frameworks
+3. It receives security patches regularly
+4. It supports the last N-1 major versions of CloudEvents spec, as defined in [Contribution Acceptance](../SDK.md#Contribution-Acceptance)
+5. Issues and PRs are triaged (labeled, commented, reviewed, etc) regularly
+
+We define a project `cloudevents/sdk-x` _not actively maintained_ if:
+
+6. No commits on master from `sdk-x-maintainers` since 4 months
+7. Issues and/or PRs are not being triaged from `sdk-x-mantainers` since 2 months
+8. Security patches are not being **released** from `sdk-x-mantainers` since 2 months
+
+To prevent projects _not actively maintained_, we define different actions the community might take: 
+
+* Temporary security patches delivered by an _sdk maintainer_ not part of `sdk-x-maintainers` group
+* Handover of the project to a new maintainer
+* Archive the project
+
+### Security patches
+
+If a project `cloudevents/sdk-x` meets _healthy_ criteria 1, 2, 4, but the `sdk-x-maintainers` group is not actively performing security patches as 
+defined in criteria 8, the community could decide to entitle one or more members from the larger _sdk maintainers_ group to perform security patches 
+and release new minor versions of the project.
+
+Because the people entitled to perform security patches needs write rights on the repo,
+the community MUST temporary assign him/them the rights to perform it.
+After the release of the patch, these rights MUST be removed from the member(s) who took care of it.
+
+Because of the urgency nature of security patches, an _informal_ vote during the CloudEvents SDK meeting is enough to assign the security patch to 
+the _sdk maintainer(s)_ which volunteers to take care of it.
+
+NOTE: this process is valid only for security patches, not for bugs or enhancements.
+
+### Handover to a new maintainer/group of maintainers
+
+It may happen that, if a project is not following the criteria 1, 2, 4, 5, 6, 7, 8, the community might decide to handover the project to a new maintainer/group of maintainers.
+The community can perform the handover to a new maintainer **iff** a voting process to add such maintainer was **already performed** with 100% of entitled people abstained and:
+
+* Or the new maintainer(s) already meet the requirements enlisted in [New maintainers section](#new-maintainers),
+* Or, because of the inactivity of the project due to criteria 7, the new maintainer(s) performed the required PRs/Reviews/Code changes to meet the [New maintainers criteria](#new-maintainers) but he/they wasn't/weren't able to merge them.
+
+The new maintainer must show the good will to keep the project healthy and community could ask for an eventual plan to improve the quality of the project.
+
+As soon as the new maintainer is identified, the community can proceed to vote to handover the project using the [Asynchronous voting process](#asynchronous-voting-process).
+If more than one new maintainer wants to handover the project, separate voting process must be done for all of them, and both of them must follow the same voting criteria (and not the ones from [New maintainers section](#new-maintainers)).
+
+The voting criteria are:
+
+* 1 week to vote
+* 2/3 of the agreement to accept the vote
+* All _sdk maintainers_ are entitled to vote
+
+### Archive a project
+
+It may happen that, if a project is not following the criteria 1, 2, 4, 5, 6, 7, 8, the community might decide to archive the project.
+Prior to archiving the project, the community should consider first to search a new maintainer to [handover the project](#handover-to-a-new-maintainergroup-of-maintainers).
+
+If no new maintainer is found, the community can proceed to archive the project using the [Asynchronous voting process](#asynchronous-voting-process).
+
+The voting criteria are:
+
+* 2 weeks to vote
+* 2/3 of the agreement to accept the vote
+* All _sdk maintainers_ are entitled to vote
+
+## Asynchronous voting process
+
+In order to ensure the democratic management of debates in the community, 
+we define an asynchronous voting process using GitHub issues.
+
+The voting is defined by:
+
+* The proposed community change to vote
+* The set of people/groups entitled to vote
+* A voting period
+* The percentage of agreements required to accept the change
+* A member of the community entitled to manage the vote, called voting manager. The voting manager MUST also be part of people entitled to vote.
+
+To start a vote, the voting manager opens an issue in the [CloudEvents Spec](https://github.com/cloudevents/spec/issues) with:
+
+* The binary question which explains the change
+* The tags to the entitled people/groups to vote (depending on the question)
+* The expiration date of the vote
+* The percentage of agreements to accept the change
+
+For example:
+
+> Question: Do you want to add "Paolo Rossi" @paolorossi as _sdk-go-maintainer_?
+>
+> Entitled to vote:
+> * @sdk-go-maintainers
+> 
+> Voting ends: 24th June 2020 12:00 CEST
+>
+> Required agreement: 50% + 1
+
+Then every person entitled can vote, up to the expiration date, commenting on the issue with a `+1` to express agreement or `-1` to express disagreement.
+Every comment except `+1` and `-1` won't be taken in account, because we expect that the voting process comes only after a debate on the change, developed on the community channels and Serverless WG/CloudEvents SDK meetings.
+In order to ensure visibility to the voting, people should be remembered to vote during Serverless WG meetings and community channels (Slack, ...).
+
+At the end of the voting period, the voting manager will count the votes, writing on the issue the results. 
+Votes after the expiration date MUST not be considered; To calculate the agreement percentage, the voting manager should 
+account the people who have expressed a vote, without taking in account the abstentions.
+
+If the vote pass, the voting manager should proceed with the change.
+If the vote does not pass, then a new voting for the same change can't be started for the next 6 months.
+
+This voting process MUST be used only to resolve the debates underlined in this document:
+
+* Change to the rules in this document
+* Add a new maintainer
+* Handover of a project to a new maintainer
+* Archive a project

--- a/governance/SDK.md
+++ b/governance/SDK.md
@@ -2,8 +2,11 @@
 
 The community is organized as follows:
 
-* Every SDK has its own [Github Team](https://github.com/orgs/cloudevents/teams), for example `sdk-go-maintainers` is the group of mantainers for [cloudevents/sdk-go project](https://github.com/cloudevents/sdk-go)
-* The union of all the `sdk-*-maintainers` assembles the _sdk maintainers_ group
+- Every SDK has its own
+  [Github Team](https://github.com/orgs/cloudevents/teams), for example
+  `sdk-go-maintainers` is the group of mantainers for
+  [cloudevents/sdk-go project](https://github.com/cloudevents/sdk-go)
+- The union of all the `sdk-*-maintainers` assembles the _sdk maintainers_ group
 
 ## New maintainers
 
@@ -11,121 +14,159 @@ TBD
 
 ## Ensuring projects health
 
-In order to ensure the health of the SDK projects, we define the following actions.
-These are crucial to show the commitment of the community to develop and support these libraries, which are an important part of the CloudEvents ecosystem.
+In order to ensure the health of the SDK projects, we define the following
+actions. These are crucial to show the commitment of the community to develop
+and support these libraries, which are an important part of the CloudEvents
+ecosystem.
 
 We define an SDK project _healthy_ if:
 
 1. It works with the latest version of the programming language
 2. It supports the latest versions of the integrated libraries/frameworks
 3. It receives security patches regularly
-4. It supports the last N-1 major versions of CloudEvents spec, as defined in [Contribution Acceptance](../SDK.md#Contribution-Acceptance)
+4. It supports the last N-1 major versions of CloudEvents spec, as defined in
+   [Contribution Acceptance](../SDK.md#Contribution-Acceptance)
 5. Issues and PRs are triaged (labeled, commented, reviewed, etc) regularly
 
 We define a project `cloudevents/sdk-x` _not actively maintained_ if:
 
 6. No commits on master from `sdk-x-maintainers` since 4 months
-7. Issues and/or PRs are not being triaged from `sdk-x-mantainers` since 2 months
-8. Security patches are not being **released** from `sdk-x-mantainers` since 1 months from CVE disclosures
+7. Issues and/or PRs are not being triaged from `sdk-x-mantainers` since 2
+   months
+8. Security patches are not being **released** from `sdk-x-mantainers` since 1
+   months from CVE disclosures
 
-To prevent projects _not actively maintained_, we define different actions the community might take: 
+To prevent projects _not actively maintained_, we define different actions the
+community might take:
 
-* Temporary security patches delivered by an _sdk maintainer_ not part of `sdk-x-maintainers` group
-* Handover of the project to a new maintainer
-* Archive the project
+- Temporary security patches delivered by an _sdk maintainer_ not part of
+  `sdk-x-maintainers` group
+- Handover of the project to a new maintainer
+- Archive the project
 
 ### Security patches
 
-If a project `cloudevents/sdk-x` meets _healthy_ criteria 1, 2, 4, but the `sdk-x-maintainers` group is not actively performing security patches as 
-defined in criteria 8, the community could decide to entitle one or more members from the larger _sdk maintainers_ group to perform security patches 
-and release new minor versions of the project.
+If a project `cloudevents/sdk-x` meets _healthy_ criteria 1, 2, 4, but the
+`sdk-x-maintainers` group is not actively performing security patches as defined
+in criteria 8, the community could decide to entitle one or more members from
+the larger _sdk maintainers_ group to perform security patches and release new
+minor versions of the project.
 
-Because the people entitled to perform security patches needs write rights on the repo,
-the community MUST temporary assign him/them the rights to perform it.
-After the release of the patch, these rights MUST be removed from the member(s) who took care of it.
+Because the people entitled to perform security patches needs write rights on
+the repo, the community MUST temporary assign him/them the rights to perform it.
+After the release of the patch, these rights MUST be removed from the member(s)
+who took care of it.
 
-Because of the urgency nature of security patches, an _informal_ vote during the CloudEvents SDK meeting is enough to assign the security patch to 
-the _sdk maintainer(s)_ which volunteers to take care of it.
+Because of the urgency nature of security patches, an _informal_ vote during the
+CloudEvents SDK meeting is enough to assign the security patch to the _sdk
+maintainer(s)_ which volunteers to take care of it.
 
-NOTE: this process is valid only for security patches, not for bugs or enhancements.
+NOTE: this process is valid only for security patches, not for bugs or
+enhancements.
 
 ### Handover to a new maintainer/group of maintainers
 
-It may happen that, if a project is not following the criteria 1, 2, 4, 5, 6, 7, 8, the community might decide to handover the project to a new maintainer/group of maintainers.
-The community can perform the handover to a new maintainer **iff** a voting process to add such maintainer was **already performed** with 100% of entitled people abstained and:
+It may happen that, if a project is not following the criteria 1, 2, 4, 5, 6, 7,
+8, the community might decide to handover the project to a new maintainer/group
+of maintainers. The community can perform the handover to a new maintainer
+**iff** a voting process to add such maintainer was **already performed** with
+100% of entitled people abstained and:
 
-* Or the new maintainer(s) already meet the requirements enlisted in [New maintainers section](#new-maintainers),
-* Or, because of the inactivity of the project due to criteria 7, the new maintainer(s) performed the required PRs/Reviews/Code changes to meet the [New maintainers criteria](#new-maintainers) but he/they wasn't/weren't able to merge them.
+- Or the new maintainer(s) already meet the requirements enlisted in
+  [New maintainers section](#new-maintainers),
+- Or, because of the inactivity of the project due to criteria 7, the new
+  maintainer(s) performed the required PRs/Reviews/Code changes to meet the
+  [New maintainers criteria](#new-maintainers) but he/they wasn't/weren't able
+  to merge them.
 
-The new maintainer must show the good will to keep the project healthy and community could ask for an eventual plan to improve the quality of the project.
+The new maintainer must show the good will to keep the project healthy and
+community could ask for an eventual plan to improve the quality of the project.
 
-As soon as the new maintainer is identified, the community can proceed to vote to handover the project using the [Asynchronous voting process](#asynchronous-voting-process).
-If more than one new maintainer wants to handover the project, separate voting process must be done for all of them, and both of them must follow the same voting criteria (and not the ones from [New maintainers section](#new-maintainers)).
+As soon as the new maintainer is identified, the community can proceed to vote
+to handover the project using the
+[Asynchronous voting process](#asynchronous-voting-process). If more than one
+new maintainer wants to handover the project, separate voting process must be
+done for all of them, and both of them must follow the same voting criteria (and
+not the ones from [New maintainers section](#new-maintainers)).
 
 The voting criteria are:
 
-* 1 week to vote
-* 2/3 of the agreement to accept the vote
-* All _sdk maintainers_ are entitled to vote
+- 1 week to vote
+- 2/3 of the agreement to accept the vote
+- All _sdk maintainers_ are entitled to vote
 
 ### Archive a project
 
-It may happen that, if a project is not following the criteria 1, 2, 4, 5, 6, 7, 8, the community might decide to archive the project.
-Prior to archiving the project, the community should consider first to search a new maintainer to [handover the project](#handover-to-a-new-maintainergroup-of-maintainers).
+It may happen that, if a project is not following the criteria 1, 2, 4, 5, 6, 7,
+8, the community might decide to archive the project. Prior to archiving the
+project, the community should consider first to search a new maintainer to
+[handover the project](#handover-to-a-new-maintainergroup-of-maintainers).
 
-If no new maintainer is found, the community can proceed to archive the project using the [Asynchronous voting process](#asynchronous-voting-process).
+If no new maintainer is found, the community can proceed to archive the project
+using the [Asynchronous voting process](#asynchronous-voting-process).
 
 The voting criteria are:
 
-* 2 weeks to vote
-* 2/3 of the agreement to accept the vote
-* All _sdk maintainers_ are entitled to vote
+- 2 weeks to vote
+- 2/3 of the agreement to accept the vote
+- All _sdk maintainers_ are entitled to vote
 
 ## Asynchronous voting process
 
-In order to ensure the democratic management of debates in the community, 
-we define an asynchronous voting process using GitHub issues.
+In order to ensure the democratic management of debates in the community, we
+define an asynchronous voting process using GitHub issues.
 
 The voting is defined by:
 
-* The proposed community change to vote
-* The set of people/groups entitled to vote
-* A voting period
-* The percentage of agreements required to accept the change
-* A member of the community entitled to manage the vote, called voting manager. The voting manager MUST also be part of people entitled to vote.
+- The proposed community change to vote
+- The set of people/groups entitled to vote
+- A voting period
+- The percentage of agreements required to accept the change
+- A member of the community entitled to manage the vote, called voting manager.
+  The voting manager MUST also be part of people entitled to vote.
 
-To start a vote, the voting manager opens an issue in the [CloudEvents Spec](https://github.com/cloudevents/spec/issues) with:
+To start a vote, the voting manager opens an issue in the
+[CloudEvents Spec](https://github.com/cloudevents/spec/issues) with:
 
-* The binary question which explains the change
-* The tags to the entitled people/groups to vote (depending on the question)
-* The expiration date of the vote
-* The percentage of agreements to accept the change
+- The binary question which explains the change
+- The tags to the entitled people/groups to vote (depending on the question)
+- The expiration date of the vote
+- The percentage of agreements to accept the change
 
 For example:
 
 > Question: Do you want to add "Paolo Rossi" @paolorossi as _sdk-go-maintainer_?
 >
 > Entitled to vote:
-> * @sdk-go-maintainers
-> 
+>
+> - @sdk-go-maintainers
+>
 > Voting ends: 24th June 2020 12:00 CEST
 >
 > Required agreement: 50% + 1
 
-Then every person entitled can vote, up to the expiration date, commenting on the issue with a `+1` to express agreement or `-1` to express disagreement.
-Every comment except `+1` and `-1` won't be taken in account, because we expect that the voting process comes only after a debate on the change, developed on the community channels and Serverless WG/CloudEvents SDK meetings.
-In order to ensure visibility to the voting, people should be remembered to vote during Serverless WG meetings and community channels (Slack, ...).
+Then every person entitled can vote, up to the expiration date, commenting on
+the issue with a `+1` to express agreement or `-1` to express disagreement.
+Every comment except `+1` and `-1` won't be taken in account, because we expect
+that the voting process comes only after a debate on the change, developed on
+the community channels and Serverless WG/CloudEvents SDK meetings. In order to
+ensure visibility to the voting, people should be remembered to vote during
+Serverless WG meetings and community channels (Slack, ...).
 
-At the end of the voting period, the voting manager will count the votes, writing on the issue the results. 
-Votes after the expiration date MUST not be considered; To calculate the agreement percentage, the voting manager should 
-account the people who have expressed a vote, without taking in account the abstentions.
+At the end of the voting period, the voting manager will count the votes,
+writing on the issue the results. Votes after the expiration date MUST not be
+considered; To calculate the agreement percentage, the voting manager should
+account the people who have expressed a vote, without taking in account the
+abstentions.
 
-If the vote pass, the voting manager should proceed with the change.
-If the vote does not pass, then a new voting for the same change can't be started for the next 6 months.
+If the vote pass, the voting manager should proceed with the change. If the vote
+does not pass, then a new voting for the same change can't be started for the
+next 6 months.
 
-This voting process MUST be used only to resolve the debates underlined in this document:
+This voting process MUST be used only to resolve the debates underlined in this
+document:
 
-* Change to the rules in this document
-* Add a new maintainer
-* Handover of a project to a new maintainer
-* Archive a project
+- Change to the rules in this document
+- Add a new maintainer
+- Handover of a project to a new maintainer
+- Archive a project

--- a/governance/SDK.md
+++ b/governance/SDK.md
@@ -26,7 +26,7 @@ We define a project `cloudevents/sdk-x` _not actively maintained_ if:
 
 6. No commits on master from `sdk-x-maintainers` since 4 months
 7. Issues and/or PRs are not being triaged from `sdk-x-mantainers` since 2 months
-8. Security patches are not being **released** from `sdk-x-mantainers` since 2 months
+8. Security patches are not being **released** from `sdk-x-mantainers` since 1 months from CVE disclosures
 
 To prevent projects _not actively maintained_, we define different actions the community might take: 
 

--- a/governance/SDK.md
+++ b/governance/SDK.md
@@ -36,8 +36,7 @@ We define a project `cloudevents/sdk-x` _not actively maintained_ if:
 8. Security patches are not being **released** from `sdk-x-mantainers` since 1
    months from CVE disclosures
 
-To prevent projects _not actively maintained_, we define different actions the
-community might take:
+To prevent the project from becoming _not actively maintained_, the community MAY takes the following actions:
 
 - Temporary security patches delivered by an _sdk maintainer_ not part of
   `sdk-x-maintainers` group
@@ -52,37 +51,33 @@ in criteria 8, the community could decide to entitle one or more members from
 the larger _sdk maintainers_ group to perform security patches and release new
 minor versions of the project.
 
-Because the people entitled to perform security patches needs write rights on
-the repo, the community MUST temporary assign him/them the rights to perform it.
-After the release of the patch, these rights MUST be removed from the member(s)
-who took care of it.
+Because the people entitled to perform security patches need write permissions on the repository, the community MUST temporarily grant these permissions.
+After the release of the patch, these permissions MUST be revoked.
 
-Because of the urgency nature of security patches, an _informal_ vote during the
+Because of the urgent nature of security patches, an _informal_ vote during the
 CloudEvents SDK meeting is enough to assign the security patch to the _sdk
-maintainer(s)_ which volunteers to take care of it.
+maintainer(s)_ who volunteers to take care of it.
 
 NOTE: this process is valid only for security patches, not for bugs or
 enhancements.
 
 ### Handover to a new maintainer/group of maintainers
 
-It may happen that, if a project is not following the criteria 1, 2, 4, 5, 6, 7,
-8, the community might decide to handover the project to a new maintainer/group
-of maintainers. The community can perform the handover to a new maintainer
-**iff** a voting process to add such maintainer was **already performed** with
-100% of entitled people abstained and:
+If a project is not meeting the criteria 1, 2, 4, 5, 6, 7, 8, the community
+MAY decides to handover the project to a new maintainer/group of
+maintainers. The community can perform the handover to a new maintainer
+if all the following conditions are met:
 
-- Or the new maintainer(s) already meet the requirements enlisted in
-  [New maintainers section](#new-maintainers),
-- Or, because of the inactivity of the project due to criteria 7, the new
-  maintainer(s) performed the required PRs/Reviews/Code changes to meet the
-  [New maintainers criteria](#new-maintainers) but he/they wasn't/weren't able
-  to merge them.
+* A vote to add the new maintainer MUST have **already taken place** with
+  all people entitled to vote abstaining.
+* One of the following conditions had been met:
+  * The new maintainer(s) already meet the requirements enlisted in [New maintainers section](#new-maintainers)
+  * The new maintainer(s) performed the required PRs, Reviews and Code changes to meet the [New maintainers criteria](#new-maintainers) but they were unable to merge them due to inactivity of the current maintainer(s).
 
 The new maintainer must show the good will to keep the project healthy and
 community could ask for an eventual plan to improve the quality of the project.
 
-As soon as the new maintainer is identified, the community can proceed to vote
+Once a new maintainer is identified, the community can proceed with a vote
 to handover the project using the
 [Asynchronous voting process](#asynchronous-voting-process). If more than one
 new maintainer wants to handover the project, separate voting process must be
@@ -97,10 +92,7 @@ The voting criteria are:
 
 ### Archive a project
 
-It may happen that, if a project is not following the criteria 1, 2, 4, 5, 6, 7,
-8, the community might decide to archive the project. Prior to archiving the
-project, the community should consider first to search a new maintainer to
-[handover the project](#handover-to-a-new-maintainergroup-of-maintainers).
+If a project is not following the criteria 1, 2, 4, 5, 6, 7, 8, the community MAY decides to archive the project. Prior to archiving, the community SHOULD first consider performing a search for a new maintainer to [handover the project](#handover-to-a-new-maintainergroup-of-maintainers).
 
 If no new maintainer is found, the community can proceed to archive the project
 using the [Asynchronous voting process](#asynchronous-voting-process).
@@ -122,14 +114,13 @@ The voting is defined by:
 - The set of people/groups entitled to vote
 - A voting period
 - The percentage of agreements required to accept the change
-- A member of the community entitled to manage the vote, called voting manager.
-  The voting manager MUST also be part of people entitled to vote.
+- A voting manager, a member of the community entitled to manage the vote. The voting manager MUST be part of people entitled to vote.
 
 To start a vote, the voting manager opens an issue in the
 [CloudEvents Spec](https://github.com/cloudevents/spec/issues) with:
 
-- The binary question which explains the change
-- The tags to the entitled people/groups to vote (depending on the question)
+- A binary question to be voted on
+- Tags of the entitled people/groups to vote (depending on the question)
 - The expiration date of the vote
 - The percentage of agreements to accept the change
 
@@ -159,11 +150,11 @@ considered; To calculate the agreement percentage, the voting manager should
 account the people who have expressed a vote, without taking in account the
 abstentions.
 
-If the vote pass, the voting manager should proceed with the change. If the vote
-does not pass, then a new voting for the same change can't be started for the
+If the vote passes, the voting manager should proceed with the change. If the vote
+does not pass, then a new vote for the same change MUST NOT happen for the
 next 6 months.
 
-This voting process MUST be used only to resolve the debates underlined in this
+This voting process MUST be used only to resolve the issues identified in this
 document:
 
 - Change to the rules in this document


### PR DESCRIPTION
As discussed in CloudEvents WG Meeting June 18, 2020, I started drafting some bits about the sdk projects governance, in particular regards:

* Keeping the projects healthy
* Handling situations where maintainers are not active
* Voting process

This PR doesn't cover the add/remove maintainers policies, which IMHO deserves a separate discussion, but the proposed document is meant to host them (I've added a blank section for them) 

All the numbers are drafted, I focused mainly on the criteria and the process.