### PR TITLE
chore: tweak SDK requirements wording

### DIFF
--- a/cloudevents/SDK.md
+++ b/cloudevents/SDK.md
@@ -46,7 +46,7 @@ Each SDK MUST meet these requirements:
 - Idiomatic usage of the programming language.
   - Using current language version(s).
 - Supports HTTP transport renderings in both `structured` and `binary`
-  encodings.
+  content mode.
 
 ### Object Model Structure Guidelines
 


### PR DESCRIPTION
Fixes # https://github.com/cloudevents/spec/issues/910

## Proposed Changes

- A very minor clarifying change to the wording of the SDK requirements to make it more consistent with the HTTP transport specification.
