### PR TITLE
Fix dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,26 +27,26 @@ The following documents are available:
 |                               |                                 Latest Release                                  |                                      Working Draft                                       |
 | :---------------------------- | :-----------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------: |
 | **Core Specification:**       |
-| CloudEvents                   |          [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md)          |            [master](https://github.com/cloudevents/spec/blob/master/spec.md)             |
+| CloudEvents                   |          [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md)          |            [master](https://github.com/cloudevents/spec/blob/master/cloudevents/spec.md)             |
 |                               |
 | **Optional Specifications:**  |
-| AMQP Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/amqp-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/amqp-protocol-binding.md)    |
-| AVRO Event Format             |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/avro-format.md)       |         [master](https://github.com/cloudevents/spec/blob/master/avro-format.md)         |
-| HTTP Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/http-protocol-binding.md)    |
-| JSON Event Format             |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/json-format.md)       |         [master](https://github.com/cloudevents/spec/blob/master/json-format.md)         |
-| Kafka Protocol Binding        | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/kafka-protocol-binding.md) |   [master](https://github.com/cloudevents/spec/blob/master/kafka-protocol-binding.md)    |
-| MQTT Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/mqtt-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/mqtt-protocol-binding.md)    |
-| NATS Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/nats-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/nats-protocol-binding.md)    |
-| WebSockets Protocol Binding   |                                        -                                        | [master](https://github.com/cloudevents/spec/blob/master/websockets-protocol-binding.md) |
-| Protobuf Event Format         |                                                                                 | [v1.0-rc1](https://github.com/cloudevents/spec/blob/master/protobuf-format.md)                                  |
-| Web hook                      |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-webhook.md)      |        [master](https://github.com/cloudevents/spec/blob/master/http-webhook.md)         |
+| AMQP Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/amqp-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/cloudevents/bindings/amqp-protocol-binding.md)    |
+| AVRO Event Format             |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/avro-format.md)       |         [master](https://github.com/cloudevents/spec/blob/master/cloudevents/formats/avro-format.md)         |
+| HTTP Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/cloudevents/bindings/http-protocol-binding.md)    |
+| JSON Event Format             |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/json-format.md)       |         [master](https://github.com/cloudevents/spec/blob/master/cloudevents/formats/json-format.md)         |
+| Kafka Protocol Binding        | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/kafka-protocol-binding.md) |   [master](https://github.com/cloudevents/spec/blob/master/cloudevents/bindings/kafka-protocol-binding.md)    |
+| MQTT Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/mqtt-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/cloudevents/bindings/mqtt-protocol-binding.md)    |
+| NATS Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/nats-protocol-binding.md)  |    [master](https://github.com/cloudevents/spec/blob/master/cloudevents/bindings/nats-protocol-binding.md)    |
+| WebSockets Protocol Binding   |                                        -                                        | [master](https://github.com/cloudevents/spec/blob/master/cloudevents/bindings/websockets-protocol-binding.md) |
+| Protobuf Event Format         |                                                                                 | [v1.0-rc1](https://github.com/cloudevents/spec/blob/master/cloudevents/formats/protobuf-format.md)                                  |
+| Web hook                      |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-webhook.md)      |        [master](https://github.com/cloudevents/spec/blob/master/cloudevents/http-webhook.md)         |
 |                               |
 | **Additional Documentation:** |
-| CloudEvents Adapters          |                                        -                                        |          [master](https://github.com/cloudevents/spec/blob/master/adapters.md)           |
-| CloudEvents SDK Requirements  |                                        -                                        |             [master](https://github.com/cloudevents/spec/blob/master/SDK.md)             |
-| Documented Extensions         |                                        -                                        |    [master](https://github.com/cloudevents/spec/blob/master/documented-extensions.md)    |
-| Primer                        |         [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/primer.md)         |           [master](https://github.com/cloudevents/spec/blob/master/primer.md)            |
-| Proprietary Specifications    |                                        -                                        |      [master](https://github.com/cloudevents/spec/blob/master/proprietary-specs.md)      |
+| CloudEvents Adapters          |                                        -                                        |          [master](https://github.com/cloudevents/spec/blob/master/cloudevents/adapters.md)           |
+| CloudEvents SDK Requirements  |                                        -                                        |             [master](https://github.com/cloudevents/spec/blob/master/cloudevents/SDK.md)             |
+| Documented Extensions         |                                        -                                        |    [master](https://github.com/cloudevents/spec/blob/master/cloudevents/documented-extensions.md)    |
+| Primer                        |         [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/primer.md)         |           [master](https://github.com/cloudevents/spec/blob/master/cloudevents/primer.md)            |
+| Proprietary Specifications    |                                        -                                        |      [master](https://github.com/cloudevents/spec/blob/master/cloudevents/proprietary-specs.md)      |
 
 If you are new to CloudEvents, it is recommended that you start by reading the
 [Primer](primer.md) for an overview of the specification's goals and design
@@ -55,7 +55,7 @@ decisions, and then move on to the [core specification](spec.md).
 Since not all event producers generate CloudEvents by default, there is
 documentation describing the recommended process for adapting some popular
 events into CloudEvents, see
-[CloudEvents Adapters](https://github.com/cloudevents/spec/blob/master/adapters.md).
+[CloudEvents Adapters](https://github.com/cloudevents/spec/blob/master/cloudevents/adapters.md).
 
 ## SDKs
 


### PR DESCRIPTION
Noticed some `master` links were broken, broke out https://github.com/tcort/markdown-link-check to find all the rest 😄 