### PR TITLE
Fix for #673 - WebHook-Allowed-Origin

### DIFF
--- a/http-webhook.md
+++ b/http-webhook.md
@@ -310,7 +310,7 @@ WebHook-Allowed-Origin: eventemitter.example.com
 or
 
 ```text
-WebHook-Request-Origin: *
+WebHook-Allowed-Origin: *
 ```
 
 #### 4.2.2. WebHook-Allowed-Rate


### PR DESCRIPTION
As @schabungbam pointed out, there was an inconsistency in one example that is fixed with this PR.
@duglin Should this also be cherry-picked into 1.0.1, as it is just about a typo?

Signed-off-by: Klaus Deißner <klaus.deissner@sap.com>

Fixes #673 