### PR TITLE
[Primer] Adding a Non-Goal w.r.t Security

### DIFF
--- a/primer.md
+++ b/primer.md
@@ -140,6 +140,7 @@ The following are considered beyond the scope of the specification:
 - Selecting a single identity/access control system
 - Inclusion of protocol-level routing information
 - Event persistence processes
+- Mechanism for Authorization, Data Integrity and Confidentiality
 
 The CloudEvents spec will not include protocol-level routing information (e.g.
 a destination URL to which the event is being sent). This is a common suggestion
@@ -173,6 +174,15 @@ available to attackers and thereby reduces security. It is expected that
 attributes may be defined that facilitate meeting persistence requirements but
 it is expected that these will continuously evolve along with industry best
 practices and advancements.
+
+The CloudEvents spec currently does not mandate or advocates any specific
+mechanism or principles in the matter of Authorization, Data Integrity and
+Confidentiality, as the core intention behind this spec is not to define
+Security principles with regards to CloudEvents. Every implementor has a
+different principle for enhancing their security model. We leave it up to the
+implementor of the spec to provide additional details for hardening their
+security model as an extension field, which can be furthermore interpreted by
+the components implemented by the implementor of the specification themselves.
 
 ## Architecture
 

--- a/primer.md
+++ b/primer.md
@@ -175,14 +175,18 @@ attributes may be defined that facilitate meeting persistence requirements but
 it is expected that these will continuously evolve along with industry best
 practices and advancements.
 
-The CloudEvents spec currently does not mandate or advocates any specific
+The CloudEvents spec currently does not mandate or advocate any specific
 mechanism or principles in the matter of Authorization, Data Integrity and
-Confidentiality, as the core intention behind this spec is not to define
+Confidentiality, as the current intention behind this spec is not to define
 Security principles with regards to CloudEvents. Every implementor has a
 different principle for enhancing their security model. We leave it up to the
 implementor of the spec to provide additional details for hardening their
 security model as an extension field, which can be furthermore interpreted by
 the components implemented by the implementor of the specification themselves.
+However, if the community observes a pattern in usage of certain extension
+fields, as a standard way to deal with the topic of data integrity. In that
+case, such extension fields can be declared as official extension to the
+CloudEvent specification.
 
 ## Architecture
 


### PR DESCRIPTION
in #703 it was asked to mandate certain fields in the spec to enhance the security model, However based on the discussion we all came to a conclusion that the spec doesn't have to get into the security business. Hence, the Group decided to add this information into the Primer. 