### PR TITLE
[Subscriptions API] Remove strong constraints on filter combinators

### DIFF
--- a/subscriptions-api.md
+++ b/subscriptions-api.md
@@ -693,8 +693,7 @@ For example:
 
 Use of this MUST include a nested array of filter expressions, where all
 nested filter expressions MUST evaluate to true in order for the `all`
-filter expression to be true. The order in which the nested expressions are
-are listed is the order in which they MUST be evaluated.
+filter expression to be true.
 
 Note: there MUST be at least one filter expression in the array.
 
@@ -712,9 +711,7 @@ For example:
 
 Use of this MUST include one nested array of filter expressions, where at least
 one nested filter expressions MUST evaluate to true in order for the `any`
-filter expression to be true. The order in which the nested expressions are
-are listed is the order in which they MUST be evaluated, and processing MUST
-stop on the first successful match.
+filter expression to be true.
 
 Note: there MUST be at least one filter expression in the array.
 


### PR DESCRIPTION
The `all` and `any` combinators enforces too strict constraints on the actual evaluation of the filter. I propose to remove them, since they may impede any eventual optimization in the evaluation of filters

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>