### PR TITLE
Fix version URI typo for the 3.4.2 section

### DIFF
--- a/schemaregistry/schemaregistry.md
+++ b/schemaregistry/schemaregistry.md
@@ -396,7 +396,7 @@ schemas within the group.
 #### 3.4.2. Get a specific schema version
 
 A specific version of a schema is retrieved via a GET on schema version's path in the
-`versions` collection, for instance `/schemagroups/mygroup/schemas/myschema`.
+`versions` collection, for instance `/schemagroups/mygroup/schemas/myschema/versions/myversion`.
 
 The returned payload is the schema document. Further attributes such as the
 `description` and the `format` indicator are returned as HTTP headers.


### PR DESCRIPTION
Hi, I fixed the URI in the 3.4.2 section. To get a specific schema version, the URI is donated as `/schemagroups/mygroup/schemas/myschema/versions/myversion` may more reasonable .