### PR TITLE
Update http-webhook.md

### DIFF
--- a/http-webhook.md
+++ b/http-webhook.md
@@ -346,7 +346,7 @@ WebHook-Allowed-Rate: 100
 - [RFC7540][rfc7540] Hypertext Transfer Protocol Version 2 (HTTP/2)
 
 [ce]: ./spec.md
-[webhooks]: http://progrium.com/blog/2007/05/03/web-hooks-to-revolutionize-the-web/
+[webhooks]: https://web.archive.org/web/20180630220036/http://progrium.com/blog/2007/05/03/web-hooks-to-revolutionize-the-web/
 [content-type]: https://tools.ietf.org/html/rfc7231#section-3.1.1.5
 [retry-after]: https://tools.ietf.org/html/rfc7231#section-7.1.3
 [authorization]: https://tools.ietf.org/html/rfc7235#section-4.2


### PR DESCRIPTION
Updated the URL for the original and now missing blog post on webhooks from progrium.com. The new URL now points to a snapshot of the old blog post at archive.org.