### PR TITLE
Add a version/timestamp attribute

### DIFF
--- a/discovery.md
+++ b/discovery.md
@@ -202,14 +202,6 @@ The following sections define the attributes that appear in a Service entity.
   NOT so that clients can use this attribute to know whether a Service returned
   by a query is the same Service returned by a previous query.
 
-  Typically, this value is defined by the Discovery Endpoint, or one of the
-  components behind it. However, there might be cases where the value is
-  provided to the Discovery Endpoint, for example, during an "import" type of
-  operation. In these "import" cases the attribute is REQUIRED to be
-  in the client's request. However, in cases where the Service has no
-  associated `id` that needs to be retained, this attribute MUST NOT be
-  present in the client's request.
-
   Whether a change to a Service would result in changing of the Service's
   metadata (except `id`) and thus be just an update of an existing Service, or
   whether the change would result in a brand new Service (with a new `id`) is
@@ -229,7 +221,7 @@ The following sections define the attributes that appear in a Service entity.
   See the Primer for more information.
 
 - Constraints:
-  - conditionally REQUIRED. See above.
+  - REQUIRED in responses from the Discovery Endpoint.
   - MUST be a valid UUID per RFC4122.
 - Examples:
   - `bf5ff5cc-d059-4c79-a89a-2513e45a1340`
@@ -246,26 +238,8 @@ The following sections define the attributes that appear in a Service entity.
   integer comparision to determine which version of this Service Entry is the
   latest - meaning, the one with the larger integer value.
 
-  While this attibute is REQUIRED to be part of the the Service's description
-  when returned from a Discovery Endpoint, depending on the action from the
-  client it might not be mandatory to appear in a client's request. For a
-  "create" operation, this attribute MUST NOT appear. For an "import" type
-  of operation, where it is important for the entry to retain a previously
-  defined value, this attribute MUST appear.
-
-  A client MAY choose to include this attribute on an "update" operation.
-  If present then the Discovery Endpoint MUST ensure that the value
-  on the incoming request matches the current value within the Discovery
-  Endpoint, and if it does not then an error MUST be generated and the Service
-  Entry MUST NOT be updated. However, if the incoming request does not include
-  this attribute then the Discovery Endpoint MUST skip the version matching
-  check.
-  Note: regardless of whether the incoming request has this attribute or not,
-  a subsequent retrieval of this Service Entry MUST have an updated value
-  for this attribute.
-
 - Constraints:
-  - Conditionally REQUIRED. See above.
+  - REQUIRED in responses from the Discovery Endpoint.
 - Examples:
   - `42`
   - `915148800`

--- a/discovery.md
+++ b/discovery.md
@@ -132,6 +132,8 @@ Service:
 ```
 {
   "id": "[a globally unique UUID]",
+  "discversion": "[discovery entry version number]",
+  "updated": "[the time of this entry's last update]"
   "url": "[unique URL to this service]",
   "name": "[unique name for this services]",
   "description": "[human string]", ?
@@ -168,6 +170,8 @@ An example:
 ```json
 {
   "id": "cbdd62e8-c095-11ea-b3de-0242ac130004",
+  "discversion": 1,
+  "updated": "2018-04-05T17:31:00Z",
   "url": "https://example.com/services/widgetService",
   "name": "widgets",
   "specversions": ["1.0"],
@@ -203,7 +207,10 @@ The following sections define the attributes that appear in a Service entity.
   Typically, this value is defined by the Discovery Endpoint, or one of the
   components behind it. However, there might be cases where the value is
   provided to the Discovery Endpoint, for example, during an "import" type of
-  operation.
+  operation. In these "import" type of cases the attribute is REQUIRED to be
+  in the client's request. However, in cases where the Service has no
+  associated `id` that needs to be retained, this attribuet MUST NOT be
+  present in the client's request.
 
   Whether a change to a Service would result in changing of the Service's
   metadata (except `id`) and thus be just an update of an existing Service, or
@@ -224,10 +231,84 @@ The following sections define the attributes that appear in a Service entity.
   See the Primer for more information.
 
 - Constraints:
-  - REQUIRED
+  - conditionally REQUIRED. See above.
   - MUST be a valid UUID per RFC4122.
 - Examples:
   - `bf5ff5cc-d059-4c79-a89a-2513e45a1340`
+
+##### discversion
+
+- Type: `Integer`
+- Description: The Discovery Endpoint's version number of this Service Entry.
+  A monotonically increasing number, starting with `1` that is
+  increased by `1` each time an update is performed on this Discovery
+  Endpoint's entry. Note: this version value is not related to the version
+  of the Service itself representated by this entry. This value is meant to
+  be used to know when the Discovery Enpoint's metadata about the Service
+  has been updated.
+
+  While this attibute is REQUIRED to be part of the the Service's description
+  when returned from a Discovery Endpoint, depending on the action from the
+  client it might not be mandatory to appear in a client's request. For a
+  "create" operation, this attribute MUST NOT appear. For an "import" type
+  of operation, where it is important for the entry to retain a previously
+  defined value, this attribute MUST appear
+
+  A client MAY choose to include this attribute on an "update" operation.
+  If present then the Discovery Endpoint MUST ensure that the value
+  on the incoming request matches the current value within the Discovery
+  Endpoint, and if it does not then an error MUST be generated and the Service
+  MUST NOT be updated. However, if the incoming request does not include this
+  attribute then the Discovery Endpoint MUST skip the version matching check.
+
+- Constraints:
+  - Conditionally REQUIRED. See above.
+- Examples:
+  - `1`
+  - `42`
+
+##### updated
+
+- Type: `String` encoded [RFC 3339](https://tools.ietf.org/html/rfc3339)
+  Timestamp
+- Description: The time when this Service's entry was last updated.
+  Discovery Endpoints MUST set this value each time any change is made to
+  the entry. Note: this timestamp is not related to any updates to the Service
+  itself represented by this entry - this value is meant to be used to know
+  when the Discovery Endpoint's metadata about the Service has been updated.
+
+  While this attribute is REQUIRED to be part of the Service's descriptions
+  when returned from a Discovery Endpoint, depending on the action from the
+  client it might not be mandatory to appear in a client's request. For a
+  "create" operation, this attribute MUST NOT appear. For an "import" type
+  of operation, where it is important for the entry to retain a previously
+  defined value, this attribute MUST appear.
+
+  A client MAY choose to include this attribute on an "update" operation.
+  If present then the Discovery Endpoint MUST ensure that the value on the
+  incoming request matches the current value within the Discovery
+  Endpoint, and if it does not then an error MUST be generated and the Service
+  MUST NOT be updated. However, if the incoming request does not include this
+  attribute then the Discovery Endpoint MUST skip this timestamp check.
+
+  For ease of implmentation and to ensure interoperability, the following
+  constraints apply:
+  - All values MUST use upper case letters (e.g. 'Z' not 'z')
+  - All values MUST NOT include the `time-secfrac` component
+  - All values MUST be in UTC. Therefore, all values MUST NOT use the
+    `time-numoffset` component, and instead MUST use `Z` for the `time-offset`
+
+  While this attribute is a Timestamp, it MUST be treated as String for
+  comparision purposes.  Meaning, the "timestamp check" discussed above MUST
+  be a case-sensitive string compare operation. This ensures that in order to
+  perform a comparision check between two values, an alphabetically larger
+  string will be a more recent timestamp.
+
+- Constraints:
+  - Conditionally REQUIRED. See above.
+- Examples:
+  - `2018-04-05T17:31:00Z`
+
 
 ##### name
 

--- a/discovery.md
+++ b/discovery.md
@@ -132,8 +132,7 @@ Service:
 ```
 {
   "id": "[a globally unique UUID]",
-  "discversion": "[discovery entry version number]",
-  "updated": "[the time of this entry's last update]"
+  "epoch": "[discovery entry epoch value]",
   "url": "[unique URL to this service]",
   "name": "[unique name for this services]",
   "description": "[human string]", ?
@@ -170,8 +169,7 @@ An example:
 ```json
 {
   "id": "cbdd62e8-c095-11ea-b3de-0242ac130004",
-  "discversion": 1,
-  "updated": "2018-04-05T17:31:00Z",
+  "epoch": 1,
   "url": "https://example.com/services/widgetService",
   "name": "widgets",
   "specversions": ["1.0"],
@@ -209,7 +207,7 @@ The following sections define the attributes that appear in a Service entity.
   provided to the Discovery Endpoint, for example, during an "import" type of
   operation. In these "import" cases the attribute is REQUIRED to be
   in the client's request. However, in cases where the Service has no
-  associated `id` that needs to be retained, this attribuet MUST NOT be
+  associated `id` that needs to be retained, this attribute MUST NOT be
   present in the client's request.
 
   Whether a change to a Service would result in changing of the Service's
@@ -236,51 +234,19 @@ The following sections define the attributes that appear in a Service entity.
 - Examples:
   - `bf5ff5cc-d059-4c79-a89a-2513e45a1340`
 
-##### discversion
+##### epoch
 
 - Type: `Integer`
-- Description: The Discovery Endpoint's version number of this Service Entry.
-  A monotonically increasing number, starting with `1` that is
-  increased by `1` each time an update is performed on this Discovery
-  Endpoint's entry. Note: this version value is not related to the version
-  of the Service itself representated by this entry. This value is meant to
-  be used to know when the Discovery Enpoint's metadata about the Service
-  has been updated.
+- Description: The Discovery Endpoint's epoch value for this Service Entry.
+  This specification does not mandate any particular semantic meaning to
+  the value used. For example, implementations are free to use a value that
+  represents a timestamp or could choose to simply use a monotomically
+  increasing number. The only requirement is that the value MUST always
+  increase each time the Service Entry is updated. This allows for a quick
+  integer comparision to determine which version of this Service Entry is the
+  latest - meaning, the one with the larger integer value.
 
   While this attibute is REQUIRED to be part of the the Service's description
-  when returned from a Discovery Endpoint, depending on the action from the
-  client it might not be mandatory to appear in a client's request. For a
-  "create" operation, this attribute MUST NOT appear. For an "import" type
-  of operation, where it is important for the entry to retain a previously
-  defined value, this attribute MUST appear
-
-  A client MAY choose to include this attribute on an "update" operation.
-  If present then the Discovery Endpoint MUST ensure that the value
-  on the incoming request matches the current value within the Discovery
-  Endpoint, and if it does not then an error MUST be generated and the Service
-  MUST NOT be updated. However, if the incoming request does not include this
-  attribute then the Discovery Endpoint MUST skip the version matching check.
-  Note: regardless of whether the incoming request had this attribute or not,
-  a subsequent retrieval of this Service Entry will have an updated value
-  for this attribute.
-
-- Constraints:
-  - Conditionally REQUIRED. See above.
-- Examples:
-  - `1`
-  - `42`
-
-##### updated
-
-- Type: `String` encoded [RFC 3339](https://tools.ietf.org/html/rfc3339)
-  Timestamp
-- Description: The time when this Service's entry was last updated.
-  Discovery Endpoints MUST set this value each time any change is made to
-  the entry. Note: this timestamp is not related to any updates to the Service
-  itself represented by this entry - this value is meant to be used to know
-  when the Discovery Endpoint's metadata about the Service has been updated.
-
-  While this attribute is REQUIRED to be part of the Service's descriptions
   when returned from a Discovery Endpoint, depending on the action from the
   client it might not be mandatory to appear in a client's request. For a
   "create" operation, this attribute MUST NOT appear. For an "import" type
@@ -288,33 +254,21 @@ The following sections define the attributes that appear in a Service entity.
   defined value, this attribute MUST appear.
 
   A client MAY choose to include this attribute on an "update" operation.
-  If present then the Discovery Endpoint MUST ensure that the value on the
-  incoming request matches the current value within the Discovery
+  If present then the Discovery Endpoint MUST ensure that the value
+  on the incoming request matches the current value within the Discovery
   Endpoint, and if it does not then an error MUST be generated and the Service
-  MUST NOT be updated. However, if the incoming request does not include this
-  attribute then the Discovery Endpoint MUST skip this timestamp check.
-  Note: regardless of whether the incoming request had this attribute or not,
-  a subsequent retrieval of this Service Entry will have an updated value
+  Entry MUST NOT be updated. However, if the incoming request does not include
+  this attribute then the Discovery Endpoint MUST skip the version matching
+  check.
+  Note: regardless of whether the incoming request has this attribute or not,
+  a subsequent retrieval of this Service Entry MUST have an updated value
   for this attribute.
-
-  For ease of implmentation and to ensure interoperability, the following
-  constraints apply:
-  - All values MUST use upper case letters (e.g. 'Z' not 'z')
-  - All values MUST NOT include the `time-secfrac` component
-  - All values MUST be in UTC. Therefore, all values MUST NOT use the
-    `time-numoffset` component, and instead MUST use `Z` for the `time-offset`
-
-  While this attribute is a Timestamp, it MUST be treated as String for
-  comparision purposes.  Meaning, the "timestamp check" discussed above MUST
-  be a case-sensitive string compare operation. This ensures that in order to
-  perform a comparision check between two values, an alphabetically larger
-  string will be a more recent timestamp.
 
 - Constraints:
   - Conditionally REQUIRED. See above.
 - Examples:
-  - `2018-04-05T17:31:00Z`
-
+  - `42`
+  - `915148800`
 
 ##### name
 

--- a/discovery.md
+++ b/discovery.md
@@ -207,7 +207,7 @@ The following sections define the attributes that appear in a Service entity.
   Typically, this value is defined by the Discovery Endpoint, or one of the
   components behind it. However, there might be cases where the value is
   provided to the Discovery Endpoint, for example, during an "import" type of
-  operation. In these "import" type of cases the attribute is REQUIRED to be
+  operation. In these "import" cases the attribute is REQUIRED to be
   in the client's request. However, in cases where the Service has no
   associated `id` that needs to be retained, this attribuet MUST NOT be
   present in the client's request.
@@ -260,6 +260,9 @@ The following sections define the attributes that appear in a Service entity.
   Endpoint, and if it does not then an error MUST be generated and the Service
   MUST NOT be updated. However, if the incoming request does not include this
   attribute then the Discovery Endpoint MUST skip the version matching check.
+  Note: regardless of whether the incoming request had this attribute or not,
+  a subsequent retrieval of this Service Entry will have an updated value
+  for this attribute.
 
 - Constraints:
   - Conditionally REQUIRED. See above.
@@ -290,6 +293,9 @@ The following sections define the attributes that appear in a Service entity.
   Endpoint, and if it does not then an error MUST be generated and the Service
   MUST NOT be updated. However, if the incoming request does not include this
   attribute then the Discovery Endpoint MUST skip this timestamp check.
+  Note: regardless of whether the incoming request had this attribute or not,
+  a subsequent retrieval of this Service Entry will have an updated value
+  for this attribute.
 
   For ease of implmentation and to ensure interoperability, the following
   constraints apply:


### PR DESCRIPTION
Per @n3wscott's suggestion, this adds a new attribute that can be used to
know when an entry has been updated. It can be used as an e-tag type of
thing or to know when, during an import, the entity being imported is
older than what the discovery endpoint already has.

I wasn't sure if a counter or a timestamp would be better, so I added
both so people can see how both look.

I'm leaning more towards a timestamp since it give a bit more information.

Signed-off-by: Doug Davis <dug@us.ibm.com>