### PR TITLE
Make it clear that empty query is still a 200

### DIFF
--- a/discovery.md
+++ b/discovery.md
@@ -551,6 +551,9 @@ parameters or filter processing to improve upon this minimum provision.
 
 - `name`
 
+Note: an empty result set is not an error and a zero sized array MUST be
+returned in those cases.
+
 Any Service previously returned to a client that does not appear in this
 result can be assumed to be no longer available in the scope of the query
 specified. In the unfiltered query case this means the Service has been


### PR DESCRIPTION
During interop testing someone was returning a 404 when the query yielded zero results. It shouldn't be an error.

Signed-off-by: Doug Davis <dug@us.ibm.com>
