### PR TITLE
Add rules for adding new SDKs

### DIFF
--- a/community/SDK-GOVERNANCE.md
+++ b/community/SDK-GOVERNANCE.md
@@ -12,15 +12,17 @@ The community is organized as follows:
 
 To propose a new SDK for the community, a PR should be opened in the `spec`
 repository with the documentation changes necessary to point to the new repo.
-For example, changes to the `README.md` and `SDK.md` files. At that time the
-community will proceed with a vote using the
-[Asynchronous voting process](#asynchronous-voting-process).
-
-The first comment in the PR should include:
+For example, changes to the `README.md` and `SDK.md` files. The first comment
+in the PR should include:
 - desired repo name (e.g. `SDK-...`)
 - list of initial maintainers (github IDs)
 
-The voting criteria are:
+Ideally, the new SDK should integrate with a technology stack that the existing
+SDKs do not already have support for.
+
+The community will proceed with a vote using the
+[Asynchronous voting process](#asynchronous-voting-process). The voting
+criteria are:
 
 - 1 week to vote
 - At least 2/3 of the votes cast agree to the proposal

--- a/community/SDK-GOVERNANCE.md
+++ b/community/SDK-GOVERNANCE.md
@@ -8,6 +8,27 @@ The community is organized as follows:
   [cloudevents/sdk-go project](https://github.com/cloudevents/sdk-go)
 - The union of all the `sdk-*-maintainers` assembles the _sdk maintainers_ group
 
+## New SDKs
+
+To propose a new SDK for the community, a PR should be opened in the `spec`
+repository with the documentation changes necessary to point to the new repo.
+For example, changes to the `README.md` and `SDK.md` files. At that time the
+community will proceed with a vote using the
+[Asynchronous voting process](#asynchronous-voting-process).
+
+The first comment in the PR should include:
+- desired repo name (e.g. `SDK-...`)
+- list of initial maintainers (github IDs)
+
+The voting criteria are:
+
+- 1 week to vote
+- At least 2/3 of the votes cast agree to the proposal
+- All _sdk maintainers_ are entitled to vote
+
+If approved, the PR will be merged and a new repo and corresponding
+github teams will be created.
+
 ## New maintainers
 
 Maintainers are a crucial part of this community. They keep our projects alive


### PR DESCRIPTION
Per the rules, I think this requires a 1 week vote.

All SDK maintainers can vote.

Vote closes on Monday Mar 8, 3:30pm ET

/cc @cloudevents/sdk-maintainers 

Signed-off-by: Doug Davis <dug@us.ibm.com>