### PR TITLE
typo and return type mismatch on /types endpoint for discovery spec

### DIFF
--- a/discovery.md
+++ b/discovery.md
@@ -505,13 +505,13 @@ whose `name` attribute contains the `search term` value (case insensitive).
 
 ##### `/types`
 
-This MUST return an array of zero or more Types values, where each Type's
+This MUST return a map of zero or more Types values, where each Type's
 value is an array of Services that support that Type.
 
 When encoded in JSON, the response format MUST adhere to the following:
 
 ```
-[
+{
   "TYPE-VALUE": [
     {
       "url": "SERVICE-url",
@@ -521,12 +521,12 @@ When encoded in JSON, the response format MUST adhere to the following:
     ...
   ]
   ...
-]
+}
 ```
 
 ##### `/types/{type}`
 
-This MUST returns an array of one or more Services that support the Type value
+This MUST returns a map of one or more Services that support the Type value
 specified. Type value MUST conform to the [CloudEvents type](./spec.md#type)
 attribute specification.
 
@@ -547,7 +547,7 @@ When encoded in JSON, the response format MUST adhere to the following:
 
 ##### `/types?matching=[search term]`
 
-Same as `/types` but the array MUST be limited to just those Types
+Same as `/types` but the map MUST be limited to just those Types
 whose value contains the `search term` value (case insensitive).
 
 ###### matching

--- a/discovery.md
+++ b/discovery.md
@@ -91,7 +91,7 @@ Event Subcription.
 
 A "service" represents the entity which manages one or more event
 [sources](#source-ce) and is associated with [producers](#producer-ce)
-that are responsible for the generatation of events.
+that are responsible for the generation of events.
 
 For example, an Object Store service might have a set of event sources
 where each event source maps to a bucket.


### PR DESCRIPTION
While implementing the discovery spec: https://github.com/cloudevents/sdk-javascript/pull/236

I notice the result of /types/* endpoint seems to be map instead of array, not sure if the intent was a map but seems more logical to me so did the change this way.

Another question that raised was the permission scheme, as I was unsure if we needed to filter types within the service object based on permission, I did implement this type of filtering as I supposed it is a possibility that we want to restrain the types of event visible for some audience