### PR TITLE
docs: add lance to community/contributors.md

### DIFF
--- a/community/contributors.md
+++ b/community/contributors.md
@@ -70,6 +70,7 @@ Contributions do not constitute an official endorsement.
   - William Markito Oliveira - [@william_markito](https://github.com/markito)
   - Gunnar Morling - [@gunnarmorling](https://github.com/gunnarmorling/)
   - Tihomir Surdilovic - [@tsurdilo](https://github.com/tsurdilo)
+  - Lance Ball - [@lance](https://github.com/lance)
 - **SAP**
   - [kubeless](https://kubeless.io)
   - Nathan Oyler - [@notque](https://github.com/notque)


### PR DESCRIPTION
Reviewing the changes since 1.0, I realized that I wasn't on the contributors doc. Not a big deal, but thought I would go ahead and add myself. It doesn't appear that names are in any particular order, so I just put myself at the bottom of the Red Hat list.

Signed-off-by: Lance Ball <lball@redhat.com>