### PR TITLE
bug (discovery): update example response

### DIFF
--- a/discovery.md
+++ b/discovery.md
@@ -710,7 +710,8 @@ Content-Type: application/json
 [
   {
     id: "{id}",
-    epoch: "{epoch}"
+    epoch: "{epoch}",
+    ... remainder of Service attributes ...
   },
   ...
 ]
@@ -821,6 +822,7 @@ Content-Type: application/json
 {
   "id": "{id}",
   "epoch": "{id}",
+  ... remainder of Service attributes ...
 }
 ```
 


### PR DESCRIPTION
Follow up to #837 

Example `POST /services` and `POST /services/{id}` response must
reflect changes too.