### PR TITLE
tweak url description

### DIFF
--- a/discovery.md
+++ b/discovery.md
@@ -258,8 +258,9 @@ The following sections define the attributes that appear in a Service entity.
 ##### url
 
 - Type: `URL`
-- Description: An absolute URL that references this Service. This value MUST be
-  usable in subsequent requests, by authorized clients, to retrieve this Service
+- Description: An absolute URL that references this Service within this
+  Discovery Endpoint. This value MUST be usable in subsequent requests, by
+  authorized clients, to retrieve this Service
   entity.
 - Constraints:
   - REQUIRED


### PR DESCRIPTION
Minor wording change to ensure that people know that this URL points to the Service entry in the Discovery Endpoint and NOT to the Service itself

Signed-off-by: Doug Davis <dug@us.ibm.com>