### PR TITLE
Subscription OAS use of required and anyOf

### DIFF
--- a/subscriptions-api-openapi.yaml
+++ b/subscriptions-api-openapi.yaml
@@ -20,6 +20,7 @@ paths:
                   $ref: "#/components/schemas/Subscription"
     post:
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -78,6 +79,7 @@ paths:
           description: The id of an existing subscription
 
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/subscriptions-api-openapi.yaml
+++ b/subscriptions-api-openapi.yaml
@@ -55,7 +55,7 @@ paths:
         - in: "path"
           name: "id"
           description: identifier of a specific subscription
-          required: false
+          required: true
           schema:
             type: string
       responses:
@@ -113,7 +113,7 @@ paths:
         - in: "path"
           name: "id"
           description: identifier of a specific subscription
-          required: false
+          required: true
           schema:
             type: string
       responses:

--- a/subscriptions-api-openapi.yaml
+++ b/subscriptions-api-openapi.yaml
@@ -137,7 +137,7 @@ components:
           example: "HTTP"
         protocolsettings:
           type: object
-          anyOf:
+          oneOf:
             - $ref: "#/components/schemas/HTTPSettings"
             - $ref: "#/components/schemas/MQTTSettings"
             - $ref: "#/components/schemas/AMQPSettings"
@@ -168,7 +168,7 @@ components:
           example: "HTTP"
         protocolsettings:
           type: object
-          anyOf:
+          oneOf:
             - $ref: "#/components/schemas/HTTPSettings"
             - $ref: "#/components/schemas/MQTTSettings"
             - $ref: "#/components/schemas/AMQPSettings"

--- a/subscriptions-api-openapi.yaml
+++ b/subscriptions-api-openapi.yaml
@@ -137,7 +137,7 @@ components:
           example: "HTTP"
         protocolsettings:
           type: object
-          oneOf:
+          anyOf:
             - $ref: "#/components/schemas/HTTPSettings"
             - $ref: "#/components/schemas/MQTTSettings"
             - $ref: "#/components/schemas/AMQPSettings"
@@ -168,7 +168,7 @@ components:
           example: "HTTP"
         protocolsettings:
           type: object
-          oneOf:
+          anyOf:
             - $ref: "#/components/schemas/HTTPSettings"
             - $ref: "#/components/schemas/MQTTSettings"
             - $ref: "#/components/schemas/AMQPSettings"


### PR DESCRIPTION
fixes #758 

- fix "required: false" on path parameters which can't be omitted
- missing required field for body of creating and updating operation
- use oneOf instead of anyOf