### PR TITLE
Adding operation ids to discovery contract

### DIFF
--- a/ce_discovery.yaml
+++ b/ce_discovery.yaml
@@ -8,6 +8,7 @@ servers:
 paths:
   /services:
     get:
+      operationId: getServices
       parameters:
        - in: query
          name: matching
@@ -26,6 +27,7 @@ paths:
                   $ref: '#/components/schemas/service'
   /services/{name}:
     get:
+      operationId: getService
       parameters:
        - in: path
          name: name


### PR DESCRIPTION
Several tools are unhappy with missing operation ids in OpenAPI and will generate rather unpleasant names for proxies.


Signed-off-by: clemensv <clemensv@microsoft.com>