### PR TITLE
v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,25 @@ The following documents are available:
 |                               |                                 Latest Release                                  |                                      Working Draft                                       |
 | :---------------------------- | :-----------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------: |
 | **Core Specification:**       |
-| CloudEvents                   |          [v1.0](https://github.com/cloudevents/spec/blob/v1.0/spec.md)          |            [master](https://github.com/cloudevents/spec/blob/master/spec.md)             |
+| CloudEvents                   |          [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md)          |            [master](https://github.com/cloudevents/spec/blob/master/spec.md)             |
 |                               |
 | **Optional Specifications:**  |
-| AMQP Protocol Binding         | [v1.0](https://github.com/cloudevents/spec/blob/v1.0/amqp-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/amqp-protocol-binding.md)    |
-| AVRO Event Format             |      [v1.0](https://github.com/cloudevents/spec/blob/v1.0/avro-format.md)       |         [master](https://github.com/cloudevents/spec/blob/master/avro-format.md)         |
-| HTTP Protocol Binding         | [v1.0](https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/http-protocol-binding.md)    |
-| JSON Event Format             |      [v1.0](https://github.com/cloudevents/spec/blob/v1.0/json-format.md)       |         [master](https://github.com/cloudevents/spec/blob/master/json-format.md)         |
-| Kafka Protocol Binding        | [v1.0](https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md) |   [master](https://github.com/cloudevents/spec/blob/master/kafka-protocol-binding.md)    |
-| MQTT Protocol Binding         | [v1.0](https://github.com/cloudevents/spec/blob/v1.0/mqtt-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/mqtt-protocol-binding.md)    |
-| NATS Protocol Binding         | [v1.0](https://github.com/cloudevents/spec/blob/v1.0/nats-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/nats-protocol-binding.md)    |
+| AMQP Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/amqp-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/amqp-protocol-binding.md)    |
+| AVRO Event Format             |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/avro-format.md)       |         [master](https://github.com/cloudevents/spec/blob/master/avro-format.md)         |
+| HTTP Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/http-protocol-binding.md)    |
+| JSON Event Format             |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/json-format.md)       |         [master](https://github.com/cloudevents/spec/blob/master/json-format.md)         |
+| Kafka Protocol Binding        | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/kafka-protocol-binding.md) |   [master](https://github.com/cloudevents/spec/blob/master/kafka-protocol-binding.md)    |
+| MQTT Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/mqtt-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/mqtt-protocol-binding.md)    |
+| NATS Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/nats-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/nats-protocol-binding.md)    |
 | WebSockets Protocol Binding   |                                        -                                        | [master](https://github.com/cloudevents/spec/blob/master/websockets-protocol-binding.md) |
-| Protobuf Event Format         |                                                                                 | [master](https://github.com/cloudevents/spec/blob/master/protobuf-format.md)                                  |
-| Web hook                      |      [v1.0](https://github.com/cloudevents/spec/blob/v1.0/http-webhook.md)      |        [master](https://github.com/cloudevents/spec/blob/master/http-webhook.md)         |
+| Protobuf Event Format         |                                                                                 | [v1.0-rc1](https://github.com/cloudevents/spec/blob/master/protobuf-format.md)                                  |
+| Web hook                      |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-webhook.md)      |        [master](https://github.com/cloudevents/spec/blob/master/http-webhook.md)         |
 |                               |
 | **Additional Documentation:** |
 | CloudEvents Adapters          |                                        -                                        |          [master](https://github.com/cloudevents/spec/blob/master/adapters.md)           |
 | CloudEvents SDK Requirements  |                                        -                                        |             [master](https://github.com/cloudevents/spec/blob/master/SDK.md)             |
 | Documented Extensions         |                                        -                                        |    [master](https://github.com/cloudevents/spec/blob/master/documented-extensions.md)    |
-| Primer                        |         [v1.0](https://github.com/cloudevents/spec/blob/v1.0/primer.md)         |           [master](https://github.com/cloudevents/spec/blob/master/primer.md)            |
+| Primer                        |         [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/primer.md)         |           [master](https://github.com/cloudevents/spec/blob/master/primer.md)            |
 | Proprietary Specifications    |                                        -                                        |      [master](https://github.com/cloudevents/spec/blob/master/proprietary-specs.md)      |
 
 If you are new to CloudEvents, it is recommended that you start by reading the

--- a/adapters/aws-s3.md
+++ b/adapters/aws-s3.md
@@ -14,7 +14,7 @@ same pattern as described in the following table:
 | :-------------------- | :---------------------------------------------- |
 | `id`                  | "responseElements.x-amz-request-id" + `.` + "responseElements.x-amz-id-2" |
 | `source`              | "eventSource" value + `.` + "awsRegion" value + `.` + "s3.buckets.name" value  |
-| `specversion`         | `1.x-wip`                                       |
+| `specversion`         | `1.0`                                           |
 | `type`                | `com.amazonaws.s3.` + "eventName" value         |
 | `datacontenttype`     | S3 event type (e.g. `application/json`)         |
 | `dataschema`          | Omit                                            |

--- a/adapters/couchdb.md
+++ b/adapters/couchdb.md
@@ -18,7 +18,7 @@ based on the event type.
 | :-------------------- | :------------------------------------ |
 | `id`                  | The event sequence identifier (`seq`) |
 | `source`              | The server URL / `db`                 |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `org.apache.couchdb.document.updated` |
 | `datacontenttype`     | `application/json`                    |
 | `subject`             | The document identifier (`id`)        |
@@ -31,7 +31,7 @@ based on the event type.
 | :-------------------- | :------------------------------------ |
 | `id`                  | The event sequence identifier (`seq`) |
 | `source`              | The server URL / `db`                 |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `org.apache.couchdb.document.deleted` |
 | `datacontenttype`     | `application/json`                    |
 | `subject`             | The document identifier (`id`)        |
@@ -46,7 +46,7 @@ based on the event type.
 | :-------------------- | :------------------------------------ |
 | `id`                  | The event sequence identifier (`seq`) |
 | `source`              | The server URL                        |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `org.apache.couchdb.database.created` |
 | `subject`             | The database name (`db_name`)         |
 | `time`                | Current time                          |
@@ -57,7 +57,7 @@ based on the event type.
 | :-------------------- | :------------------------------------ |
 | `id`                  | The event sequence identifier (`seq`) |
 | `source`              | The server URL                        |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `org.apache.couchdb.database.updated` |
 | `subject`             | The database name (`db_name`)         |
 | `time`                | Current time                          |
@@ -68,7 +68,7 @@ based on the event type.
 | :-------------------- | :------------------------------------ |
 | `id`                  | The event sequence identifier (`seq`) |
 | `source`              | The server URL                        |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `org.apache.couchdb.database.deleted` |
 | `subject`             | The database name (`db_name`)         |
 | `time`                | Current time                          |

--- a/adapters/github.md
+++ b/adapters/github.md
@@ -16,7 +16,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value                                            |
 | `source`              | "repository.url" value                                                           |
-| `specversion`         | `1.x-wip`                                                                        |
+| `specversion`         | `1.0`                                                                            |
 | `type`                | `com.github.check_run.` + "action" value                                         |
 | `datacontentencoding` | Omit                                                                             |
 | `datacontenttype`     | `application/json`                                                               |
@@ -31,7 +31,7 @@ based on the specified event.
 | :-------------------- | :----------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value      |
 | `source`              | "repository.url" value                     |
-| `specversion`         | `1.x-wip`                                  |
+| `specversion`         | `1.0`                                      |
 | `type`                | `com.github.check_suite.` + "action" value |
 | `datacontentencoding` | Omit                                       |
 | `datacontenttype`     | `application/json`                         |
@@ -46,7 +46,7 @@ based on the specified event.
 | :-------------------- | :---------------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value                 |
 | `source`              | "comment.url" value + `/` + "comment.commit_id" value |
-| `specversion`         | `1.x-wip`                                             |
+| `specversion`         | `1.0`                                                 |
 | `type`                | `com.github.commit_comment.` + "action" value         |
 | `datacontentencoding` | Omit                                                  |
 | `datacontenttype`     | `application/json`                                    |
@@ -61,7 +61,7 @@ based on the specified event.
 | :-------------------- | :----------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value            |
 | `source`              | "repository.url" value                           |
-| `specversion`         | `1.x-wip`                                        |
+| `specversion`         | `1.0`                                            |
 | `type`                | `com.github.content_reference.` + "action" value |
 | `datacontentencoding` | Omit                                             |
 | `datacontenttype`     | `application/json`                               |
@@ -76,7 +76,7 @@ based on the specified event.
 | :-------------------- | :-------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value   |
 | `source`              | "repository.url" value                  |
-| `specversion`         | `1.x-wip`                               |
+| `specversion`         | `1.0`                                   |
 | `type`                | `com.github.create.` + "ref_type" value |
 | `datacontentencoding` | Omit                                    |
 | `datacontenttype`     | `application/json`                      |
@@ -91,7 +91,7 @@ based on the specified event.
 | :-------------------- | :-------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value   |
 | `source`              | "repository.url" value                  |
-| `specversion`         | `1.x-wip`                               |
+| `specversion`         | `1.0`                                   |
 | `type`                | `com.github.delete.` + "ref_type" value |
 | `datacontentencoding` | Omit                                    |
 | `datacontenttype`     | `application/json`                      |
@@ -106,7 +106,7 @@ based on the specified event.
 | :-------------------- | :-------------------------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value                           |
 | `source`              | "repository.url" value                                          |
-| `specversion`         | `1.x-wip`                                                       |
+| `specversion`         | `1.0`                                                           |
 | `type`                | `com.github.deploy_key.` + "action" value                       |
 | `datacontentencoding` | Omit                                                            |
 | `datacontenttype`     | `application/json`                                              |
@@ -121,7 +121,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "repository.url" value                |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.deployment`               |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |
@@ -136,7 +136,7 @@ based on the specified event.
 | :-------------------- | :---------------------------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value                             |
 | `source`              | "deployment.url" value                                            |
-| `specversion`         | `1.x-wip`                                                         |
+| `specversion`         | `1.0`                                                             |
 | `type`                | `com.github.deployment_status.` + "deployment_status.state" value |
 | `datacontentencoding` | Omit                                                              |
 | `datacontenttype`     | `application/json`                                                |
@@ -151,7 +151,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "repository.url" value                |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.fork`                     |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |
@@ -166,7 +166,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "sender.url" value                    |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.github_app_authorization` |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |
@@ -181,7 +181,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value       |
 | `source`              | "repository.url" value                      |
-| `specversion`         | `1.x-wip`                                   |
+| `specversion`         | `1.0`                                       |
 | `type`                | `com.github.gollum.` + "pages.action" value |
 | `datacontentencoding` | Omit                                        |
 | `datacontenttype`     | `application/json`                          |
@@ -196,7 +196,7 @@ based on the specified event.
 | :-------------------- | :-------------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value               |
 | `source`              | "installation.account.url" value                    |
-| `specversion`         | `1.x-wip`                                           |
+| `specversion`         | `1.0`                                               |
 | `type`                | `com.github.installation.` + "action" value         |
 | `datacontentencoding` | Omit                                                |
 | `datacontenttype`     | `application/json`                                  |
@@ -211,7 +211,7 @@ based on the specified event.
 | :-------------------- | :----------------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value                  |
 | `source`              | "installation.account.url" value                       |
-| `specversion`         | `1.x-wip`                                              |
+| `specversion`         | `1.0`                                                  |
 | `type`                | `com.github.installation_repository.` + "action" value |
 | `datacontentencoding` | Omit                                                   |
 | `datacontenttype`     | `application/json`                                     |
@@ -226,7 +226,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value        |
 | `source`              | "issue.url" value                            |
-| `specversion`         | `1.x-wip`                                    |
+| `specversion`         | `1.0`                                        |
 | `type`                | `com.github.issue_comment.` + "action" value |
 | `datacontentencoding` | Omit                                         |
 | `datacontenttype`     | `application/json`                           |
@@ -241,7 +241,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "repository.url" value                |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.issue.` + "action" value  |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |
@@ -256,7 +256,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "repository.url" value                |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.label.` + "action" value  |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |
@@ -271,7 +271,7 @@ based on the specified event.
 | :-------------------- | :-------------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value               |
 | `source`              | "sender.url" value without the `/username` portion  |
-| `specversion`         | `1.x-wip`                                           |
+| `specversion`         | `1.0`                                               |
 | `type`                | `com.github.marketplace_purchase.` + "action" value |
 | `datacontentencoding` | Omit                                                |
 | `datacontenttype`     | `application/json`                                  |
@@ -286,7 +286,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "repository.url" value                |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.member.` + "action" value |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |
@@ -301,7 +301,7 @@ based on the specified event.
 | :-------------------- | :-------------------------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value                           |
 | `source`              | "team.url" value                                                |
-| `specversion`         | `1.x-wip`                                                       |
+| `specversion`         | `1.0`                                                           |
 | `type`                | `com.github.membership.` + "scope" value + `.` + "action" value |
 | `datacontentencoding` | Omit                                                            |
 | `datacontenttype`     | `application/json`                                              |
@@ -316,7 +316,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "repository.url" value                |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.meta.` + "action" value   |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |
@@ -331,7 +331,7 @@ based on the specified event.
 | :-------------------- | :--------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value    |
 | `source`              | "repository.url" value                   |
-| `specversion`         | `1.x-wip`                                |
+| `specversion`         | `1.0`                                    |
 | `type`                | `com.github.milestone.` + "action" value |
 | `datacontentencoding` | Omit                                     |
 | `datacontenttype`     | `application/json`                       |
@@ -346,7 +346,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value        |
 | `source`              | "organization.url" value                     |
-| `specversion`         | `1.x-wip`                                    |
+| `specversion`         | `1.0`                                        |
 | `type`                | `com.github.organization.` + "action" value  |
 | `datacontentencoding` | Omit                                         |
 | `datacontenttype`     | `application/json`                           |
@@ -361,7 +361,7 @@ based on the specified event.
 | :-------------------- | :--------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value    |
 | `source`              | "organization.url" value                 |
-| `specversion`         | `1.x-wip`                                |
+| `specversion`         | `1.0`                                    |
 | `type`                | `com.github.org_block.` + "action" value |
 | `datacontentencoding` | Omit                                     |
 | `datacontenttype`     | `application/json`                       |
@@ -376,7 +376,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "repository.url" value                |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.page_build`               |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |
@@ -391,7 +391,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value       |
 | `source`              | "repository.url" value                      |
-| `specversion`         | `1.x-wip`                                   |
+| `specversion`         | `1.0`                                       |
 | `type`                | `com.github.project_card.` + "action" value |
 | `datacontentencoding` | Omit                                        |
 | `datacontenttype`     | `application/json`                          |
@@ -406,7 +406,7 @@ based on the specified event.
 | :-------------------- | :-------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value         |
 | `source`              | "repository.url" value                        |
-| `specversion`         | `1.x-wip`                                     |
+| `specversion`         | `1.0`                                         |
 | `type`                | `com.github.project_column.` + "action" value |
 | `datacontentencoding` | Omit                                          |
 | `datacontenttype`     | `application/json`                            |
@@ -421,7 +421,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value  |
 | `source`              | "repository.url" value                 |
-| `specversion`         | `1.x-wip`                              |
+| `specversion`         | `1.0`                                  |
 | `type`                | `com.github.project.` + "action" value |
 | `datacontentencoding` | Omit                                   |
 | `datacontenttype`     | `application/json`                     |
@@ -436,7 +436,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "repository.owner.url" value          |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.public`                   |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |
@@ -451,7 +451,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value       |
 | `source`              | "repository.url" value                      |
-| `specversion`         | `1.x-wip`                                   |
+| `specversion`         | `1.0`                                       |
 | `type`                | `com.github.pull_request.` + "action" value |
 | `datacontentencoding` | Omit                                        |
 | `datacontenttype`     | `application/json`                          |
@@ -466,7 +466,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value              |
 | `source`              | "pull_request.url" value                           |
-| `specversion`         | `1.x-wip`                                          |
+| `specversion`         | `1.0`                                              |
 | `type`                | `com.github.pull_request_review.` + "action" value |
 | `datacontentencoding` | Omit                                               |
 | `datacontenttype`     | `application/json`                                 |
@@ -481,7 +481,7 @@ based on the specified event.
 | :-------------------- | :--------------------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value                      |
 | `source`              | "pull_request.url" value                                   |
-| `specversion`         | `1.x-wip`                                                  |
+| `specversion`         | `1.0`                                                      |
 | `type`                | `com.github.pull_request_review_comment.` + "action" value |
 | `datacontentencoding` | Omit                                                       |
 | `datacontenttype`     | `application/json`                                         |
@@ -496,7 +496,7 @@ based on the specified event.
 | :-------------------- | :-------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value   |
 | `source`              | "repository.url" value                  |
-| `specversion`         | `1.x-wip`                               |
+| `specversion`         | `1.0`                                   |
 | `type`                | `com.github.push`                       |
 | `datacontentencoding` | Omit                                    |
 | `datacontenttype`     | `application/json`                      |
@@ -511,7 +511,7 @@ based on the specified event.
 | :-------------------- | :---------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value           |
 | `source`              | "repository.url" value                          |
-| `specversion`         | `1.x-wip`                                       |
+| `specversion`         | `1.0`                                           |
 | `type`                | `com.github.registry_package.` + "action" value |
 | `datacontentencoding` | Omit                                            |
 | `datacontenttype`     | `application/json`                              |
@@ -526,7 +526,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value  |
 | `source`              | "repository.url" value                 |
-| `specversion`         | `1.x-wip`                              |
+| `specversion`         | `1.0`                                  |
 | `type`                | `com.github.release.` + "action" value |
 | `datacontentencoding` | Omit                                   |
 | `datacontenttype`     | `application/json`                     |
@@ -541,7 +541,7 @@ based on the specified event.
 | :-------------------- | :---------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value     |
 | `source`              | "repository.owner.url" value              |
-| `specversion`         | `1.x-wip`                                 |
+| `specversion`         | `1.0`                                     |
 | `type`                | `com.github.repository.` + "action" value |
 | `datacontentencoding` | Omit                                      |
 | `datacontenttype`     | `application/json`                        |
@@ -556,7 +556,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "repository.owner.url" value          |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.repository_import`        |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |
@@ -571,7 +571,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value                         |
 | `source`              | "repository.url" value                                        |
-| `specversion`         | `1.x-wip`                                                     |
+| `specversion`         | `1.0`                                                         |
 | `type`                | `com.github.repository_vulnerability_alert.` + "action" value |
 | `datacontentencoding` | Omit                                                          |
 | `datacontenttype`     | `application/json`                                            |
@@ -586,7 +586,7 @@ based on the specified event.
 | :-------------------- | :----------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value            |
 | `source`              | `github.com`                                     |
-| `specversion`         | `1.x-wip`                                        |
+| `specversion`         | `1.0`                                            |
 | `type`                | `com.github.security_advisory.` + "action" value |
 | `datacontentencoding` | Omit                                             |
 | `datacontenttype`     | `application/json`                               |
@@ -601,7 +601,7 @@ based on the specified event.
 | :-------------------- | :---------------------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value                 |
 | `source`              | "repository.url" value                                |
-| `specversion`         | `1.x-wip`                                             |
+| `specversion`         | `1.0`                                                 |
 | `type`                | `com.github.star.` + "action" value                   |
 | `datacontentencoding` | Omit                                                  |
 | `datacontenttype`     | `application/json`                                    |
@@ -616,7 +616,7 @@ based on the specified event.
 | :-------------------- | :--------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value    |
 | `source`              | "repository.url" value                   |
-| `specversion`         | `1.x-wip`                                |
+| `specversion`         | `1.0`                                    |
 | `type`                | `com.github.status.` # + "state" value ? |
 | `datacontentencoding` | Omit                                     |
 | `datacontenttype`     | `application/json`                       |
@@ -631,7 +631,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "repository.url" value                |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.team.` + "action" value   |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |
@@ -646,7 +646,7 @@ based on the specified event.
 | :-------------------- | :-------------------------------------- |
 | `id`                  | "X-GitHub-Delivery" HTTP header value   |
 | `source`              | "repository.url" value                  |
-| `specversion`         | `1.x-wip`                               |
+| `specversion`         | `1.0`                                   |
 | `type`                | `com.github.team_add.` + "action" value |
 | `datacontentencoding` | Omit                                    |
 | `datacontenttype`     | `application/json`                      |
@@ -661,7 +661,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------ |
 | `id`                  | "X-GitHub-Delivery" HTTP header value |
 | `source`              | "repository.url" value                |
-| `specversion`         | `1.x-wip`                             |
+| `specversion`         | `1.0`                                 |
 | `type`                | `com.github.watch.` + "action" value  |
 | `datacontentencoding` | Omit                                  |
 | `datacontenttype`     | `application/json`                    |

--- a/adapters/gitlab.md
+++ b/adapters/gitlab.md
@@ -16,7 +16,7 @@ based on the specified event.
 | :-------------------- | :--------------------------------------- |
 | `id`                  | Generate a new unique value, e.g. a UUID |
 | `source`              | "repository.homepage" value              |
-| `specversion`         | `1.x-wip`                                |
+| `specversion`         | `1.0`                                    |
 | `type`                | `com.gitlab.push`                        |
 | `datacontenttype`     | `application/json`                       |
 | `dataschema`          | Omit                                     |
@@ -30,7 +30,7 @@ based on the specified event.
 | :-------------------- | :--------------------------------------- |
 | `id`                  | Generate a new unique value, e.g. a UUID |
 | `source`              | "repository.homepage" value              |
-| `specversion`         | `1.x-wip`                                |
+| `specversion`         | `1.0`                                    |
 | `type`                | `com.gitlab.tag_push`                    |
 | `datacontenttype`     | `application/json`                       |
 | `dataschema`          | Omit                                     |
@@ -44,7 +44,7 @@ based on the specified event.
 | :-------------------- | :---------------------------------------------------- |
 | `id`                  | Generate a new unique value, e.g. a UUID              |
 | `source`              | "repository.homepage" value                           |
-| `specversion`         | `1.x-wip`                                             |
+| `specversion`         | `1.0`                                                 |
 | `type`                | `com.gitlab.issue.` + "object_attributes.state" value |
 | `datacontenttype`     | `application/json`                                    |
 | `dataschema`          | Omit                                                  |
@@ -58,7 +58,7 @@ based on the specified event.
 | :-------------------- | :--------------------------------------- |
 | `id`                  | Generate a new unique value, e.g. a UUID |
 | `source`              | "commit.url" value                       |
-| `specversion`         | `1.x-wip`                                |
+| `specversion`         | `1.0`                                    |
 | `type`                | `com.gitlab.note.commit`                 |
 | `datacontenttype`     | `application/json`                       |
 | `dataschema`          | Omit                                     |
@@ -72,7 +72,7 @@ based on the specified event.
 | :-------------------- | :----------------------------------------------------------- |
 | `id`                  | Generate a new unique value, e.g. a UUID                     |
 | `source`              | "object_attributes.url" value, without the `#note\_...` part |
-| `specversion`         | `1.x-wip`                                                    |
+| `specversion`         | `1.0`                                                        |
 | `type`                | `com.gitlab.note.merge_request`                              |
 | `datacontenttype`     | `application/json`                                           |
 | `dataschema`          | Omit                                                         |
@@ -86,7 +86,7 @@ based on the specified event.
 | :-------------------- | :---------------------------------------------------------- |
 | `id`                  | Generate a new unique value, e.g. a UUID                    |
 | `source`              | "object_attributes.url" value without the `#note\_...` part |
-| `specversion`         | `1.x-wip`                                                   |
+| `specversion`         | `1.0`                                                       |
 | `type`                | `com.gitlab.note.issue`                                     |
 | `datacontenttype`     | `application/json`                                          |
 | `dataschema`          | Omit                                                        |
@@ -100,7 +100,7 @@ based on the specified event.
 | :-------------------- | :---------------------------------------------------------- |
 | `id`                  | Generate a new unique value, e.g. a UUID                    |
 | `source`              | "object_attributes.url" value without the `#note\_...` part |
-| `specversion`         | `1.x-wip`                                                   |
+| `specversion`         | `1.0`                                                       |
 | `type`                | `com.gitlab.note.snippet`                                   |
 | `datacontenttype`     | `application/json`                                          |
 | `dataschema`          | Omit                                                        |
@@ -114,7 +114,7 @@ based on the specified event.
 | :-------------------- | :------------------------------------------------------------- |
 | `id`                  | Generate a new unique value, e.g. a UUID                       |
 | `source`              | "repository.homepage" value                                    |
-| `specversion`         | `1.x-wip`                                                      |
+| `specversion`         | `1.0`                                                          |
 | `type`                | `com.gitlab.merge_request.` + "object_attributes.action" value |
 | `datacontenttype`     | `application/json`                                             |
 | `dataschema`          | Omit                                                           |
@@ -128,7 +128,7 @@ based on the specified event.
 | :-------------------- | :--------------------------------------------------------- |
 | `id`                  | Generate a new unique value, e.g. a UUID                   |
 | `source`              | "project.web_url" value                                    |
-| `specversion`         | `1.x-wip`                                                  |
+| `specversion`         | `1.0`                                                      |
 | `type`                | `com.gitlab.wiki_page.` + "object_attributes.action" value |
 | `datacontenttype`     | `application/json`                                         |
 | `dataschema`          | Omit                                                       |
@@ -142,7 +142,7 @@ based on the specified event.
 | :-------------------- | :-------------------------------------------------------- |
 | `id`                  | Generate a new unique value, e.g. a UUID                  |
 | `source`              | "project.web_url" value                                   |
-| `specversion`         | `1.x-wip`                                                 |
+| `specversion`         | `1.0`                                                     |
 | `type`                | `com.gitlab.pipeline.` + "object_attributes.status" value |
 | `datacontenttype`     | `application/json`                                        |
 | `dataschema`          | Omit                                                      |
@@ -156,7 +156,7 @@ based on the specified event.
 | :-------------------- | :--------------------------------------- |
 | `id`                  | Generate a new unique value, e.g. a UUID |
 | `source`              | "repository.homepage" value              |
-| `specversion`         | `1.x-wip`                                |
+| `specversion`         | `1.0`                                    |
 | `type`                | `com.gitlab.job.` + "job_status" value   |
 | `datacontenttype`     | `application/json`                       |
 | `dataschema`          | Omit                                     |

--- a/amqp-protocol-binding.md
+++ b/amqp-protocol-binding.md
@@ -1,4 +1,4 @@
-# AMQP Protocol Binding for CloudEvents - Version 1.x-wip
+# AMQP Protocol Binding for CloudEvents - Version 1.0.1
 
 ## Abstract
 
@@ -225,7 +225,7 @@ content-type: application/json; charset=utf-8
 
 ----------- application-properties -----------
 
-cloudEvents:specversion: 1.x-wip
+cloudEvents:specversion: 1.0
 cloudEvents:type: com.example.someevent
 cloudEvents:time: 2018-04-05T03:56:24Z
 cloudEvents:id: 1234-1234-1234
@@ -287,7 +287,7 @@ content-type: application/cloudevents+json; charset=utf-8
 ------------- application-data --------------------------
 
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/avro-format.md
+++ b/avro-format.md
@@ -1,4 +1,4 @@
-# Avro Event Format for CloudEvents - Version 1.x-wip
+# Avro Event Format for CloudEvents - Version 1.0.1
 
 ## Abstract
 
@@ -82,7 +82,7 @@ described by the [CloudEvent Avro Schema](./spec.avsc):
   "namespace": "io.cloudevents",
   "type": "record",
   "name": "CloudEvent",
-  "version": "1.x-wip",
+  "version": "1.0",
   "doc": "Avro Event Format for CloudEvents",
   "fields": [
     {
@@ -157,7 +157,7 @@ The following table shows exemplary mappings:
 | CloudEvents | Type   | Exemplary Avro Value                           |
 | ----------- | ------ | ---------------------------------------------- |
 | type        | string | `"com.example.someevent"`                      |
-| specversion | string | `"1.x-wip"`                                    |
+| specversion | string | `"1.0"`                                        |
 | source      | string | `"/mycontext"`                                 |
 | id          | string | `"7a0dc520-c870-4193c8"`                       |
 | time        | string | `"2019-06-05T23:45:00Z"`                       |

--- a/extensions/dataref.md
+++ b/extensions/dataref.md
@@ -48,7 +48,7 @@ both `data` and `dataref` (serialized as JSON):
 
 ```JSON
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.github.pull_request.opened",
     "source" : "https://github.com/cloudevents/spec/pull/123",
     "id" : "A234-1234-1234",
@@ -63,7 +63,7 @@ The following example shows a CloudEvent in which a middleware has replaced the
 
 ```JSON
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.github.pull_request.opened",
     "source" : "https://github.com/cloudevents/spec/pull/123",
     "id" : "A234-1234-1234",

--- a/extensions/distributed-tracing.md
+++ b/extensions/distributed-tracing.md
@@ -46,7 +46,7 @@ An example with HTTP:
 ```bash
 CURL -X POST example/webhook.json \
 -H 'ce-id: 1' \
--H 'ce-specversion: 1.x-wip' \
+-H 'ce-specversion: 1.0' \
 -H 'ce-type: example' \
 -H 'ce-source: http://localhost' \
 -H 'ce-traceparent:  00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01' \

--- a/http-protocol-binding.md
+++ b/http-protocol-binding.md
@@ -1,4 +1,4 @@
-# HTTP Protocol Binding for CloudEvents - Version 1.x-wip
+# HTTP Protocol Binding for CloudEvents - Version 1.0.1
 
 ## Abstract
 
@@ -232,7 +232,7 @@ request:
 ```text
 POST /someresource HTTP/1.1
 Host: webhook.example.com
-ce-specversion: 1.x-wip
+ce-specversion: 1.0
 ce-type: com.example.someevent
 ce-time: 2018-04-05T03:56:24Z
 ce-id: 1234-1234-1234
@@ -250,7 +250,7 @@ This example shows a response containing an event:
 
 ```text
 HTTP/1.1 200 OK
-ce-specversion: 1.x-wip
+ce-specversion: 1.0
 ce-type: com.example.someevent
 ce-time: 2018-04-05T03:56:24Z
 ce-id: 1234-1234-1234
@@ -309,7 +309,7 @@ Content-Type: application/cloudevents+json; charset=utf-8
 Content-Length: nnnn
 
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -330,7 +330,7 @@ Content-Type: application/cloudevents+json; charset=utf-8
 Content-Length: nnnn
 
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...
@@ -386,7 +386,7 @@ Content-Length: nnnn
 
 [
     {
-        "specversion" : "1.x-wip",
+        "specversion" : "1.0",
         "type" : "com.example.someevent",
 
         ... further attributes omitted ...
@@ -396,7 +396,7 @@ Content-Length: nnnn
         }
     },
     {
-        "specversion" : "1.x-wip",
+        "specversion" : "1.0",
         "type" : "com.example.someotherevent",
 
         ... further attributes omitted ...
@@ -419,7 +419,7 @@ Content-Length: nnnn
 
 [
     {
-        "specversion" : "1.x-wip",
+        "specversion" : "1.0",
         "type" : "com.example.someevent",
 
         ... further attributes omitted ...
@@ -429,7 +429,7 @@ Content-Length: nnnn
         }
     },
     {
-        "specversion" : "1.x-wip",
+        "specversion" : "1.0",
         "type" : "com.example.someotherevent",
 
         ... further attributes omitted ...

--- a/http-webhook.md
+++ b/http-webhook.md
@@ -1,4 +1,4 @@
-# HTTP 1.1 Web Hooks for Event Delivery - Version 1.x-wip
+# HTTP 1.1 Web Hooks for Event Delivery - Version 1.0.1
 
 ## Abstract
 

--- a/json-format.md
+++ b/json-format.md
@@ -1,4 +1,4 @@
-# JSON Event Format for CloudEvents - Version 1.x-wip
+# JSON Event Format for CloudEvents - Version 1.0.1
 
 ## Abstract
 
@@ -100,7 +100,7 @@ The following table shows exemplary attribute mappings:
 | CloudEvents     | Type             | Exemplary JSON Value    |
 | --------------- | ---------------- | ----------------------- |
 | type            | String           | "com.example.someevent" |
-| specversion     | String           | "1.x-wip"               |
+| specversion     | String           | "1.0"                   |
 | source          | URI-reference    | "/mycontext"            |
 | subject         | String           | "larger-context"        |
 | subject         | String (null)    | null                    |
@@ -160,7 +160,7 @@ Example event with `String`-valued `data`:
 
 ```JSON
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "A234-1234-1234",
@@ -177,7 +177,7 @@ Example event with `Binary`-valued data
 
 ```JSON
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "id" : "B234-1234-1234",
@@ -194,7 +194,7 @@ or [JSON data](#31-handling-of-data) data:
 
 ```JSON
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.example.someevent",
     "source" : "/mycontext",
     "subject": null,
@@ -243,7 +243,7 @@ second with JSON data.
 ```JSON
 [
   {
-      "specversion" : "1.x-wip",
+      "specversion" : "1.0",
       "type" : "com.example.someevent",
       "source" : "/mycontext/4",
       "id" : "B234-1234-1234",
@@ -254,7 +254,7 @@ second with JSON data.
       "data_base64" : "... base64 encoded string ..."
   },
   {
-      "specversion" : "1.x-wip",
+      "specversion" : "1.0",
       "type" : "com.example.someotherevent",
       "source" : "/mycontext/9",
       "id" : "C234-1234-1234",

--- a/kafka-protocol-binding.md
+++ b/kafka-protocol-binding.md
@@ -1,4 +1,4 @@
-# Kafka Protocol Binding for CloudEvents - Version 1.x-wip
+# Kafka Protocol Binding for CloudEvents - Version 1.0.1
 
 ## Abstract
 
@@ -221,7 +221,7 @@ Key: mykey
 
 ------------------ headers -------------------
 
-ce_specversion: "1.x-wip"
+ce_specversion: "1.0"
 ce_type: "com.example.someevent"
 ce_source: "/mycontext/subcontext"
 ce_id: "1234-1234-1234"
@@ -287,7 +287,7 @@ content-type: application/cloudevents+json; charset=UTF-8
 ------------------- value --------------------
 
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.example.someevent",
     "source" : "/mycontext/subcontext",
     "id" : "1234-1234-1234",

--- a/mqtt-protocol-binding.md
+++ b/mqtt-protocol-binding.md
@@ -1,4 +1,4 @@
-# MQTT Protocol Binding for CloudEvents - Version 1.x-wip
+# MQTT Protocol Binding for CloudEvents - Version 1.0.1
 
 ## Abstract
 
@@ -197,7 +197,7 @@ Content Type: application/json; charset=utf-8
 
 ------------- User Properties ----------------
 
-specversion: 1.x-wip
+specversion: 1.0
 type: com.example.someevent
 time: 2018-04-05T03:56:24Z
 id: 1234-1234-1234
@@ -260,7 +260,7 @@ Content Type: application/cloudevents+json; charset=utf-8
 ------------------ payload -------------------
 
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.example.someevent",
 	"time" : 2018-04-05T03:56;24Z,
 	"id" : 1234-1234-1234,
@@ -289,7 +289,7 @@ Topic Name: mytopic
 ------------------ payload -------------------
 
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.example.someevent",
 	"time" : 2018-04-05T03:56;24Z,
 	"id" : 1234-1234-1234,

--- a/nats-protocol-binding.md
+++ b/nats-protocol-binding.md
@@ -1,4 +1,4 @@
-# NATS Protocol Binding for CloudEvents - Version 1.x-wip
+# NATS Protocol Binding for CloudEvents - Version 1.0.1
 
 ## Abstract
 
@@ -128,7 +128,7 @@ Subject: mySubject
 ------------------ payload -------------------
 
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.example.someevent",
 
     ... further attributes omitted ...

--- a/primer.md
+++ b/primer.md
@@ -1,4 +1,4 @@
-# CloudEvents Primer - Version 1.x-wip
+# CloudEvents Primer - Version 1.0.1
 
 ## Abstract
 
@@ -441,13 +441,13 @@ nesting would be:
 
 ```
 Content-Type: application/json
-ce-specversion: 1.x-wip
+ce-specversion: 1.0
 ce-type: myevent
 ce-id: 1234-1234-1234
 ce-source: example.com
 
 {
-  "specversion": "1.x-wip",
+  "specversion": "1.0",
   "type": "coolevent",
   "id": "xxxx-xxxx-xxxx",
   "source": "bigco.com",

--- a/protobuf-format.md
+++ b/protobuf-format.md
@@ -1,4 +1,4 @@
-# Protobuf Event Format for CloudEvents - Version 1.0
+# Protobuf Event Format for CloudEvents - Version 1.0-rc1
 
 ## Abstract
 

--- a/spec.avsc
+++ b/spec.avsc
@@ -2,7 +2,7 @@
   "namespace":"io.cloudevents",
   "type":"record",
   "name":"AvroCloudEvent",
-  "version":"1.x-wip",
+  "version":"1.0",
   "doc":"Avro Event Format for CloudEvents",
   "fields":[
     {

--- a/spec.json
+++ b/spec.json
@@ -26,7 +26,7 @@
       "description": "The version of the CloudEvents specification which the event uses.",
       "$ref": "#/definitions/specversiondef",
       "examples": [
-        "1.x-wip"
+        "1.0"
       ]
     },
     "type": {

--- a/spec.md
+++ b/spec.md
@@ -1,4 +1,4 @@
-# CloudEvents - Version 1.x-wip
+# CloudEvents - Version 1.0.1
 
 ## Abstract
 
@@ -302,7 +302,7 @@ The following attributes are REQUIRED to be present in all CloudEvents:
 - Type: `String`
 - Description: The version of the CloudEvents specification which the event
   uses. This enables the interpretation of the context. Compliant event
-  producers MUST use a value of `1.x-wip` when referring to this version of the
+  producers MUST use a value of `1.0` when referring to this version of the
   specification.
 
   Currently, this attribute will only have the 'major' and 'minor' version
@@ -562,7 +562,7 @@ The following example shows a CloudEvent serialized as JSON:
 
 ```JSON
 {
-    "specversion" : "1.x-wip",
+    "specversion" : "1.0",
     "type" : "com.github.pull_request.opened",
     "source" : "https://github.com/cloudevents/spec/pull",
     "subject" : "123",

--- a/websockets-protocol-binding.md
+++ b/websockets-protocol-binding.md
@@ -1,4 +1,4 @@
-# WebSockets Protocol Binding for CloudEvents - Version 1.x-wip
+# WebSockets Protocol Binding for CloudEvents - Version 1.0.1
 
 ## Abstract
 


### PR DESCRIPTION
Significant PRs since v1.0:
- Add protobuf format as a sub-protocol - #721
- Allow JSON values to be null, meaning unset - #713
- [Primer] Adding a Non-Goal w.r.t Security - #712
- WebSockets protocol binding - #697
- Clarify difference between message mode and HTTP content mode - #672
- add missing sdks to readme - #666
- New sdk maintainers rules - #665
- move sdk governance and cleanup - #663
- Bring 'datadef' definition into line with specification - #658
- Add CoC and move some governance docs into 'community'  - #656
- Add blog post around understanding Cloud Events interactions - #651
- SDK governance draft - #649
- docs: add common processes for SDK maintainers and contributors - #648
- Adding Demo for Cloud Events Orchestration - #646 
- Clarified MUST requirement for JSON format - #644
- Re-Introducing Protocol Buffer Representation - #626
- Closes #615 - #616
- Reworked Distributed Tracing Extension - #607
- Minor updates to Cloud Events Primer - #600
- Kafka clarifications - #599
- Proprietary binding spec inclusion guide - #595
- Adding link to Pub/Sub binding - #588
- Add some clarity around SDK milestones - #584
- How to determine binary CE vs random non-CE message - #577
- Adding Visual Studio Code extension to community open-source doc - #573
- Specify encoding of kafka header keys and values and message key - #572
- Fix distributed tracing example - #569
- Paragraph about nested events to the primer - #567
- add rules for changing Admins- #564 
- Updating JSON Schema - #563
- Say it's ok to ignore non-MUST recommendations - at your own risk - #562
- Update Distributed Tracing extension spec links - #550
- Add Ruby SDK to SDK lists - #548
