### PR TITLE
docs: do not use code ticks for data that may actually be data_base64

### DIFF
--- a/json-format.md
+++ b/json-format.md
@@ -123,12 +123,12 @@ the [type system mapping](#22-type-system-mapping).
 Before taking action, a JSON serializer MUST first determine the runtime data
 type of the `data` content.
 
-If the implementation determines that the type of `data` is `Binary`, the value
+If the implementation determines that the type of data is `Binary`, the value
 MUST be represented as a [JSON string][json-string] expression containing the
 [Base64][base64] encoded binary value, and use the member name `data_base64`
 to store it inside the JSON object.
 
-For any other type, the implementation MUST translate the `data` value into
+For any other type, the implementation MUST translate the data value into
 a [JSON value][json-value], and use the member name `data`
 to store it inside the JSON object.
 


### PR DESCRIPTION
The spec currently uses ticks around `data` as if this is a literal field.

This isn't quite accurate, we don't mean the literal key `data`. We state the data can be stored in `data` or `data_base64 ` right after, so it's a little confusing saying `data` before. I suggest removing the ticks to make this clearer.

See the diff to understand the change the best.

Related: https://github.com/cloudevents/spec/issues/520