### PR TITLE
[CESQL] Clarification of the IN semantics

### DIFF
--- a/expression-language.md
+++ b/expression-language.md
@@ -290,8 +290,9 @@ assumed valid, e.g. `EXISTS id` MUST always return `true`.
 | `x IN (y1, y2, ...): String x String^n -> Boolean`     | Returns `true` if `x` is equal to an element in the _Set_ of `yN` elements |
 | `x NOT IN (y1, y2, ...): String x String^n -> Boolean` | Same as `NOT (x IN set)`                                                   |
 
-The matching is done using the same semantics of the equal `=` operator, except for the implicit casting rules described in the [Type casting paragraph](#37-type-casting).
-In other words, for every `yi` in the set, if `yi` has the same type of `x`, then the equal `=` operator semantics are applied, otherwise `yi` is not considered equal to `x`.
+The matching is done using the same semantics of the equal `=` operator, except for the implicit casting rules described
+in the [Type casting paragraph](#37-type-casting). In other words, for every `yi` in the set, if `yi` has the same type
+of `x`, then the equal `=` operator semantics are applied, otherwise `yi` is not considered equal to `x`.
 
 ### 3.5. Functions
 
@@ -362,7 +363,7 @@ A CESQL engine MUST apply the following implicit casting rules in order:
 1. If the operator is n-ary with `n > 2`:
    1. If it's not ambiguous, cast all the parameters to the target type
    1. If it's ambiguous, raise an error and the cast results are undefined
-   
+
 Note that no implicit casting rules are defined for the `EXISTS` and `IN` operator.
 
 For example, assuming `MY_STRING_PREDICATE` is a unary predicate accepting a _String_ parameter and returning a

--- a/expression-language.md
+++ b/expression-language.md
@@ -287,12 +287,10 @@ assumed valid, e.g. `EXISTS id` MUST always return `true`.
 
 | Definition                                             | Semantics                                                                  |
 | ------------------------------------------------------ | -------------------------------------------------------------------------- |
-| `x IN (y1, y2, ...): String x String^n -> Boolean`     | Returns `true` if `x` is equal to an element in the _Set_ of `yN` elements |
-| `x NOT IN (y1, y2, ...): String x String^n -> Boolean` | Same as `NOT (x IN set)`                                                   |
+| `x IN (y1, y2, ...): Any x Any^n -> Boolean`     | Returns `true` if `x` is equal to an element in the _Set_ of `yN` elements |
+| `x NOT IN (y1, y2, ...): Any x Any^n -> Boolean` | Same as `NOT (x IN set)`                                                   |
 
-The matching is done using the same semantics of the equal `=` operator, except for the implicit casting rules described
-in the [Type casting paragraph](#37-type-casting). In other words, for every `yi` in the set, if `yi` has the same type
-of `x`, then the equal `=` operator semantics are applied, otherwise `yi` is not considered equal to `x`.
+The matching is done using the same semantics of the equal `=` operator, but using `x` type as the target type for the implicit type casting.
 
 ### 3.5. Functions
 
@@ -364,7 +362,7 @@ A CESQL engine MUST apply the following implicit casting rules in order:
    1. If it's not ambiguous, cast all the parameters to the target type
    1. If it's ambiguous, raise an error and the cast results are undefined
 
-Note that no implicit casting rules are defined for the `EXISTS` and `IN` operator.
+for the `IN` operator, a special rule is defined: the left argument MUST be used as the target type to eventually cast the set elements.
 
 For example, assuming `MY_STRING_PREDICATE` is a unary predicate accepting a _String_ parameter and returning a
 _Boolean_, this expression:

--- a/expression-language.md
+++ b/expression-language.md
@@ -287,10 +287,11 @@ assumed valid, e.g. `EXISTS id` MUST always return `true`.
 
 | Definition                                             | Semantics                                                                  |
 | ------------------------------------------------------ | -------------------------------------------------------------------------- |
-| `x IN (y1, y2, ...): String x String^n -> Boolean`     | Returns `true` if `x` is an element included in the _Set_ of `yN` elements |
+| `x IN (y1, y2, ...): String x String^n -> Boolean`     | Returns `true` if `x` is equal to an element in the _Set_ of `yN` elements |
 | `x NOT IN (y1, y2, ...): String x String^n -> Boolean` | Same as `NOT (x IN set)`                                                   |
 
-The matching is done using the same semantics of the equal `=` operator.
+The matching is done using the same semantics of the equal `=` operator, except for the implicit casting rules described in the [Type casting paragraph](#37-type-casting).
+In other words, for every `yi` in the set, if `yi` has the same type of `x`, then the equal `=` operator semantics are applied, otherwise `yi` is not considered equal to `x`.
 
 ### 3.5. Functions
 

--- a/expression-language.md
+++ b/expression-language.md
@@ -362,6 +362,8 @@ A CESQL engine MUST apply the following implicit casting rules in order:
 1. If the operator is n-ary with `n > 2`:
    1. If it's not ambiguous, cast all the parameters to the target type
    1. If it's ambiguous, raise an error and the cast results are undefined
+   
+Note that no implicit casting rules are defined for the `EXISTS` and `IN` operator.
 
 For example, assuming `MY_STRING_PREDICATE` is a unary predicate accepting a _String_ parameter and returning a
 _Boolean_, this expression:


### PR DESCRIPTION
The `IN` operator semantics were unclear, in particular its relation with the implicit type casting rule.

This clarification specified that no implicit casting rules are applied for `IN`, that is:

```
'123' IN (123)
```

Evaluates to `FALSE`. One can rewrite this expression using explicit cast, like:

```
'123' IN (STRING(123))
```