### PR TITLE
Explicitly state application/json defaulting when serializing

### DIFF
--- a/json-format.md
+++ b/json-format.md
@@ -150,6 +150,8 @@ contain JSON-formatted content. Such a content type is defined as one having a
 [media subtype][rfc2045-sec5] equal to `json` or ending with a `+json` format
 extension. That is, a `datacontenttype` declares JSON-formatted content if its
 media type, when stripped of parameters, has the form `*/json` or `*/*+json`.
+If the `datacontenttype` is unspecified, processing SHOULD proceed as if the
+`datacontenttype` had been specified explicitly as `application/json`.
 
 If the `datacontenttype` declares the data to contain JSON-formatted content, a
 JSON serializer MUST translate the data value to a [JSON value][json-value], and


### PR DESCRIPTION
(I've used SHOULD rather than MUST to be consistent with deserialization. If we were starting from scratch, I'd suggest that MUST would be more appropriate, but it's probably too late to do that.)

Fixes #880

## Proposed Changes

- Explicitly state that when serializing data using the JSON event format, treat a missing `datacontenttype` as implicitly `application/json`

**Release Note**

```release-note
If `datacontenttype` is missing when serializing in the JSON format, it should be treated as `application/json`
```
