### PR TITLE
Rename services types[].type to types[].name; Drop /types endpoint

### DIFF
--- a/ce_discovery.yaml
+++ b/ce_discovery.yaml
@@ -42,42 +42,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/service'
-  /types:
-    get:
-      parameters:
-       - in: query
-         name: matching
-         description: The search term.
-         required: false
-         schema:
-           type: string
-      responses:
-        '200':
-          description: A list of types (optionally matching the query parameter).
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/type'
-  /types/{type}:
-    get:
-      parameters:
-       - in: path
-         name: type
-         description: The name of the type to be returned.
-         required: true
-         schema:
-           type: string
-      responses:
-        '200':
-          description: The corresponding service.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/type'
 components:
   schemas:
     service:
@@ -128,7 +92,7 @@ components:
     type:
       type: object
       properties:
-        type:
+        name:
           type: string
           description: CloudEvents type attribute.
           example: com.github.pull.create, com.example.object.delete.v2

--- a/ce_discovery.yaml
+++ b/ce_discovery.yaml
@@ -84,7 +84,7 @@ components:
             type: string
             description: protocol
           example: '[ "HTTP", "AMQP", "KAFKA" ]'
-        types:
+        events:
           type: array
           description: List of event types available in this service.
           items:
@@ -92,7 +92,7 @@ components:
     type:
       type: object
       properties:
-        name:
+        type:
           type: string
           description: CloudEvents type attribute.
           example: com.github.pull.create, com.example.object.delete.v2

--- a/discovery.md
+++ b/discovery.md
@@ -143,9 +143,9 @@ Service:
   },
   "authscope": "[string]", ?
   "protocols": [ "[string]" + ],
-  "types": [ ?
+  "events": [ ?
     { *
-      "name": "[ce-type value]",
+      "type": "[ce-type value]",
       "description": "[human string]", ?
       "datacontenttype": "[ce-datacontenttype value]", ?
       "dataschema": "[ce-dataschema URI]", ?
@@ -173,12 +173,12 @@ An example:
   "specversions": ["1.0"],
   "subscriptionurl": "https://events.example.com",
   "protocols": ["HTTP"],
-  "types": [
+  "events": [
     {
-      "name": "com.example.widget.create"
+      "type": "com.example.widget.create"
     },
     {
-      "name": "com.example.widget.delete"
+      "type": "com.example.widget.delete"
     }
   ]
 }
@@ -334,7 +334,7 @@ The following sections define the attributes that appear in a Service entity.
   - `[ "HTTP" ]`
   - `[ "HTTP", "AMQP", "KAFKA" ]`
 
-##### name
+##### type
 
 - Type: `String`
 - Description: CloudEvents
@@ -447,9 +447,9 @@ The following sections define the attributes that appear in a Service entity.
   "description": "Blob storage in the cloud",
   "protocols": ["HTTP"],
   "subscriptionurl": "https://cloud.example.com/docs/storage",
-  "types": [
+  "events": [
     {
-      "name": "com.example.storage.object.create",
+      "type": "com.example.storage.object.create",
       "specversions": ["1.x-wip"],
       "datacontenttype": "application/json",
       "dataschema": "http://schemas.example.com/download/com.example.storage.object.create.json",

--- a/discovery.md
+++ b/discovery.md
@@ -38,13 +38,13 @@ advance.
 The deployment relationship of a Discovery Endpoint to the Services and Event
 Producers that it advertises is out of scope of this specification. For example,
 a Discovery Endpoint could choose to be implemented as part of a Service, or
-Event Producer, or it could be acting as an independent aggregrator of this
+Event Producer, or it could be acting as an independent aggregator of this
 metadata. This implementation detail will be transparent to consumers.
 
-The main usecase to condider from the viewpoint of the event consumer is what
+The main use-case to consider from the viewpoint of the event consumer is what
 services are available, and what event types do they generate?
 
-The CloudEvent `source` attribute is a potential cause of high fanout. For
+The CloudEvent `source` attribute is a potential cause of high fan-out. For
 example, consider a blob storage system where each directory constitutes a
 distinct `source` attribute value. For this reason, the exact CloudEvents
 `source` attribute value that might appear in a CloudEvent will not appear in
@@ -65,7 +65,7 @@ interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 Note: some of the terms defined below are taken from the [CloudEvents](spec.md)
 specification, and are marked with a reference to the original definition. Any
 difference between the definitions is accidental and the CloudEvents version
-takes precendence.
+takes precedence.
 
 This specification defines the following terms:
 
@@ -73,7 +73,7 @@ This specification defines the following terms:
 
 A compliant implementation of this specification that advertises the set of
 Services, Event Types and other metadata to aid in the creation of an Event
-Subcription.
+Subscription.
 
 #### Service
 
@@ -213,7 +213,7 @@ The following sections define the attributes that appear in a Service entity.
   For example, if a Service's implementation is upgraded to a new version then
   whether this would result in a new Service (and `id`) or is an update to the
   existing Service's metadata, is an implementation choice. Likewise, this
-  specifcation makes no statement, or guarantees, as to the forwards or
+  specification makes no statement, or guarantees, as to the forwards or
   backwards compatibility a Service as it changes over time.
 
   Note, unlike the `name` attribute which only needs to be unique within the
@@ -424,7 +424,7 @@ The following sections define the attributes that appear in a Service entity.
   that are used for this event `type`. The structure contains the following
   attributes:
   - `name` - the CloudEvents context attribute name used by this extension. It
-    MUST adhere to the CloudEvents context attrbibute naming rules
+    MUST adhere to the CloudEvents context attribute naming rules
   - `type` - the data type of the extension attribute. It MUST adhere to the
     CloudEvents [type system](./spec.md#type-system)
   - `specurl` - an attribute pointing to the specification that defines the

--- a/discovery.md
+++ b/discovery.md
@@ -41,19 +41,8 @@ a Discovery Endpoint could choose to be implemented as part of a Service, or
 Event Producer, or it could be acting as an independent aggregrator of this
 metadata. This implementation detail will be transparent to consumers.
 
-There are several discovery use cases to consider from the viewpoint of event
-consumers.
-
-1. What services are available, and what event types do they generate?
-2. What event types are available, and from which services?
-
-The second case becomes relevant if multiple services support the same event
-types. Use case 1 is likely the dominant use case. Given the example of a public
-cloud provider where all services generate events, there might be dozens of
-sources and hundreds of event types. The discovery funnel of services first,
-then event types helps users navigate without having to see large lists of event
-types. Both of these cases show the importance of using filters in the discovery
-API to narrow down the selection of available events.
+The main usecase to condider from the viewpoint of the event consumer is what
+services are available, and what event types do they generate?
 
 The CloudEvent `source` attribute is a potential cause of high fanout. For
 example, consider a blob storage system where each directory constitutes a
@@ -156,7 +145,7 @@ Service:
   "protocols": [ "[string]" + ],
   "types": [ ?
     { *
-      "type": "[ce-type value]",
+      "name": "[ce-type value]",
       "description": "[human string]", ?
       "datacontenttype": "[ce-datacontenttype value]", ?
       "dataschema": "[ce-dataschema URI]", ?
@@ -186,10 +175,10 @@ An example:
   "protocols": ["HTTP"],
   "types": [
     {
-      "type": "com.example.widget.create"
+      "name": "com.example.widget.create"
     },
     {
-      "type": "com.example.widget.delete"
+      "name": "com.example.widget.delete"
     }
   ]
 }
@@ -345,7 +334,7 @@ The following sections define the attributes that appear in a Service entity.
   - `[ "HTTP" ]`
   - `[ "HTTP", "AMQP", "KAFKA" ]`
 
-##### type
+##### name
 
 - Type: `String`
 - Description: CloudEvents
@@ -460,7 +449,7 @@ The following sections define the attributes that appear in a Service entity.
   "subscriptionurl": "https://cloud.example.com/docs/storage",
   "types": [
     {
-      "type": "com.example.storage.object.create",
+      "name": "com.example.storage.object.create",
       "specversions": ["1.x-wip"],
       "datacontenttype": "application/json",
       "dataschema": "http://schemas.example.com/download/com.example.storage.object.create.json",
@@ -547,80 +536,6 @@ When encoded in JSON, the response format MUST adhere to the following:
   ... remainder of Service attributes ...
 }
 ```
-
-#### Types
-
-##### `/types`
-
-This MUST return a map of zero or more Types values, where each Type's value is
-an array of Services that support that Type.
-
-When encoded in JSON, the response format MUST adhere to the following:
-
-```
-{
-  "TYPE-VALUE": [
-    {
-      "id: "{id}",
-      "url": "{url}",
-      "name: "{name}",
-      ... remainder of Service attributes ...
-    }
-    ...
-  ]
-  ...
-}
-```
-
-##### `/types/{type}`
-
-This MUST returns a map of one or more Services that support the Type value
-specified. Type value MUST conform to the [CloudEvents type](./spec.md#type)
-attribute specification.
-
-When encoded in JSON, the response format MUST adhere to the following:
-
-```
-{
-  "{type}": [
-    {
-      "id: "{id}",
-      "url": "{url}",
-      "name: "{name}",
-      ... remainder of Service attributes ...
-    }
-    ...
-  ]
-}
-```
-
-##### `/types?matching=[search term]`
-
-Same as `/types` but the map MUST be limited to just those Types whose value
-contains the `search term` value (case insensitive).
-
-###### matching
-
-- Type: `string`
-- Description: Search term that provides case insensitive match against the
-  Type's value. The parameter can match any portion of the value.
-- Constraints:
-  - OPTIONAL
-  - If present, MUST be non-empty
-- Examples:
-  - `"com.storage.object"`
-    - matches:
-      - `"com.storage.object.create"`
-      - `"com.storage.object.delete"`
-      - `"com.storage.object.update"`
-  - `"storage"`
-    - matches:
-      - `"com.storage.object.create"`
-      - `"com.storage.object.delete"`
-      - `"com.storage.object.update"`
-  - `"create"`
-    - matches:
-      - `"com.storage.object.create"`
 
 ## Protocol Bindings
 


### PR DESCRIPTION
Fixes: https://github.com/cloudevents/spec/issues/685
Fixes: https://github.com/cloudevents/spec/issues/684
Fixes: https://github.com/cloudevents/spec/issues/679

- Rename services types[].type to types[].name
- Drop /types endpoint

Signed-off-by: Scott Nichols <snichols@vmware.com>