### PR TITLE
ci: conventional commits

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,11 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v2

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,5 +1,5 @@
 name: Lint Commit Messages
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   commitlint:

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -8,4 +8,5 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      # https://github.com/wagoid/commitlint-github-action
       - uses: wagoid/commitlint-github-action@v2

--- a/community/CONTRIBUTING.md
+++ b/community/CONTRIBUTING.md
@@ -29,7 +29,8 @@ set of changes you'd like to see. See the
 [Spec Formatting Conventions](#spec-formatting-conventions) section for the
 guidelines we follow for how documents are formatted.
 
-Please use [conventional commits](https://conventionalcommits.org)
+Please use [conventional commits](https://conventionalcommits.org) when writing
+commit messages.
 
 Each PR must be signed per the following section.
 

--- a/community/CONTRIBUTING.md
+++ b/community/CONTRIBUTING.md
@@ -5,9 +5,13 @@ well as the guidelines we follow for how our documents are formatted.
 
 ## Table of Contents
 
-- [Reporting an Issue](#reporting-an-issue)
-- [Suggesting a Change](#suggesting-a-change)
-- [Spec Formatting Conventions](#spec-formatting-conventions)
+- [Contributing to CloudEvents](#contributing-to-cloudevents)
+  - [Table of Contents](#table-of-contents)
+  - [Reporting an Issue](#reporting-an-issue)
+  - [Suggesting a Change](#suggesting-a-change)
+    - [Assigning and Owning work](#assigning-and-owning-work)
+    - [Sign your work](#sign-your-work)
+  - [Spec Formatting Conventions](#spec-formatting-conventions)
 
 ## Reporting an Issue
 
@@ -24,6 +28,8 @@ To suggest a change to this repository, submit a
 set of changes you'd like to see. See the
 [Spec Formatting Conventions](#spec-formatting-conventions) section for the
 guidelines we follow for how documents are formatted.
+
+Please use [conventional commits](https://conventionalcommits.org)
 
 Each PR must be signed per the following section.
 


### PR DESCRIPTION
Per issues:

- https://github.com/cloudevents/spec/issues/755
- https://github.com/cloudevents/spec/issues/687

It is difficult to determine the differences between spec versions and progression to the spec as time goes on.

---

One way we can help developers understand the spec changes is by using and enforcing [conventional commits](www.conventionalcommits.org).

With these types of commits, we can generate more detailed changelogs in the future. Unfortunately, there's not a whole lot we can do with unstructured commit messages from the past.

### Proposed Improvement in this PR

This PR adds a GitHub Action to this repo to add a check to pushes and pull requests to see if the last commit is a conventional commit. Note: PRs when squashed and merged can use a single commit message.

- Adds `.github/workflows/commitlint.yaml`
- Updates `.github/CONTRIBUTING.md`, mentioning how contributors should use conventional commits.
  - Note: Updated TOC was done automatically in VS Code

PR mergers should merge PRs with a conventional commit message to keep the CI green.

CC @duglin this is following up the CNCF chat about this yesterday.