### PR TITLE
New sdk maintainers rules

### DIFF
--- a/community/SDK-GOVERNANCE.md
+++ b/community/SDK-GOVERNANCE.md
@@ -10,21 +10,33 @@ The community is organized as follows:
 
 ## New maintainers
 
-Maintainers are a crucial part of this community: they keep alive our projects and ensure both development and maintenance.
-We define a set of criteria, followed by a vote, to include an active contributor as maintainer of one or more sdk projects.
-The active contributor may propose himself to become a maintainer, although we encourage the community to include him as part of the group.
+Maintainers are a crucial part of this community: they keep alive our projects
+and ensure both development and maintenance. We define a set of criteria,
+followed by a vote, to include an active contributor as maintainer of one or
+more sdk projects. The active contributor may propose himself to become a
+maintainer, although we encourage the community to include him as part of the
+group.
 
-The criteria for a contributor to `sdk-x` to become part of `sdk-x-maintainers` is:
+The criteria for a contributor to `sdk-x` to become part of `sdk-x-maintainers`
+is:
 
 1. At least 20 reviews on eligible PRs
 1. At least 20 submitted eligible PRs as author
 
-When we refer to the term _eligible PR_, we explicit PRs with substantial contributions to the project.
-Because a _"substantial contribution"_ may vary between the different technologies used, each project defines in the `CONTRIBUTING.md` (available at the root of the Github Repository) what _eligible PR_ means for it.
+When we refer to the term _eligible PR_, we explicit PRs with substantial
+contributions to the project. Because a _"substantial contribution"_ may vary
+between the different technologies used, each project defines in the
+`CONTRIBUTING.md` (available at the root of the Github Repository) what
+_eligible PR_ means for it.
 
-If the contributor miss one of those criteria, he cannot ask to become maintainer of the project, **unless** the situation defined in [handover the project](#handover-to-a-new-maintainergroup-of-maintainers) applies.
+If the contributor miss one of those criteria, he cannot ask to become
+maintainer of the project, **unless** the situation defined in
+[handover the project](#handover-to-a-new-maintainergroup-of-maintainers)
+applies.
 
-As soon as the contributor meets the criteria, he can ask (or an existing maintainer can ask) to proceed with a vote using the [Asynchronous voting process](#asynchronous-voting-process).
+As soon as the contributor meets the criteria, he can ask (or an existing
+maintainer can ask) to proceed with a vote using the
+[Asynchronous voting process](#asynchronous-voting-process).
 
 The voting criteria are:
 
@@ -32,7 +44,8 @@ The voting criteria are:
 - At least 2/3 of the votes cast agree to the proposal
 - _sdk-x maintainers_ are entitled to vote
 
-If **nobody** votes, then the contributor may proceed with the [handover of the project](#handover-to-a-new-maintainergroup-of-maintainers).
+If **nobody** votes, then the contributor may proceed with the
+[handover of the project](#handover-to-a-new-maintainergroup-of-maintainers).
 
 ## Ensuring projects health
 
@@ -139,7 +152,9 @@ The voting criteria are:
 
 ## Modifying this document
 
-In order to modify this document, the community should proceed with a vote on the changes using the [Asynchronous voting process](#asynchronous-voting-process).
+In order to modify this document, the community should proceed with a vote on
+the changes using the
+[Asynchronous voting process](#asynchronous-voting-process).
 
 The voting criteria are:
 

--- a/community/SDK-GOVERNANCE.md
+++ b/community/SDK-GOVERNANCE.md
@@ -23,12 +23,15 @@ are:
 1. Significant number, and regular, reviewer on non-trivial PRs, _AND_
 1. Significant number, and regular, author of non-trivial PRs
 
-Note that the definition of _"significant"_ is purposely left as undefined since it is
-very subjective and depends on the technological choices of the sdk projects.
-The purpose of these requirements are to demonstrate the person's expertise and regular commitment to the project - not simply to achieve a certain level of activity.
+Note that the definition of _"significant"_ is purposely left as undefined since
+it is very subjective and depends on the technological choices of the sdk
+projects. The purpose of these requirements are to demonstrate the person's
+expertise and regular commitment to the project - not simply to achieve a
+certain level of activity.
 
-Each sdk project MAY define in the `CONTRIBUTING.md` (available at the root of the Github Repository)
-stricter requirements, in order to meet the community demands, e.g. _we require that the contributor submitted at least 20 PRs_.
+Each sdk project MAY define in the `CONTRIBUTING.md` (available at the root of
+the Github Repository) stricter requirements, in order to meet the community
+demands, e.g. _we require that the contributor submitted at least 20 PRs_.
 
 If a contributor does not meet these criteria, they should not be considered for
 approval as a maintainer of the project, **unless** the situation defined in

--- a/community/SDK-GOVERNANCE.md
+++ b/community/SDK-GOVERNANCE.md
@@ -20,21 +20,22 @@ proactively.
 The criteria for a contributor to become a maintainer for a given SDK repository
 are:
 
-1. At least 20 reviews on eligible PRs
-1. At least 20 submitted eligible PRs as author
+1. Significant number, and regular, reviewer on non-trivial PRs, _AND_
+1. Significant number, and regular, author of non-trivial PRs
 
-When we refer to the term _eligible pull requests_, we explicit mean pull
-requests with substantial contributions to the project. Because a _"substantial
-contribution"_ may vary between the different technologies used, each project
-defines in the `CONTRIBUTING.md` (available at the root of the Github
-Repository) what _eligible PR_ means for it.
+Note that the definition of _"significant"_ is purposely left as undefined since it is
+very subjective and depends on the technological choices of the sdk projects.
+The purpose of these requirements are to demonstrate the person's expertise and regular commitment to the project - not simply to achieve a certain level of activity.
 
-If a contributor does not meet these criteria, he should not be considered for
+Each sdk project MAY define in the `CONTRIBUTING.md` (available at the root of the Github Repository)
+stricter requirements, in order to meet the community demands, e.g. _we require that the contributor submitted at least 20 PRs_.
+
+If a contributor does not meet these criteria, they should not be considered for
 approval as a maintainer of the project, **unless** the situation defined in
 [handover the project](#handover-to-a-new-maintainergroup-of-maintainers)
 applies.
 
-Once a contributor has met the above criteria, he, or an existing maintainer,
+Once a contributor has met the above criteria, they, or an existing maintainer,
 can ask to proceed with a vote using the
 [Asynchronous voting process](#asynchronous-voting-process).
 

--- a/community/SDK-GOVERNANCE.md
+++ b/community/SDK-GOVERNANCE.md
@@ -10,7 +10,29 @@ The community is organized as follows:
 
 ## New maintainers
 
-TBD
+Maintainers are a crucial part of this community: they keep alive our projects and ensure both development and maintenance.
+We define a set of criteria, followed by a vote, to include an active contributor as maintainer of one or more sdk projects.
+The active contributor may propose himself to become a maintainer, although we encourage the community to include him as part of the group.
+
+The criteria for a contributor to `sdk-x` to become part of `sdk-x-maintainers` is:
+
+1. At least 20 reviews on eligible PRs
+1. At least 20 submitted eligible PRs as author
+
+When we refer to the term _eligible PR_, we explicit PRs with substantial contributions to the project.
+Because a _"substantial contribution"_ may vary between the different technologies used, each project defines in the `CONTRIBUTING.md` (available at the root of the Github Repository) what _eligible PR_ means for it.
+
+If the contributor miss one of those criteria, he cannot ask to become maintainer of the project, **unless** the situation defined in [handover the project](#handover-to-a-new-maintainergroup-of-maintainers) applies.
+
+As soon as the contributor meets the criteria, he can ask (or an existing maintainer can ask) to proceed with a vote using the [Asynchronous voting process](#asynchronous-voting-process).
+
+The voting criteria are:
+
+- 1 week to vote
+- At least 2/3 of the votes cast agree to the proposal
+- _sdk-x maintainers_ are entitled to vote
+
+If **nobody** votes, then the contributor may proceed with the [handover of the project](#handover-to-a-new-maintainergroup-of-maintainers).
 
 ## Ensuring projects health
 
@@ -112,6 +134,16 @@ using the [Asynchronous voting process](#asynchronous-voting-process).
 The voting criteria are:
 
 - 2 weeks to vote
+- At least 2/3 of the votes cast agree to the proposal
+- All _sdk maintainers_ are entitled to vote
+
+## Modifying this document
+
+In order to modify this document, the community should proceed with a vote on the changes using the [Asynchronous voting process](#asynchronous-voting-process).
+
+The voting criteria are:
+
+- 1 week to vote
 - At least 2/3 of the votes cast agree to the proposal
 - All _sdk maintainers_ are entitled to vote
 

--- a/community/SDK-GOVERNANCE.md
+++ b/community/SDK-GOVERNANCE.md
@@ -10,32 +10,32 @@ The community is organized as follows:
 
 ## New maintainers
 
-Maintainers are a crucial part of this community: they keep alive our projects
+Maintainers are a crucial part of this community. They keep our projects alive
 and ensure both development and maintenance. We define a set of criteria,
 followed by a vote, to include an active contributor as maintainer of one or
-more sdk projects. The active contributor may propose himself to become a
-maintainer, although we encourage the community to include him as part of the
-group.
+more SDK projects. An active contributor may propose themselves as a maintainer,
+although we encourage the existing maintainers to nominate active contributors
+proactively.
 
-The criteria for a contributor to `sdk-x` to become part of `sdk-x-maintainers`
-is:
+The criteria for a contributor to become a maintainer for a given SDK repository
+are:
 
 1. At least 20 reviews on eligible PRs
 1. At least 20 submitted eligible PRs as author
 
-When we refer to the term _eligible PR_, we explicit PRs with substantial
-contributions to the project. Because a _"substantial contribution"_ may vary
-between the different technologies used, each project defines in the
-`CONTRIBUTING.md` (available at the root of the Github Repository) what
-_eligible PR_ means for it.
+When we refer to the term _eligible pull requests_, we explicit mean pull
+requests with substantial contributions to the project. Because a _"substantial
+contribution"_ may vary between the different technologies used, each project
+defines in the `CONTRIBUTING.md` (available at the root of the Github
+Repository) what _eligible PR_ means for it.
 
-If the contributor miss one of those criteria, he cannot ask to become
-maintainer of the project, **unless** the situation defined in
+If a contributor does not meet these criteria, he should not be considered for
+approval as a maintainer of the project, **unless** the situation defined in
 [handover the project](#handover-to-a-new-maintainergroup-of-maintainers)
 applies.
 
-As soon as the contributor meets the criteria, he can ask (or an existing
-maintainer can ask) to proceed with a vote using the
+Once a contributor has met the above criteria, he, or an existing maintainer,
+can ask to proceed with a vote using the
 [Asynchronous voting process](#asynchronous-voting-process).
 
 The voting criteria are:


### PR DESCRIPTION
This PR adds 2 paragraphs to the sdk governance doc:

* definition to add new maintainers
* definition on how to modify the sdk governance doc itself

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>