### PR TITLE
feat(discovery): replace id by authority

### DIFF
--- a/discovery.md
+++ b/discovery.md
@@ -196,37 +196,20 @@ the wire format/API defined by this specification.
 
 The following sections define the attributes that appear in a Service entity.
 
-##### id
+#### `authority` (service authority)
 
-- Type: `String`
-- Description: A unique identifier for this Service. This value MUST be globally
-  unique. While other metadata about this Service MAY change, this value MUST
-  NOT so that clients can use this attribute to know whether a Service returned
-  by a query is the same Service returned by a previous query.
-
-  Whether a change to a Service would result in changing of the Service's
-  metadata (except `id`) and thus be just an update of an existing Service, or
-  whether the change would result in a brand new Service (with a new `id`) is
-  not defined by this specification.
-
-  For example, if a Service's implementation is upgraded to a new version then
-  whether this would result in a new Service (and `id`) or is an update to the
-  existing Service's metadata, is an implementation choice. Likewise, this
-  specification makes no statement, or guarantees, as to the forwards or
-  backwards compatibility of a Service as it changes over time.
-
-  Note, unlike the `name` attribute which only needs to be unique within the
-  scope of a single Discovery Endpoint, the global uniqueness aspect of this
-  attribute allows for the discovery of the same Service across multiple
-  Discovery Endpoints.
-
-  See the Primer for more information.
-
+- Type: `URI`
+- Description: Identifies the authority for this service. Similar to schemas authority.
 - Constraints:
-  - REQUIRED in responses from the Discovery Endpoint.
-  - MUST be a valid UUID per RFC4122.
+  - OPTIONAL. If the attribute is absent or empty, its implied default value is the base
+    URI of the API endpoint.
+  - MUST be a valid URI.
+  - For services imported from other discovery endpoints in replication scenarios, the
+    attribute is REQUIRED to be not empty. If the value is empty or absent
+    during import, it MUST be explicitly set to its implied default value.
 - Examples:
-  - `bf5ff5cc-d059-4c79-a89a-2513e45a1340`
+  - `urn:com-example-schemas`
+  - `https://schemas.example.com`
 
 ##### epoch
 
@@ -252,7 +235,7 @@ The following sections define the attributes that appear in a Service entity.
 - Type: `String`
 - Description: A unique human readable identifier for this Service. This value
   MUST be unique (case insensitive) within the scope of this Discovery Endpoint.
-  Note, this differs from the `id` attribute which is globally unique.
+  Note, the couple `authority` and `name` are unique globally.
 - Constraints:
   - REQUIRED
   - MUST be a non-empty string


### PR DESCRIPTION
Signed-off-by: Remi Cattiau <remi@cattiau.com>

## Proposed Changes

- Adopt the authority concept from Schema Registry within Discovery Services
- Remove id as it is no use anymore as authority + name become de facto global unique id
