### PR TITLE
Indicate TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In addition to the documentation mentioned above, there is also an
 - [CSharp](https://github.com/cloudevents/sdk-csharp)
 - [Go](https://github.com/cloudevents/sdk-go)
 - [Java](https://github.com/cloudevents/sdk-java)
-- [Javascript](https://github.com/cloudevents/sdk-javascript)
+- [Javascript/TypeScript](https://github.com/cloudevents/sdk-javascript)
 - [PHP](https://github.com/cloudevents/sdk-php)
 - [Python](https://github.com/cloudevents/sdk-python)
 - [Ruby](https://github.com/cloudevents/sdk-ruby)


### PR DESCRIPTION
This change makes it clear that the Javascript SDK supports TypeScript.  In fact, it is written in TypeScript.

This just saves people the time of digging into the repository of the Javascript SDK to see whether it includes any TypeScript
definitions.

## Proposed Changes

- Update README to indicate SDK supports TypeScript

**Release Note**

No need to update any release notes.
