### PR TITLE
Introducing XML Format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following documents are available ([Release Notes](misc/RELEASE_NOTES.md)):
 | NATS Protocol Binding         | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/bindings/nats-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/nats-protocol-binding.md)    |
 | WebSockets Protocol Binding   |                                        -                                        | [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/websockets-protocol-binding.md) |
 | Protobuf Event Format         |                                                                                 | [v1.0-rc1](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/protobuf-format.md)                                  |
-| XML Event Format              | - | [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/working-drafts/xml-foramt.md) |
+| XML Event Format              | - | [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/working-drafts/xml-format.md) |
 | Web hook                      |      [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/http-webhook.md)      |        [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md)         |
 |                               |
 | **Additional Documentation:** |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following documents are available:
 | NATS Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/nats-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/nats-protocol-binding.md)    |
 | WebSockets Protocol Binding   |                                        -                                        | [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/websockets-protocol-binding.md) |
 | Protobuf Event Format         |                                                                                 | [v1.0-rc1](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/protobuf-format.md) |
-| XML Event Format              | - | [WIP][xml-format-working |]
+| XML Event Format              | - | [WIP][xml-format-working] |
 | Web hook                      |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-webhook.md)      |        [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md)         |
 |                               |
 | **Additional Documentation:** |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The following documents are available:
 | MQTT Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/mqtt-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/mqtt-protocol-binding.md)    |
 | NATS Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/nats-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/nats-protocol-binding.md)    |
 | WebSockets Protocol Binding   |                                        -                                        | [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/websockets-protocol-binding.md) |
-| Protobuf Event Format         |                                                                                 | [v1.0-rc1](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/protobuf-format.md)                                  |
+| Protobuf Event Format         |                                                                                 | [v1.0-rc1](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/protobuf-format.md) |
+| XML Event Format              | - | [WIP][xml-format-working |]
 | Web hook                      |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-webhook.md)      |        [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md)         |
 |                               |
 | **Additional Documentation:** |
@@ -141,3 +142,6 @@ Periodically, the group may have in-person meetings that coincide with a major
 conference. Please see the
 [meeting minutes doc](https://docs.google.com/document/d/1OVF68rpuPK5shIHILK9JOqlZBbfe91RNzQ7u_P7YCDE/edit#)
 for any future plans.
+
+[xml-format-working]: https://github.com/cloudevents/spec/blob/main/cloudevents/formats/xml-format.md
+[xml-format-latest]: https://github.com/cloudevents/spec/blob/main/cloudevents/formats/xml-format.md

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following documents are available ([Release Notes](misc/RELEASE_NOTES.md)):
 | NATS Protocol Binding         | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/bindings/nats-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/nats-protocol-binding.md)    |
 | WebSockets Protocol Binding   |                                        -                                        | [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/websockets-protocol-binding.md) |
 | Protobuf Event Format         |                                                                                 | [v1.0-rc1](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/protobuf-format.md)                                  |
+| XML Event Format              | - | [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/working-drafts/xml-foramt.md) |
 | Web hook                      |      [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/http-webhook.md)      |        [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md)         |
 |                               |
 | **Additional Documentation:** |

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -31,11 +31,11 @@ data type mappings for CloudEvents context attributes.
 * The [Data](#3-data) section defines the container for the data portion of a
 CloudEvent.
 
-* The [Envelope](#4-envelope) section defines an XML element for CloudEvents
-attributes and an associated media type.
+* The [Envelope](#4-envelope) section defines an XML element to contain CloudEvent
+context attributes and data.
 
 * The [Batch](#5-xml-batch-format) section describes how multiple CloudEvents
-can be packaged into a single XML document.
+can be packaged into a single XML element.
 
 ### 1.1. Conformance
 

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -97,8 +97,9 @@ discriminator SHOULD be interpreted with an implied type of `xs:string`
 ## 3. Data
 
 The `Data` portion of a CloudEvent follows a similar model to that employed by
-the [JSON Format specification][json-format]. The element names are capitalized
-to avoid collision with curent or future CloudEvent attribute names.
+the [JSON Format specification][json-format]. A `data` element is used to
+encapsulate the payload and an `xsi:type` used to discrimate the payload
+type.
 
 ### 3.1 Binary Data
 

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -20,7 +20,7 @@ This document is a working draft.
 
 ## 1. Introduction
 
-[CloudEvents][ce] is a standardized and protocol-agnostic definition of the
+[CloudEvents][ce-spec] is a standardized and protocol-agnostic definition of the
 structure and metadata description of events. This specification defines how
 elements defined in the CloudEvents specification are to be represented using
 [Extensible Markup Language (XML)](xml-spec) documents.
@@ -35,7 +35,7 @@ CloudEvent.
 attributes and an associated media type.
 
 * The [Batch](#5-xml-batch-format) section describes how multiple CloudEvents
-may be packaged into a single XML document.
+can be packaged into a single XML document.
 
 ### 1.1. Conformance
 
@@ -58,8 +58,8 @@ structure.
 
 The CloudEvents type system is mapped to the XML schema types as follows :
 
-| CloudEvents   |  XML Schema Type| Notes |
-| :-------------| :---------------------------------------------------------- |
+| CloudEvents   |  XML Schema Type | Notes |
+| :-------------| :--------------- | :---- |
 | Boolean       | [xs:boolean][xml-primitives] | |
 | Integer       | [xs:int][xml-primitives] | |
 | String        | [xs:string][xml-primitives] | |
@@ -68,15 +68,15 @@ The CloudEvents type system is mapped to the XML schema types as follows :
 | URI-reference | [xs:anyURI][xml-primitives] following [RFC 3986][rfc3986] | |
 | Timestamp     | [xs:dateTime][xml-primitives] following [RFC 3339][rfc3339] | |
 
-Each context attribute is represented as an XML element whose name exactly matches that of
-a required or optional CloudEvent attribute, extension attribute names `MUST` adhere and
-align with the conventions in defined in the [cloud event specification][ce-spec].
+Each context attribute is represented as an XML element whose name MUST exactly match
+that of a REQUIRED or OPTIONAL CloudEvent attribute, extension attribute names MUST
+adhere to, and align with, the conventions in defined in the [cloud event specification][ce-spec].
 
 See the [envelope](#4-envelope) for special handing of the `specversion` context attribute.
 
-Extension attributes `SHOULD` be expressed with the appropriate `xsi:type` to allow them
+Extension attributes SHOULD be expressed with the appropriate `xsi:type` to allow them
 to be exchanged without loss of type information. Extension attributes with no `xsi:type`
-discriminator `SHOULD` be interpreted with an implied type of `xs:string`
+discriminator SHOULD be interpreted with an implied type of `xs:string`
 
 ``` xml
     ...
@@ -91,12 +91,12 @@ discriminator `SHOULD` be interpreted with an implied type of `xs:string`
 ## 3. Data
 
 The `Data` portion of a CloudEvent follows a similar model to that employed by
-the [JSON Format specification][json-format]. The elmenent names used are capitalized to avoid
-collision with CloudEvent attribute names.
+the [JSON Format specification][json-format]. The element names MUST be capitalized to avoid
+collision with curent or future CloudEvent attribute names.
 
 ### 3.1 Binary Data
 
-Carried in an element with an defined type of `xs:base64Binary`
+MUST be carried in an element with an defined type of `xs:base64Binary`
 
 ``` xml
 <Data xsi:type="xs:base64Binary">.........</Data>
@@ -104,7 +104,7 @@ Carried in an element with an defined type of `xs:base64Binary`
 
 ### 3.2 Text Data
 
-Carried in an element with an defined type of `xs:string`
+MUST be carried in an element with an defined type of `xs:string`
 
 ``` xml
 <Data xsi:type="xs:string">This is text</Data>
@@ -112,7 +112,7 @@ Carried in an element with an defined type of `xs:string`
 
 ### 3.3 XML Data
 
-XML data is carried in an explicit element:
+XML data MUST be carried in an explicit element `<DataXml>`:
 
 ``` xml
 <DataXml>
@@ -125,7 +125,7 @@ XML data is carried in an explicit element:
 ## 4. Envelope
 
 Each CloudEvent is wholly represented as an XML element, the root xml
-document element is `<CloudEvent>`. This element carries the `speversion`
+document element MUST be `<CloudEvent>`. This element carries the `specversion`
 as an XML attribute value.
 
 Such a representation MUST use the media type `application/cloudevents+xml`.
@@ -145,7 +145,7 @@ eg (Namespace definitions omitted for brevity):
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
     <myboolean xsi:type="xs:boolean">false</myboolean>
-    <Data xsi:type="xs_string">Now is the winter of our discount tents...</Data
+    <Data xsi:type="xs_string">Now is the winter of our discount tents...</Data>
 </CloudEvent>
 ```
 
@@ -166,7 +166,7 @@ Example:
 
 ``` xml
 <CloudEventBatch>
-    <CloudEvent specverison="1.0">
+    <CloudEvent specversion="1.0">
        ....
     </CloudEvent>
     <CloudEvent specversion="1.0">

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -63,25 +63,27 @@ An XML document preamble SHOULD be included to ensure deterministic processing.
 
 ## 2. Attributes
 
-The CloudEvents type system is mapped to the XML schema types as follows :
+The CloudEvents type system is mapped to a set of CloudEvent specific
+type designators as follows :
 
-| CloudEvents   |  XML Schema Type | Notes |
-| :-------------| :--------------- | :---- |
-| Boolean       | [xs:boolean][xml-primitives] | |
-| Integer       | [xs:int][xml-primitives] | |
-| String        | [xs:string][xml-primitives] | |
-| Binary        | [xs:base64Binary][xml-primitives] | |
-| URI           | [xs:anyURI][xml-primitives] following [RFC 3986][rfc3986]| |
-| URI-reference | [xs:anyURI][xml-primitives] following [RFC 3986][rfc3986] | |
-| Timestamp     | [xs:dateTime][xml-primitives] following [RFC 3339][rfc3339] | |
+| CloudEvents Type  |  XML Format Type | XML Schema Type | Notes |
+| :-----------------| :----------------| :--------------- | :---- |
+| Boolean       | ce:boolean | [xs:boolean][xml-primitives] | `true` or `false` |
+| Integer       | ce:int | [xs:int][xml-primitives] | |
+| String        | ce:string | [xs:string][xml-primitives] | |
+| Binary        | ce:binary | [xs:base64Binary][xml-primitives] |  |
+| URI           | ce:uri | [xs:anyURI][xml-primitives] following [RFC 3986][rfc3986]| |
+| URI-reference | ce:uriRef | [xs:anyURI][xml-primitives] following [RFC 3986][rfc3986] | |
+| Timestamp     | ce:timestamp | [xs:dateTime][xml-primitives] following [RFC 3339][rfc3339] | |
 
 Each CloudEvent context attribute is represented as an XML element whose local
 name exactly matches that of the attribute.
 
 See the [envelope](#4-envelope) for special handing of the `specversion` context attribute.
 
-Extension attributes MUST be decorated with the appropriate `xsi:type` to allow them
-to be exchanged without loss of type information.
+Extension attributes MUST be decorated with the appropriate CloudEvent format
+designators using using the `xsi:type` XML attribute, this allows them to be exchanged
+without loss of type information.
 
 REQUIRED and OPTIONAL context attributes SHOULD NOT be decorated with an `xsi:type`.
 
@@ -94,8 +96,8 @@ processing.
     ..
     <time>2021-08-14T14:30:22-08:00</time>
     ..
-    <myextension xsi:type="xs:string">my extension value</myextension>
-    <myboolean xsi:type="xs:boolean">false</myboolean>
+    <myextension xsi:type="ce:string">my extension value</myextension>
+    <myboolean xsi:type="ce:boolean">false</myboolean>
 ```
 
 ## 3. Data
@@ -110,22 +112,22 @@ The following data representations are supported:
 
 ### 3.1 Binary Data
 
-Binary data MUST be carried in an element with an defined type of `xs:base64Binary`.
+Binary data MUST be carried in an element with an defined type of `ce:binary`.
 
 Example:
 
 ``` xml
-<data xsi:type="xs:base64Binary">.........</data>
+<data xsi:type="ce:binary">.........</data>
 ```
 
 ### 3.2 Text Data
 
-Text MUST be carried in an element with an defined type of `xs:string`.
+Text MUST be carried in an element with an defined type of `ce:string`.
 
 Example:
 
 ``` xml
-<data xsi:type="xs:string">This is text</data>
+<data xsi:type="ce:string">This is text</data>
 ```
 
 ### 3.3 XML Data
@@ -167,8 +169,8 @@ Example _(XML preamble and namespace definitions omitted for brevity)_:
     <id>000-1111-2222</id>
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
-    <myboolean xsi:type="xs:boolean">false</myboolean>
-    <data xsi:type="xs:string">Now is the winter of our discount tents...</data>
+    <myboolean xsi:type="ce:boolean">false</myboolean>
+    <data xsi:type="ce:string">Now is the winter of our discount tents...</data>
 </event>
 ```
 
@@ -233,7 +235,7 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
     <id>000-1111-2222</id>
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
-    <data xsi:type="xs:string">{ "salutation": "Good Morning", "text": "hello world" }</data>
+    <data xsi:type="ce:string">{ "salutation": "Good Morning", "text": "hello world" }</data>
 </event>
 ```
 

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -54,7 +54,11 @@ custom extensions to be communicated without type loss.
 A schema-less approach has been taken favoring convention over rigid document
 structure.
 
-The namespace `http://cloudevents.io/xmlformat/v1` SHOULD be used.
+The namespace `http://cloudevents.io/xmlformat/v1` SHOULD be used, when
+namespace prefixes are used a prefix of `ce` is preferred but MUST NOT be expected
+from an XML document processing perspective.
+
+An XML document preamble SHOULD be included to ensure deterministic processing.
 
 ## 2. Attributes
 
@@ -128,8 +132,8 @@ to be represented.
 
 ## 4. Envelope
 
-Each CloudEvent is wholly represented as an XML element `<CloudEvent>` that
-carries the `specversion`as an XML attribute value.
+Each CloudEvent is wholly represented as an XML element `<Event>` that
+carries the `specversion` as an XML attribute value.
 
 Such a representation MUST use the media type `application/cloudevents+xml`.
 
@@ -138,10 +142,10 @@ The enveloping element contains:
 * A set of context attribute elements.
 * An optional `data` element.
 
-eg (Namespace definitions omitted for brevity):
+eg _(XML preamble and namespace definitions omitted for brevity)_:
 
 ``` xml
-<CloudEvent specversion="1.0">
+<Event specversion="1.0">
     <time>2020-03-19T12:54:00-07:00</time>
     <datacontenttype>text/plain</datacontenttype>
     <id>000-1111-2222</id>
@@ -149,7 +153,7 @@ eg (Namespace definitions omitted for brevity):
     <type>SOME.EVENT.TYPE</type>
     <myboolean xsi:type="xs:boolean">false</myboolean>
     <data xsi:type="xs:string">Now is the winter of our discount tents...</data>
-</CloudEvent>
+</Event>
 ```
 
 ## 5. XML Batch Format
@@ -165,24 +169,24 @@ support for the _XML Format_ is indicated.
 An XML Batch of CloudEvents MUST use the media type
 `application/cloudevents-batch+xml`.
 
-Example:
+Example _(XML preamble and namespace definitions omitted for brevity)_:
 
 ``` xml
-<CloudEventBatch>
-    <CloudEvent specversion="1.0">
+<Batch>
+    <Event specversion="1.0">
        ....
-    </CloudEvent>
-    <CloudEvent specversion="1.0">
+    </Event>
+    <Event specversion="1.0">
        ....
-    </CloudEvent>
+    </Event>
     ....
-</CloudEventBatch>
+</Batch>
 ```
 
 An example of an empty batch of CloudEvents (typically used in a response, but also valid in a request):
 
 ```xml
-<CloudEventBatch />
+<Batch />
 ```
 
 ## 6. Examples
@@ -191,47 +195,73 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<CloudEvent xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
+<Event xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
     <time>2020-03-19T12:54:00-07:00</time>
     <datacontenttype>image/png</datacontenttype>
     <id>000-1111-2222</id>
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
     <data xsi:type="xs:base64Binary">... Base64 encoded data...</data>
-</CloudEvent>
+</Event>
 ```
 
 ### 6.2 CloudEvent with JSON event data
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<CloudEvent xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
+<Event xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
     <time>2020-03-19T12:54:00-07:00</time>
     <datacontenttype>application/json</datacontenttype>
     <id>000-1111-2222</id>
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
     <data xsi:type="xs:string">{ "salutation": "Good Morning", "text": "hello world" }</data>
-</CloudEvent>
+</Event>
 ```
 
 ### 6.3 CloudEvent with XML event data
 
+#### 6.3.1 Locally namespaced event data
+
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<CloudEvent xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
+<Event xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
     <time>2020-03-19T12:54:00-07:00</time>
     <datacontenttype>application/xml</datacontenttype>
     <id>000-1111-2222</id>
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
     <data xsi:type="xs:any">
-        <Location>
-            <Latitude>51.509865</Latitude>
-            <Longitude>-0.118092</Longitude>
-        </Location>
+        <geo:Location xmlns:geo="http://someauthority.example/">
+            <geo:Latitude>51.509865</geo:Latitude>
+            <geo:Longitude>-0.118092</geo:Longitude>
+        </geo:Location>
     </data>
-</CloudEvent>
+</Event>
+```
+
+#### 6.3.2 Explicit namespacing
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ce:Event xmlns:ce="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+          xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:geo="http://someauthority.example/"
+          specversion="1.0" >
+    <ce:time>2020-03-19T12:54:00-07:00</ce:time>
+    <ce:datacontenttype>application/xml</ce:datacontenttype>
+    <ce:id>000-1111-2222</ce:id>
+    <ce:source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</ce:source>
+    <ce:type>SOME.EVENT.TYPE</ce:type>
+    <ce:data xsi:type="xs:any">
+        <geo:Location>
+            <geo:Latitude>51.509865</geo:Latitude>
+            <geo:Longitude>-0.118092</geo:Longitude>
+        </geo:Location>
+    </ce:data>
+</ce:Event>
 ```
 
 [ce-spec]: ../spec.md

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -45,7 +45,7 @@ interpreted as described in [RFC2119][rfc2119].
 
 ### 1.2 Approach
 
-This XML representation used is deliberately verbose in favor of readability
+The XML representation used is deliberately verbose in favor of readability
 and deterministic processing.
 
 Preservation of type information for CloudEvent attributes is supported allowing
@@ -130,15 +130,17 @@ Example:
 
 ### 3.3 XML Data
 
-XML data MUST be carried in an element with a defined type of `xs:any`
-allowing a single child XML element (with any required namespace definitions)
-to be represented.
+XML data MUST be carried in an element with a defined type of `xs:any` with
+a single child XML element (with any required namespace definitions).
+
+The child business data XML elements MUST NOT reside in the CloudEvent namespace,
+an empty namespace MAY be used as appropriate.
 
 Example:
 
 ``` xml
 <data xsi:type="xs:any">
-    <myData>
+    <myData xmlns="http://my.org/namespace">
         ....
     </myData>  
 </data>
@@ -185,7 +187,7 @@ An XML Batch of CloudEvents MUST use the media type
 
 Example _(XML preamble and namespace definitions omitted for brevity)_:
 
-``` xml
+```xml
 <batch>
     <event specversion="1.0">
        ....
@@ -278,9 +280,81 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
 </ce:event>
 ```
 
+#### 6.3.3 ISO 20022 Usage Example
+
+[ISO 20022][iso-20022] is an XML based messaging standard used in the financial industry; this is a
+non-normative example.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<event xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
+    <time>2022-02-22T15:12:00-08:00</time>
+    <datacontenttype>application/xml</datacontenttype>
+    <id>000-1111-2222</id>
+    <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
+    <type>com.mybank.pain.001.001.03</type>
+    <data xsi:type="xs:any">
+        <Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.03">
+            <CstmrCdtTrfInitn>
+            <GrpHdr>
+                <MsgId>ABC/060928/CCT001</MsgId>
+                <CreDtTm>2022-02-22T14:07:00</CreDtTm>
+                <NbOfTxs>3</NbOfTxs>
+                <CtrlSum>2400.56</CtrlSum>
+                <InitgPty>
+                    <Nm>Cobelfac</Nm>
+                    <Id>
+                        <OrgId>
+                            <Othr>
+                                <Id>0468651441</Id>
+                                <Issr>KBO-BCE</Issr>
+                            </Othr>
+                        </OrgId>
+                    </Id>
+                </InitgPty>
+            </GrpHdr>
+            <PmtInf>
+                <PmtInfId> ABC/4560/2008-09-25</PmtInfId>
+                <PmtMtd>TRF</PmtMtd>
+                <BtchBookg>false</BtchBookg>
+
+            <!-- Content ommited for brevity -->
+
+            </PmtInf>
+        </Document>
+    </data>
+</event>
+```
+
+#### 6.3.4 Batch Example
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<batch xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+       xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <event specversion="1.0" >
+        <time>2020-03-19T12:54:00-07:00</time>
+        <datacontenttype>image/png</datacontenttype>
+        <id>000-1111-2222</id>
+        <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
+        <type>SOME.EVENT.TYPE</type>
+        <data xsi:type="xs:base64Binary">... Base64 encoded data...</data>
+    </event>
+    <event specversion="1.0" >
+        <time>2020-03-19T12:59:00-07:00</time>
+        <datacontenttype>image/png</datacontenttype>
+        <id>000-1111-3333</id>
+        <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
+        <type>SOME.EVENT.TYPE</type>
+        <data xsi:type="xs:base64Binary">... Base64 encoded data...</data>
+    </event>
+    .....
+</batch>
+```
+
 [ce-spec]: ../spec.md
 [ce-types]: ../spec.md#type-system
-[xml-schema]: ./cloudevents.xsd
 [xml-format]: ./xml-format.md
 [json-format]: ../formats/json-format.md
 [xml-spec]: https://www.w3.org/TR/2008/REC-xml-20081126/
@@ -288,3 +362,4 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
 [rfc2119]: https://tools.ietf.org/html/rfc2119
 [rfc3339]: https://www.ietf.org/rfc/rfc3339.txt
 [rfc3986]: https://tools.ietf.org/html/rfc3986
+[iso-20022]: https://www.iso20022.org

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -81,13 +81,12 @@ name exactly matches that of the attribute.
 
 See the [envelope](#4-envelope) for special handing of the `specversion` context attribute.
 
-Extension attributes MUST be decorated with the appropriate CloudEvent format
-designators using the `xsi:type` XML attribute, this allows them to be exchanged
+Extension context attributes MUST be decorated with the appropriate CloudEvent type format
+designators using an `xsi:type` XML attribute, this allows them to be exchanged
 without loss of type information.
 
-REQUIRED and OPTIONAL context attributes SHOULD NOT be decorated with an `xsi:type` to
-avoid potential inconsistencies. Implementors MUST process these values according to their
-types as defined by the [CloudEvent type specification][ce-types].
+REQUIRED and OPTIONAL context atrtribute MAY be decorated with `xsi:type`, if present this
+value MUST match that of the type specified by the [CloudEvent type specification][ce-types].
 
 No other XML element attributes are expected, if present they MUST be ignored during
 processing.
@@ -114,22 +113,23 @@ The following data representations are supported:
 
 ### 3.1 Binary Data
 
-Binary data MUST be carried in an element with an defined type of `ce:binary`.
+Binary data MUST be carried in an element with an defined type of `xs:base64Binary`
+and encoded appropriately..
 
 Example:
 
 ``` xml
-<data xsi:type="ce:binary">.........</data>
+<data xsi:type="xs:base64Binary">.........</data>
 ```
 
 ### 3.2 Text Data
 
-Text MUST be carried in an element with an defined type of `ce:string`.
+Text MUST be carried in an element with an defined type of `xs:string`.
 
 Example:
 
 ``` xml
-<data xsi:type="ce:string">This is text</data>
+<data xsi:type="xs:string">This is text</data>
 ```
 
 ### 3.3 XML Data
@@ -169,7 +169,7 @@ Example _(XML preamble and namespace definitions omitted for brevity)_:
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
     <myboolean xsi:type="ce:boolean">false</myboolean>
-    <data xsi:type="ce:string">Now is the winter of our discount tents...</data>
+    <data xsi:type="xs:string">Now is the winter of our discount tents...</data>
 </event>
 ```
 
@@ -228,7 +228,7 @@ Example _(XML preamble and namespace definitions omitted for brevity)_:
     <id>000-1111-2222</id>
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
-    <data xsi:type="ce:string">{ "salutation": "Good Morning", "text": "hello world" }</data>
+    <data xsi:type="xs:string">{ "salutation": "Good Morning", "text": "hello world" }</data>
 </event>
 ```
 

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -69,23 +69,25 @@ type designators as follows :
 | CloudEvents Type  |  XML Format Type | XML Schema Type | Notes |
 | :-----------------| :----------------| :--------------- | :---- |
 | Boolean       | ce:boolean | [xs:boolean][xml-primitives] | `true` or `false` |
-| Integer       | ce:int | [xs:int][xml-primitives] | |
+| Integer       | ce:integer | [xs:int][xml-primitives] | |
 | String        | ce:string | [xs:string][xml-primitives] | |
 | Binary        | ce:binary | [xs:base64Binary][xml-primitives] |  |
 | URI           | ce:uri | [xs:anyURI][xml-primitives] following [RFC 3986][rfc3986]| |
 | URI-reference | ce:uriRef | [xs:anyURI][xml-primitives] following [RFC 3986][rfc3986] | |
 | Timestamp     | ce:timestamp | [xs:dateTime][xml-primitives] following [RFC 3339][rfc3339] | |
 
-Each CloudEvent context attribute is represented as an XML element whose local
+Each CloudEvent context attribute MUST be represented as an XML element whose local
 name exactly matches that of the attribute.
 
 See the [envelope](#4-envelope) for special handing of the `specversion` context attribute.
 
 Extension attributes MUST be decorated with the appropriate CloudEvent format
-designators using using the `xsi:type` XML attribute, this allows them to be exchanged
+designators using the `xsi:type` XML attribute, this allows them to be exchanged
 without loss of type information.
 
-REQUIRED and OPTIONAL context attributes SHOULD NOT be decorated with an `xsi:type`.
+REQUIRED and OPTIONAL context attributes SHOULD NOT be decorated with an `xsi:type` to
+avoid potential inconsistencies. Implementors MUST process these values according to their
+types as defined by the [CloudEvent type specification][ce-types].
 
 No other XML element attributes are expected, if present they MUST be ignored during
 processing.
@@ -134,9 +136,6 @@ Example:
 
 XML data MUST be carried in an element with a defined type of `xs:any` with
 a single child XML element (with any required namespace definitions).
-
-The child business data XML elements MUST NOT reside in the CloudEvent namespace,
-an empty namespace MAY be used as appropriate.
 
 Example:
 
@@ -199,12 +198,6 @@ Example _(XML preamble and namespace definitions omitted for brevity)_:
     </event>
     ....
 </batch>
-```
-
-An example of an empty batch of CloudEvents (typically used in a response, but also valid in a request):
-
-```xml
-<batch />
 ```
 
 ## 6. Examples

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -128,9 +128,8 @@ to be represented.
 
 ## 4. Envelope
 
-Each CloudEvent is wholly represented as an XML element, the root xml
-document element MUST be `<CloudEvent>`. This element carries the `specversion`
-as an XML attribute value.
+Each CloudEvent is wholly represented as an XML element `<CloudEvent>` that
+carries the `specversion`as an XML attribute value.
 
 Such a representation MUST use the media type `application/cloudevents+xml`.
 

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -31,7 +31,7 @@ data type mappings for CloudEvents context attributes.
 * The [Data](#3-data) section defines the container for the data portion of a
 CloudEvent.
 
-* The [Envelope](#4-envelope) section defines an XML container for CloudEvents
+* The [Envelope](#4-envelope) section defines an XML element for CloudEvents
 attributes and an associated media type.
 
 * The [Batch](#5-xml-batch-format) section describes how multiple CloudEvents
@@ -45,14 +45,16 @@ interpreted as described in [RFC2119][rfc2119].
 
 ### 1.2 Approach
 
-This specification is deliberately verbose in favor of readability and
-deterministic processing.
+This XML representation used is deliberately verbose in favor of readability
+and deterministic processing.
 
-Preservation of attribute value type information is supported allowing
-custom extensions to be communicated without value type loss.
+Preservation of type information for CloudEvent attributes is supported allowing
+custom extensions to be communicated without type loss.
 
 A schema-less approach has been taken favoring convention over rigid document
 structure.
+
+The namespace `http://cloudevents.io/xmlformat/v1` SHOULD be used.
 
 ## 2. Attributes
 
@@ -82,7 +84,7 @@ discriminator SHOULD be interpreted with an implied type of `xs:string`
     ...
     <id>AAABBBCCCNNN0000</id>
     ..
-    <time>2021-08-14T-08:00</time>
+    <time>2021-08-14T14:30:22-08:00</time>
     ..
     <myextension xsi:type="xs:string">my extension value</myextension>
     <myboolean xsi:type="xs:boolean">false</myboolean>
@@ -91,15 +93,15 @@ discriminator SHOULD be interpreted with an implied type of `xs:string`
 ## 3. Data
 
 The `Data` portion of a CloudEvent follows a similar model to that employed by
-the [JSON Format specification][json-format]. The element names MUST be capitalized to avoid
-collision with curent or future CloudEvent attribute names.
+the [JSON Format specification][json-format]. The element names are capitalized
+to avoid collision with curent or future CloudEvent attribute names.
 
 ### 3.1 Binary Data
 
 MUST be carried in an element with an defined type of `xs:base64Binary`
 
 ``` xml
-<Data xsi:type="xs:base64Binary">.........</Data>
+<data xsi:type="xs:base64Binary">.........</data>
 ```
 
 ### 3.2 Text Data
@@ -107,19 +109,21 @@ MUST be carried in an element with an defined type of `xs:base64Binary`
 MUST be carried in an element with an defined type of `xs:string`
 
 ``` xml
-<Data xsi:type="xs:string">This is text</Data>
+<data xsi:type="xs:string">This is text</data>
 ```
 
 ### 3.3 XML Data
 
-XML data MUST be carried in an explicit element `<DataXml>`:
+XML data MUST be carried in an element with a defined type of `xs:any`
+allowing a single XML element (with any required namespace definitions)
+to be represented.
 
 ``` xml
-<DataXml>
-        <myData>
-            ....
-        </myData>  
-</DataXml>
+<data xsi:type="xs:any">
+    <myData>
+        ....
+    </myData>  
+</data>
 ```
 
 ## 4. Envelope
@@ -132,8 +136,8 @@ Such a representation MUST use the media type `application/cloudevents+xml`.
 
 The enveloping element contains:
 
-* A set of context attributre elements.
-* Optionally: Either `<Data>` or `<DataXml>`
+* A set of context attribute elements.
+* An optional `data` element.
 
 eg (Namespace definitions omitted for brevity):
 
@@ -145,7 +149,7 @@ eg (Namespace definitions omitted for brevity):
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
     <myboolean xsi:type="xs:boolean">false</myboolean>
-    <Data xsi:type="xs:string">Now is the winter of our discount tents...</Data>
+    <data xsi:type="xs:string">Now is the winter of our discount tents...</data>
 </CloudEvent>
 ```
 
@@ -188,13 +192,13 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<CloudEvent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
+<CloudEvent xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
     <time>2020-03-19T12:54:00-07:00</time>
     <datacontenttype>image/png</datacontenttype>
     <id>000-1111-2222</id>
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
-    <Data xsi:type="xs:base64Binary">... Base64 encoded data...</Data>
+    <data xsi:type="xs:base64Binary">... Base64 encoded data...</data>
 </CloudEvent>
 ```
 
@@ -202,13 +206,13 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<CloudEvent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
+<CloudEvent xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
     <time>2020-03-19T12:54:00-07:00</time>
     <datacontenttype>application/json</datacontenttype>
     <id>000-1111-2222</id>
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
-    <Data xsi:type="xs:string">{ "salutation" : "Good Morning", "text" : "hello world" }</Data>
+    <data xsi:type="xs:string">{ "salutation": "Good Morning", "text": "hello world" }</data>
 </CloudEvent>
 ```
 
@@ -216,18 +220,18 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<CloudEvent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
+<CloudEvent xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
     <time>2020-03-19T12:54:00-07:00</time>
     <datacontenttype>application/xml</datacontenttype>
     <id>000-1111-2222</id>
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
-    <DataXml>
+    <data xsi:type="xs:any">
         <Location>
             <Latitude>51.509865</Latitude>
             <Longitude>-0.118092</Longitude>
         </Location>
-    </DataXml>
+    </data>
 </CloudEvent>
 ```
 

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -85,8 +85,8 @@ Extension context attributes MUST be decorated with the appropriate CloudEvent t
 designators using an `xsi:type` XML attribute, this allows them to be exchanged
 without loss of type information.
 
-REQUIRED and OPTIONAL context atrtribute MAY be decorated with `xsi:type`, if present this
-value MUST match that of the type specified by the [CloudEvent type specification][ce-types].
+REQUIRED and OPTIONAL context attribute MAY be decorated with an`xsi:type`, if present this
+designator MUST match that of the type specified by the [CloudEvent context attributes][ce-attrs].
 
 No other XML element attributes are expected, if present they MUST be ignored during
 processing.
@@ -350,6 +350,7 @@ non-normative example.
 
 [ce-spec]: ../spec.md
 [ce-types]: ../spec.md#type-system
+[ce-attrs]: ../spec.md#context-attributes
 [xml-format]: ./xml-format.md
 [json-format]: ../formats/json-format.md
 [xml-spec]: https://www.w3.org/TR/2008/REC-xml-20081126/

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -1,0 +1,243 @@
+# XML Event Format for CloudEvents
+
+## Abstract
+
+This format specification for CloudEvents defines how events are expressed
+in XML documents.
+
+## Status of this document
+
+This document is a working draft.
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Attributes](#2-attributes)
+3. [Data](#3-data)
+4. [Envelope](#4-envelope)
+5. [XML Batch Format](#5-xml-batch-format)
+6. [Examples](#6-examples)
+
+## 1. Introduction
+
+[CloudEvents][ce] is a standardized and protocol-agnostic definition of the
+structure and metadata description of events. This specification defines how
+elements defined in the CloudEvents specification are to be represented using
+[Extensible Markup Language (XML)](xml-spec) documents.
+
+* The [Attributes](#2-attributes) section describes the representation and
+data type mappings for CloudEvents context attributes.
+
+* The [Data](#3-data) section defines the container for the data portion of a
+CloudEvent.
+
+* The [Envelope](#4-envelope) section defines an XML container for CloudEvents
+attributes and an associated media type.
+
+* The [Batch](#5-xml-batch-format) section describes how multiple CloudEvents
+may be packaged into a single XML document.
+
+### 1.1. Conformance
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC2119][rfc2119].
+
+### 1.2 Approach
+
+This specification is deliberately verbose in favor of readability and
+deterministic processing.
+
+Preservation of attribute value type information is supported allowing
+custom extensions to be communicated without value type loss.
+
+A schema-less approach has been taken favoring convention over rigid document
+structure.
+
+## 2. Attributes
+
+The CloudEvents type system is mapped to the XML schema types as follows :
+
+| CloudEvents   |  XML Schema Type| Notes |
+| :-------------| :---------------------------------------------------------- |
+| Boolean       | [xs:boolean][xml-primitives] | |
+| Integer       | [xs:int][xml-primitives] | |
+| String        | [xs:string][xml-primitives] | |
+| Binary        | [xs:base64Binary][xml-primitives] | |
+| URI           | [xs:anyURI][xml-primitives] following [RFC 3986][rfc3986]| |
+| URI-reference | [xs:anyURI][xml-primitives] following [RFC 3986][rfc3986] | |
+| Timestamp     | [xs:dateTime][xml-primitives] following [RFC 3339][rfc3339] | |
+
+Each context attribute is represented as an XML element whose name exactly matches that of
+a required or optional CloudEvent attribute, extension attribute names `MUST` adhere and
+align with the conventions in defined in the [cloud event specification][ce-spec].
+
+See the [envelope](#4-envelope) for special handing of the `specversion` context attribute.
+
+Extension attributes `SHOULD` be expressed with the appropriate `xsi:type` to allow them
+to be exchanged without loss of type information. Extension attributes with no `xsi:type`
+discriminator `SHOULD` be interpreted with an implied type of `xs:string`
+
+``` xml
+    ...
+    <id>AAABBBCCCNNN0000</id>
+    ..
+    <time>2021-08-14T-08:00</time>
+    ..
+    <myextension xsi:type="xs:string">my extension value</myextension>
+    <myboolean xsi:type="xs:boolean">false</myboolean>
+```
+
+## 3. Data
+
+The `Data` portion of a CloudEvent follows a similar model to that employed by
+the [JSON Format specification][json-format]. The elmenent names used are capitalized to avoid
+collision with CloudEvent attribute names.
+
+### 3.1 Binary Data
+
+Carried in an element with an defined type of `xs:base64Binary`
+
+``` xml
+<Data xsi:type="xs:base64Binary">.........</Data>
+```
+
+### 3.2 Text Data
+
+Carried in an element with an defined type of `xs:string`
+
+``` xml
+<Data xsi:type="xs:string">This is text</Data>
+```
+
+### 3.3 XML Data
+
+XML data is carried in an explicit element:
+
+``` xml
+<DataXml>
+        <myData>
+            ....
+        </myData>  
+</DataXml>
+```
+
+## 4. Envelope
+
+Each CloudEvent is wholly represented as an XML element, the root xml
+document element is `<CloudEvent>`. This element carries the `speversion`
+as an XML attribute value.
+
+Such a representation MUST use the media type `application/cloudevents+xml`.
+
+The enveloping element contains:
+
+* A set of context attributre elements.
+* Optionally: Either `<Data>` or `<DataXml>`
+
+eg (Namespace definitions omitted for brevity):
+
+``` xml
+<CloudEvent specversion="1.0">
+    <time>2020-03-19T12:54:00-07:00</time>
+    <datacontenttype>text/plain</datacontenttype>
+    <id>000-1111-2222</id>
+    <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
+    <type>SOME.EVENT.TYPE</type>
+    <myboolean xsi:type="xs:boolean">false</myboolean>
+    <Data xsi:type="xs_string">Now is the winter of our discount tents...</Data
+</CloudEvent>
+```
+
+## 5. XML Batch Format
+
+In the _XML Batch Format_ several CloudEvents are batched into a single XML
+document. The document comprises a list of elements in the XML Format.
+
+Although the _XML Batch Format_ builds on top of the _XML Format_, it is
+considered as a separate format: a valid implementation of the _XML Format_
+doesn't need to support it. The _XML Batch Format_ MUST NOT be used when only
+support for the _XML Format_ is indicated.
+
+An XML Batch of CloudEvents MUST use the media type
+`application/cloudevents-batch+xml`.
+
+Example:
+
+``` xml
+<CloudEventBatch>
+    <CloudEvent specverison="1.0">
+       ....
+    </CloudEvent>
+    <CloudEvent specversion="1.0">
+       ....
+    </CloudEvent>
+    ....
+</CloudEventBatch>
+```
+
+An example of an empty batch of CloudEvents (typically used in a response, but also valid in a request):
+
+```xml
+<CloudEventBatch />
+```
+
+## 6. Examples
+
+### 6.1 CloudEvent with PNG image data
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<CloudEvent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
+    <time>2020-03-19T12:54:00-07:00</time>
+    <datacontenttype>image/png</datacontenttype>
+    <id>000-1111-2222</id>
+    <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
+    <type>SOME.EVENT.TYPE</type>
+    <Data xsi:type="xs:base64Binary">... Base64 encoded data...</Data>
+</CloudEvent>
+```
+
+### 6.2 CloudEvent with JSON event data
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<CloudEvent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
+    <time>2020-03-19T12:54:00-07:00</time>
+    <datacontenttype>application/json</datacontenttype>
+    <id>000-1111-2222</id>
+    <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
+    <type>SOME.EVENT.TYPE</type>
+    <Data xsi:type="xs:string">{ "salutation" : "Good Morning", "text" : "hello world" }</Data>
+</CloudEvent>
+```
+
+### 6.3 CloudEvent with XML event data
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<CloudEvent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
+    <time>2020-03-19T12:54:00-07:00</time>
+    <datacontenttype>application/xml</datacontenttype>
+    <id>000-1111-2222</id>
+    <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
+    <type>SOME.EVENT.TYPE</type>
+    <DataXml>
+        <Location>
+            <Latitude>51.509865</Latitude>
+            <Longitude>-0.118092</Longitude>
+        </Location>
+    </DataXml>
+</CloudEvent>
+```
+
+[ce-spec]: ../spec.md
+[ce-types]: ../spec.md#type-system
+[xml-schema]: ./cloudevents.xsd
+[xml-format]: ./xml-format.md
+[json-format]: ../formats/json-format.md
+[xml-spec]: https://www.w3.org/TR/2008/REC-xml-20081126/
+[xml-primitives]: https://www.w3.org/TR/xmlschema-2/#built-in-primitive-datatypes
+[rfc2119]: https://tools.ietf.org/html/rfc2119
+[rfc3339]: https://www.ietf.org/rfc/rfc3339.txt
+[rfc3986]: https://tools.ietf.org/html/rfc3986

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -145,7 +145,7 @@ eg (Namespace definitions omitted for brevity):
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
     <myboolean xsi:type="xs:boolean">false</myboolean>
-    <Data xsi:type="xs_string">Now is the winter of our discount tents...</Data>
+    <Data xsi:type="xs:string">Now is the winter of our discount tents...</Data>
 </CloudEvent>
 ```
 

--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -54,9 +54,10 @@ custom extensions to be communicated without type loss.
 A schema-less approach has been taken favoring convention over rigid document
 structure.
 
-The namespace `http://cloudevents.io/xmlformat/v1` SHOULD be used, when
-namespace prefixes are used a prefix of `ce` is preferred but MUST NOT be expected
-from an XML document processing perspective.
+The namespace `http://cloudevents.io/xmlformat/V1` MUST be used.
+
+When namespace prefixes are used a prefix of `ce` is preferred but MUST NOT
+be expected from an XML document processing perspective.
 
 An XML document preamble SHOULD be included to ensure deterministic processing.
 
@@ -96,7 +97,7 @@ discriminator SHOULD be interpreted with an implied type of `xs:string`
 
 ## 3. Data
 
-The `Data` portion of a CloudEvent follows a similar model to that employed by
+The data portion of a CloudEvent follows a similar model to that employed by
 the [JSON Format specification][json-format]. A `data` element is used to
 encapsulate the payload and an `xsi:type` used to discrimate the payload
 type.
@@ -133,7 +134,7 @@ to be represented.
 
 ## 4. Envelope
 
-Each CloudEvent is wholly represented as an XML element `<Event>` that
+Each CloudEvent is wholly represented as an XML element `<event>` that
 carries the `specversion` as an XML attribute value.
 
 Such a representation MUST use the media type `application/cloudevents+xml`.
@@ -146,7 +147,7 @@ The enveloping element contains:
 eg _(XML preamble and namespace definitions omitted for brevity)_:
 
 ``` xml
-<Event specversion="1.0">
+<event specversion="1.0">
     <time>2020-03-19T12:54:00-07:00</time>
     <datacontenttype>text/plain</datacontenttype>
     <id>000-1111-2222</id>
@@ -154,13 +155,13 @@ eg _(XML preamble and namespace definitions omitted for brevity)_:
     <type>SOME.EVENT.TYPE</type>
     <myboolean xsi:type="xs:boolean">false</myboolean>
     <data xsi:type="xs:string">Now is the winter of our discount tents...</data>
-</Event>
+</event>
 ```
 
 ## 5. XML Batch Format
 
 In the _XML Batch Format_ several CloudEvents are batched into a single XML
-document. The document comprises a list of elements in the XML Format.
+element. The element comprises a list of elements in the XML Format.
 
 Although the _XML Batch Format_ builds on top of the _XML Format_, it is
 considered as a separate format: a valid implementation of the _XML Format_
@@ -173,21 +174,21 @@ An XML Batch of CloudEvents MUST use the media type
 Example _(XML preamble and namespace definitions omitted for brevity)_:
 
 ``` xml
-<Batch>
-    <Event specversion="1.0">
+<batch>
+    <event specversion="1.0">
        ....
-    </Event>
-    <Event specversion="1.0">
+    </event>
+    <event specversion="1.0">
        ....
-    </Event>
+    </event>
     ....
-</Batch>
+</batch>
 ```
 
 An example of an empty batch of CloudEvents (typically used in a response, but also valid in a request):
 
 ```xml
-<Batch />
+<batch />
 ```
 
 ## 6. Examples
@@ -196,7 +197,7 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<Event xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<event xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
        xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
     <time>2020-03-19T12:54:00-07:00</time>
     <datacontenttype>image/png</datacontenttype>
@@ -204,14 +205,14 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
     <data xsi:type="xs:base64Binary">... Base64 encoded data...</data>
-</Event>
+</event>
 ```
 
 ### 6.2 CloudEvent with JSON event data
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<Event xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<event xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
        xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
     <time>2020-03-19T12:54:00-07:00</time>
     <datacontenttype>application/json</datacontenttype>
@@ -219,7 +220,7 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
     <source>urn:uuid:123e4567-e89b-12d3-a456-426614174000</source>
     <type>SOME.EVENT.TYPE</type>
     <data xsi:type="xs:string">{ "salutation": "Good Morning", "text": "hello world" }</data>
-</Event>
+</event>
 ```
 
 ### 6.3 CloudEvent with XML event data
@@ -228,7 +229,7 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<Event xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<event xmlns="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
        xmlns:xs="http://www.w3.org/2001/XMLSchema" specversion="1.0" >
     <time>2020-03-19T12:54:00-07:00</time>
     <datacontenttype>application/xml</datacontenttype>
@@ -241,14 +242,14 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
             <geo:Longitude>-0.118092</geo:Longitude>
         </geo:Location>
     </data>
-</Event>
+</event>
 ```
 
 #### 6.3.2 Explicit namespacing
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<ce:Event xmlns:ce="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<ce:event xmlns:ce="http://cloudevents.io/xmlformat/V1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
           xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:geo="http://someauthority.example/"
           specversion="1.0" >
     <ce:time>2020-03-19T12:54:00-07:00</ce:time>
@@ -262,7 +263,7 @@ An example of an empty batch of CloudEvents (typically used in a response, but a
             <geo:Longitude>-0.118092</geo:Longitude>
         </geo:Location>
     </ce:data>
-</ce:Event>
+</ce:event>
 ```
 
 [ce-spec]: ../spec.md


### PR DESCRIPTION
feat: Introduce XML Format

Adds support for XML as a format for CloudEvents (including batch format), XML schema provided along with textual specification.

Closes #662 

Signed-off-by: Day, Jeremy(jday) <jday@paypal.com>