### PR TITLE
Update punctuation (period) in dataconenttype section

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -357,7 +357,7 @@ on the definition of OPTIONAL.
   For some binary mode protocol bindings, this field is directly mapped to the
   respective protocol's content-type metadata property. Normative rules for the
   binary mode and the content-type metadata mapping can be found in the
-  respective protocol
+  respective protocol.
 
   In some event formats the `datacontenttype` attribute MAY be omitted. For
   example, if a JSON format event has no `datacontenttype` attribute, then it is


### PR DESCRIPTION
Fixes #

To consistently use punctuation throughout the spec, fix typo in `datacontenttype` section.

## Proposed Changes

- Add missing period (".").

**Release Note**

N/A
