### PR TITLE
Discovery add history

### DIFF
--- a/ce_discovery.yaml
+++ b/ce_discovery.yaml
@@ -27,18 +27,10 @@ paths:
     post:
       operationId: postServices
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/services'
+        $ref: '#/components/requestBodies/servicespostrequest'
       responses:
         '200':
-          description: A list of the resulting Service values resulting from processing the request, in the same order as in the request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/services'
+          $ref: '#/components/responses/servicespostresponse'
         '400':
           description: Bad Request - constraint failure
         '409':
@@ -46,18 +38,10 @@ paths:
     delete:
       operationId: deleteServices
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/serviceinstances'
+        $ref: '#/components/requestBodies/servicesdeleterequest'
       responses:
         '200':
-          description: A list of the Services that were deleted
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/services'
+          $ref: '#/components/responses/servicesdeleteresponse'
         '400':
           description: Bad Request - constraint failure
         '404':
@@ -93,18 +77,10 @@ paths:
          schema:
            $ref: '#/components/schemas/service/properties/id'
       requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/service'
+        $ref: '#/components/requestBodies/servicepostrequest'
       responses:
         '200':
-          description: A Service Instance referencing the updated Service
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/service'
+          $ref: '#/components/responses/servicepostresponse'
         '400':
           description: Bad Request - constraint failure
         '404':
@@ -121,18 +97,10 @@ paths:
          schema:
            $ref: '#/components/schemas/service/properties/id'
       requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/serviceinstance'
+        $ref: '#/components/requestBodies/servicedeleterequest'
       responses:
         '200':
-          description: The Service that was deleted
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/service'
+          $ref: '#/components/responses/servicedeleteresponse'
         '400':
           description: Bad Request - constraint failure
         '404':
@@ -140,6 +108,60 @@ paths:
         '409':
           description: Conflict - epoch not greater
 components:
+  requestBodies:
+    servicespostrequest:
+      description: A request to create or update the discovery endpoint's collection of services with the given services
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/services'
+    servicesdeleterequest:
+      description: A request to remove the given services from the discovery endpoint's collection of services
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/serviceinstances'
+    servicepostrequest:
+      description: A request to create or update the discovery endpoint's collection of services with the given service
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/service'
+    servicedeleterequest:
+      description: A request to remove the given service from the discovery endpoint's collection of services
+      required: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/serviceinstance'
+  responses:
+    servicespostresponse:
+      description: A list of the resulting Service values resulting from processing the request, in the same order as in the request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/services'
+    servicesdeleteresponse:
+      description: A list of the Services that were deleted
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/services'
+    servicepostresponse:
+      description: A Service Instance referencing the updated Service
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/service'
+    servicedeleteresponse:
+      description: The Service that was deleted
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/service'
   schemas:
     eventtype:
       type: object
@@ -263,3 +285,72 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/service'
+    change:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/changeservicespost'
+        - $ref: '#/components/schemas/changeservicepost'
+        - $ref: '#/components/schemas/changeservicesdelete'
+        - $ref: '#/components/schemas/changeservicedelete'
+    changepost:
+      type: string
+      enum:
+        - POST
+    changedelete:
+      type: string
+      enum:
+        - DELETE
+    changeservicespath:
+      type: string
+      pattern: ^\/services(\/){0,1}$
+    changeservicepath:
+      type: string
+      pattern: ^\/services(\/[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}){0,1}$
+    changeservicespost:
+      type: object
+      properties:
+        operation:
+          $ref: '#/components/schemas/changepost'
+        path:
+          $ref: '#/components/schemas/changeservicespath'
+        request:
+          $ref: '#/components/requestBodies/servicespostrequest'
+        response:
+          $ref: '#/components/responses/servicespostresponse'
+      required: [operation, path, request, response]
+    changeservicesdelete:
+      type: object
+      properties:
+        operation:
+          $ref: '#/components/schemas/changedelete'
+        path:
+          $ref: '#/components/schemas/changeservicespath'
+        request:
+          $ref: '#/components/requestBodies/servicesdeleterequest'
+        response:
+          $ref: '#/components/responses/servicesdeleteresponse'
+      required: [operation, path, request, response]
+    changeservicepost:
+      type: object
+      properties:
+        operation:
+          $ref: '#/components/schemas/changepost'
+        path:
+          $ref: '#/components/schemas/changeservicepath'
+        request:
+          $ref: '#/components/requestBodies/servicepostrequest'
+        response:
+          $ref: '#/components/responses/servicepostresponse'
+      required: [operation, path, request, response]
+    changeservicedelete:
+      type: object
+      properties:
+        operation:
+          $ref: '#/components/schemas/changedelete'
+        path:
+          $ref: '#/components/schemas/changeservicepath'
+        request:
+          $ref: '#/components/requestBodies/servicedeleterequest'
+        response:
+          $ref: '#/components/responses/servicedeleteresponse'
+      required: [operation, path, request, response]

--- a/ce_discovery.yaml
+++ b/ce_discovery.yaml
@@ -52,12 +52,7 @@ paths:
     get:
       operationId: getService
       parameters:
-       - in: path
-         name: id
-         description: The id of the service to be returned
-         required: true
-         schema:
-           $ref: '#/components/schemas/service/properties/id'
+        - $ref: '#/components/parameters/id'
       responses:
         '200':
           description: The corresponding service
@@ -70,12 +65,7 @@ paths:
     post:
       operationId: postService
       parameters:
-       - in: path
-         name: id
-         description: The id of the service to be returned
-         required: true
-         schema:
-           $ref: '#/components/schemas/service/properties/id'
+        - $ref: '#/components/parameters/id'
       requestBody:
         $ref: '#/components/requestBodies/servicepostrequest'
       responses:
@@ -90,12 +80,7 @@ paths:
     delete:
       operationId: deleteService
       parameters:
-       - in: path
-         name: id
-         description: The id of the service to be returned
-         required: true
-         schema:
-           $ref: '#/components/schemas/service/properties/id'
+        - $ref: '#/components/parameters/id'
       requestBody:
         $ref: '#/components/requestBodies/servicedeleterequest'
       responses:
@@ -108,6 +93,14 @@ paths:
         '409':
           description: Conflict - epoch not greater
 components:
+  parameters:
+    id:
+      in: path
+      name: id
+      description: The id of the service
+      required: true
+      schema:
+        $ref: '#/components/schemas/service/properties/id'
   requestBodies:
     servicespostrequest:
       description: A request to create or update the discovery endpoint's collection of services with the given services

--- a/ce_discovery.yaml
+++ b/ce_discovery.yaml
@@ -92,6 +92,16 @@ paths:
           description: Not Found
         '409':
           description: Conflict - epoch not greater
+  /changes:
+    get:
+      operationId: getChanges
+      responses:
+        '200':
+          description: The historical service changes requested to this discovery endpoint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/changes'
 components:
   parameters:
     id:
@@ -285,6 +295,10 @@ components:
         - $ref: '#/components/schemas/changeservicepost'
         - $ref: '#/components/schemas/changeservicesdelete'
         - $ref: '#/components/schemas/changeservicedelete'
+    changes:
+      type: array
+      items:
+        $ref: '#/components/schemas/change'
     changepost:
       type: string
       enum:

--- a/discovery.md
+++ b/discovery.md
@@ -913,6 +913,38 @@ Any Discovery Endpoint Service entities MUST adhere to the following:
 }
 ```
 
+#### `GET /changes`
+
+The discovery service MAY offer a partial or complete history of changes to its
+collection of services.
+
+The changes listed by this endpoint are the same changes as those discoverable
+events that the "self" service entity offers.  As such, this endpoint offers
+requestors the ability to request copies of change events occurring prior to
+the request.  Discovery Endpoints that offer this historical listing MAY use a
+limited retention period.
+
+In the case of `200 OK`, the response format MUST adhere to the following:
+
+```
+200 OK
+Content-Type: application/json
+
+[
+  {
+    "operation": "{operation}", // POST|DELETE
+    "path": "{path}",           // /services[/{id}]
+    "request": {request},       // as per path specification
+    "response": {response}      // as per path specification
+  },
+  ...
+]
+```
+
+Implementations MAY use the [pagination](pagination.md) specification
+if the number of changes returned is large. Clients SHOULD be
+prepared to support paginated responses.
+
 ### OpenAPI
 
 See [Discovery Endpoint OpenAPI Specification](ce_discovery.yaml).

--- a/discovery.md
+++ b/discovery.md
@@ -876,6 +876,43 @@ Content-Type: application/json
 ]
 ```
 
+### History
+
+The discovery service MAY include itself as a Service entity that is
+discoverable.
+
+The events produced by this "self" Service describe the management requests
+made to the discovery service. The events produced MUST include the operation
+and path to which the management request was made as well as the request body
+and the response that was given.
+
+Receiving the complete set of these will allow a downstream mirror to exactly
+materialize a consistent Service collection.  A downstream mirror MAY alter
+records as appropriate for its cirucmstances.
+
+Any Discovery Endpoint Service entities MUST adhere to the following:
+```json
+{
+  "id": "{id}",
+  ... other service attributes ...
+  "events": [
+    {
+      "specversions": ["1.x-wip"],
+      "type" : "io.cloudevents.discovery.change",
+      "dataschemacontent": { // see ce_discovery.yaml#/components/schemas/change
+        "type": "object",
+        "properties": {
+          "operation": "{operation}", // POST|DELETE
+          "path": "{path}",           // /services[/{id}]
+          "request": {request},       // as per path specification
+          "response": {response}      // as per path specification
+        }
+      }
+    }
+  ]
+}
+```
+
 ### OpenAPI
 
 See [Discovery Endpoint OpenAPI Specification](ce_discovery.yaml).


### PR DESCRIPTION
Fixes #699 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add discovery endpoint as a Service entity by which it publishes changes to itself
- Add historical querying capability (perhaps better delivered by allowing subscriptions to specify delivery of events starting from those available as of a time in the past)

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note
Add Discovery Endpoint as a "self" Service Entity
Add historical service change query endpoint 
```
