### PR TITLE
Removing old additions to the page, adding 1.0 requirement.

### DIFF
--- a/community/open-source.md
+++ b/community/open-source.md
@@ -1,48 +1,16 @@
 If you have created (or know of) an open source library or product that uses
-CloudEvents, please include in the list below.
+CloudEvents v1.0+, please include in the list below.
 
-- [CloudEvents.NET](https://github.com/aliencube/CloudEvents.NET): is a .NET
-  implementation of the CloudEvents [spec](../spec.md) and
-  [HTTP protocol binding](../http-protocol-binding.md). It has been released to
-  [nuget.org](https://www.nuget.org/packages?q=Aliencube.CloudEventsNet). It
-  also contains some app
-  [samples](https://github.com/aliencube/CloudEvents.NET/tree/master/sample)
-  of 1) console app to Web API, and 2) Web API to Azure Event Grid, which
-  demonstrates how CloudEvent messages are generated and sent to Web API and
-  Azure Event Grid over HTTP.
-- [microBean CloudEvents](https://microbean.github.io/microbean-cloudevents/):
-  CloudEvents represented as plain Java objects. Satellite projects add
-  [Jackson and CDI event integration](https://microbean.github.io/microbean-cloudevents-jackson-cdi).
-- [jCloudEvents](https://github.com/project-streamzi/jcloudevents): Java POJO
-  implementation of the CloudEvents specification and some CDI bindings.
-- [Strombrau Gateway](https://github.com/project-streamzi/event-gateway): Vert.x
-  based gateway routing CloudEvent metadata to internal Apache Kafka topic
-- [Event Gateway](https://github.com/serverless/event-gateway): It's dataflow
-  for event-driven, serverless architectures. The Event Gateway combines both
-  API Gateway and Pub/Sub functionality into a single event-driven experience.
-- [CloudEvents Extend API](https://github.com/goextend/cloudevents-extend-api)
-  is a JavaScript programming model for Extend which allows handling Cloud
-  Events.
-- [CloudEvents Verify](https://github.com/btbd/CEVerify): is a tool to help
-  verify CloudEvents according to the proper specifications. It is currently
-  being hosted publicly [here](http://soaphub.org/ceverify).
-- [Gloo](https://github.com/solo-io/gloo): is a function gateway built on top of
-  [Envoy Proxy](https://envoyproxy.io/) by [Solo.io](https://www.solo.io/) that
-  supports CloudEvents.
-- [cloudevents-python](https://github.com/williamhogman/cloudevents-python): A
-  CloudEvents library for python.
-- [CloudEvents.live](https://cloudevents.live/): A real-time debugger/request
-  bin for the CloudEvents webhook format. Submit events to the bin and
-  immediately see them in the web UI (Sources:
-  [Backend](https://github.com/klira/cloudevents-bin)
-  [Frontend](https://github.com/klira/cloudevents-debugger))
+## Routing and Platforms
+
 - [Argo-Events](https://github.com/argoproj/argo-events): An event-based
   dependency manager for Kubernetes which uses sensors to act on CloudEvents.
-- [cloudevent.js](https://github.com/smartiniOnGitHub/cloudevent.js): A
-  CloudEvents library for Node.js.
-- [CloudEvents JSON Schema](https://marketplace.visualstudio.com/items?itemName=tsurdilovic.cloudevents-schema-vscode):
-  Visual Studio Code extension for CloudEvents format.
 - [Knative Eventing](https://knative.dev) implements CloudEvents based sources
   and event delivery abstractions build on top of Kubernetes.
 - [VMware Event Broker Appliance](https://vmweventbroker.io) enables event
   driven workflows from vCenter Server Events.
+
+## Tooling and Extensions
+
+- [CloudEvents JSON Schema](https://marketplace.visualstudio.com/items?itemName=tsurdilovic.cloudevents-schema-vscode):
+  Visual Studio Code extension for CloudEvents format.


### PR DESCRIPTION
Signed-off-by: Scott Nichols <scott@chainguard.dev>

## Proposed Changes

- Removed refs in the open source page where the integration did not support v1.0 of the CloudEvents spec.
- Added some simple headers to sort the content.

**Release Note**


```release-note
Cleaned up the open-source.md page.
```
