### PR TITLE
refactor: change subscription API to resource based

### DIFF
--- a/subscriptions-api-openapi.yaml
+++ b/subscriptions-api-openapi.yaml
@@ -7,55 +7,25 @@ servers:
 paths:
   /subscriptions:
     get:
-      description: Retrieve one or multiple subscriptions
-      parameters:
-        - in: "query"
-          name: "id"
-          description: identifier of a specific subscription
-          required: false
-          schema:
-            type: string
+      description: Retrieve multiple subscriptions
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: "#/components/schemas/Subscription"
-                    description: the subscription that was requested with teh 'id' parameter
-                  - type: array
-                    description: a list of subscriptions
-                    items:
-                       $ref: "#/components/schemas/Subscription"
-    put:
-      description: Update a subscription
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Subscription"
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Subscription"
+                type: array
+                description: a list of subscriptions
+                items:
+                  $ref: "#/components/schemas/Subscription"
     post:
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Subscription"
+              $ref: "#/components/schemas/SubscriptionRequest"
       responses:
         "200":
-          description: Updated successfully
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Subscription"
-        "201":
           description: Created successfully
           content:
             application/json:
@@ -68,10 +38,65 @@ paths:
                 format: url
         "400":
           description: Invalid or malformed request
+    options:
+      description: Discover supported features and methods for this endpoint
+      responses:
+        "200":
+          description: OK
+          headers:
+            Allow:
+              schema:
+                type: string
+                default: "GET,POST,OPTIONS"
+  /subscriptions/{id}:
+    get:
+      description: Retrieve one or multiple subscriptions
+      parameters:
+        - in: "path"
+          name: "id"
+          description: identifier of a specific subscription
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Subscription"
+        "404":
+          description: Subscription not found
+    put:
+      description: Update a subscription
+      parameters:
+        - in: "path"
+          name: "id"
+          required: true
+          schema:
+            type: string
+          description: The id of an existing subscription
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Subscription"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Subscription"
+        "400":
+          description: Invalid or malformed request
+        "404":
+          description: Subscription not found
     delete:
       description: Delete a subscription
       parameters:
-        - in: "query"
+        - in: "path"
           name: "id"
           required: true
           schema:
@@ -80,12 +105,17 @@ paths:
       responses:
         "200":
           description: Successfully deleted
-        "400":
-          description: Invalid or malformed request
         "404":
           description: Subscription not found
     options:
       description: Discover supported features and methods for this endpoint
+      parameters:
+        - in: "path"
+          name: "id"
+          description: identifier of a specific subscription
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: OK
@@ -96,6 +126,33 @@ paths:
                 default: "GET,PUT,POST,DELETE,OPTIONS"
 components:
   schemas:
+    SubscriptionRequest:
+      properties:
+        protocol:
+          type: string
+          enum: ["HTTP", "MQTT3", "MQTT5", "AMQP", "NATS", "KAFKA"]
+          description: REQUIRED. Identifier of a delivery protocol.
+          example: "HTTP"
+        protocolsettings:
+          type: object
+          anyOf:
+            - $ref: "#/components/schemas/HTTPSettings"
+            - $ref: "#/components/schemas/MQTTSettings"
+            - $ref: "#/components/schemas/AMQPSettings"
+            - $ref: "#/components/schemas/NATSSettings"
+            - $ref: "#/components/schemas/ApacheKafkaSettings"
+          description: OPTIONAL. A set of settings specific to the selected delivery protocol provider.
+        sink:
+          type: string
+          format: url
+          description: REQUIRED. The address to which events shall be delivered using the selected protocol.
+          example: "https://endpoint.example.com/webhook"
+        filter:
+          $ref: "#/components/schemas/Filter"
+      required:
+        - protocol
+        - protocolsettings
+        - sink
     Subscription:
       properties:
         id:

--- a/subscriptions-api-openapi.yaml
+++ b/subscriptions-api-openapi.yaml
@@ -197,11 +197,6 @@ components:
             type: object
     HTTPSettings:
       properties:
-        proxyurl:
-          type: string
-          format: url
-        proxycredentials:
-          $ref: "#/components/schemas/Credentials"
         headers:
           type: object
         method:
@@ -251,12 +246,3 @@ components:
           type: string
       required:
         - subject
-    Credentials:
-      properties:
-        username:
-          type: string
-        passkey:
-          type: string
-          format: password
-        accesstoken:
-          type: string


### PR DESCRIPTION
Signed-off-by: Remi Cattiau <remi@cattiau.com>

Current spec is using GET/DELETE/PUT/POST on /subscriptions with id url parameter or id in body.
This PR move to:
GET /subscriptions: List subscriptions
POST /subscriptions: Create subscription
GET /subscriptions/{id}: Retrieve a subscription
PUT /subscriptions/{id}: Update a subscription
DELETE /subscriptions/{id}: Delete a subscription

Some questions popped while working on it: 
 - in my opinion, the proxy settings should be the application choice, not the subscription choice.
 - the creation request should not contain an id, as the id should be generated by the application (so I added a SubscriptionRequest schema)

<img width="535" alt="Screen Shot 2020-10-27 at 5 39 26 PM" src="https://user-images.githubusercontent.com/3437026/97376793-8a950c80-187b-11eb-8c8d-7bd082e2e61f.png">

 