### PR TITLE
docs: add a note about data to the primer

### DIFF
--- a/primer.md
+++ b/primer.md
@@ -289,6 +289,28 @@ context, for the purposes of this CloudEvent attribute those meanings are not
 relevant and therefore using `id` for some other purpose beyond uniqueness
 checking is out of scope of the specification and not recommended.
 
+### data
+
+The `data` attribute of a CloudEvent may carry the event data itself. Event
+consumers can use the `datacontenttype` attribute of a CloudEvent to determine
+what the type is, for example `application/json` or `image/png`. There are no
+restrictions on the type of data that may be included with a CloudEvent. Event
+consumers can expect that the event data is transported unaltered due to any
+encoding used by an SDK to facilitate transport over a given protocol. When a
+CloudEvent is sent by an event producer over a supported protocol, the event
+`data` may be encoded in Base64 form for transmission. However, on the receiving
+end of the transmission this data will be decoded into its original unaltered
+form. CloudEvent SDKs are responsible for encoding and decoding this data.
+
+Consider an example. An IoT device is creating CloudEvents with JSON expressed
+as a sequence of bytes, i.e. in binary form. It may set the `datacontenttype`
+attribute on the event to `application/json` even though the data itself is in
+binary form. A receiver of this event should expect to find the data attribute
+still in its original binary form even after having been transmitted over the
+wire. It is the responsibility of the event consumer to convert this data from
+its binary form into JSON or other data type as specified by the
+`datacontenttype` attribute.
+
 ## CloudEvent Attribute Extensions
 
 In order to achieve the stated goals, the specification authors will attempt to

--- a/primer.md
+++ b/primer.md
@@ -291,16 +291,16 @@ checking is out of scope of the specification and not recommended.
 
 ### data
 
-The `data` attribute of a CloudEvent may carry the event data itself. Event
-consumers can use the `datacontenttype` attribute of a CloudEvent to determine
-what the type is, for example `application/json` or `image/png`. There are no
-restrictions on the type of data that may be included with a CloudEvent. Event
-consumers can expect that the event data is transported unaltered due to any
-encoding used by an SDK to facilitate transport over a given protocol. When a
-CloudEvent is sent by an event producer over a supported protocol, the event
-`data` may be encoded in Base64 form for transmission. However, on the receiving
-end of the transmission this data will be decoded into its original unaltered
-form. CloudEvent SDKs are responsible for encoding and decoding this data.
+Event consumers can use the `datacontenttype` attribute of a CloudEvent to
+determine what the type is, for example `application/json` or `image/png`. There
+are no restrictions on the encoding format of data that may be included with a
+CloudEvent. Event consumers can expect that the event data is transported
+unaltered due to any encoding used by an SDK to facilitate transport over a
+given protocol. When a CloudEvent is sent by an event producer over a supported
+protocol, the event `data` may be encoded in Base64 form for transmission.
+However, on the receiving end of the transmission this data will be decoded into
+its original unaltered form. CloudEvent SDKs are responsible for encoding and
+decoding this data.
 
 Consider an example. An IoT device is creating CloudEvents with JSON expressed
 as a sequence of bytes, i.e. in binary form. It may set the `datacontenttype`

--- a/primer.md
+++ b/primer.md
@@ -292,24 +292,15 @@ checking is out of scope of the specification and not recommended.
 ### data
 
 Event consumers can use the `datacontenttype` attribute of a CloudEvent to
-determine what the type is, for example `application/json` or `image/png`. There
-are no restrictions on the encoding format of data that may be included with a
-CloudEvent. Event consumers can expect that the event data is transported
-unaltered due to any encoding used by an SDK to facilitate transport over a
-given protocol. When a CloudEvent is sent by an event producer over a supported
-protocol, the event `data` may be encoded in Base64 form for transmission.
-However, on the receiving end of the transmission this data will be decoded into
-its original unaltered form. CloudEvent SDKs are responsible for encoding and
-decoding this data.
-
-Consider an example. An IoT device is creating CloudEvents with JSON expressed
-as a sequence of bytes, i.e. in binary form. It may set the `datacontenttype`
-attribute on the event to `application/json` even though the data itself is in
-binary form. A receiver of this event should expect to find the data attribute
-still in its original binary form even after having been transmitted over the
-wire. It is the responsibility of the event consumer to convert this data from
-its binary form into JSON or other data type as specified by the
-`datacontenttype` attribute.
+determine the type of `data`, for example `application/json` or `image/png`.
+There are no restrictions on the encoding format of data that may be included
+with a CloudEvent. Event consumers can expect that the event data is
+transported unaltered due to any encoding used by an SDK to facilitate
+transport over a given protocol.  CloudEvent SDKs should avoid modifying the
+event data in any way.  This includes actions such as syntax reformatting.
+Even though it might appear to not influence the semantic meaning of the
+information, the SDK can not be sure if the original format is meaningful to
+the consumer's processing.
 
 ## CloudEvent Attribute Extensions
 


### PR DESCRIPTION
This commit adds some text around a CloudEvent's data attribute. Specifically,
it highlights that the data may be encoded as base64 for transmission across
the wire, but is otherwise left unchanged for the event consumer.

Signed-off-by: Lance Ball <lball@redhat.com>