### PR TITLE
spec.json: make dataschema optional

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -104,8 +104,7 @@
     },
     "dataschemadef": {
       "type": "string",
-      "format": "uri",
-      "minLength": 1
+      "format": "uri"
     },
     "subjectdef": {
       "type": "string",


### PR DESCRIPTION
Closes #710 
dataschemadef currently has a minLength of 1, which makes it mandatory as a CloudEvents attribute
removing minLength 1 from dataschemadef

Signed-off-by: Manuel Stein manuel.stein@nokia-bell-labs.com