### PR TITLE
Fix broken link to section about filter dialects

### DIFF
--- a/cesql/spec.md
+++ b/cesql/spec.md
@@ -465,6 +465,6 @@ hop < ttl
 [ce-attribute-naming-convention]: ./spec.md#attribute-naming-convention
 [ce-type-system]: ./spec.md#type-system
 [ce-id-attribute]: ./spec.md#id
-[subscriptions-filter-dialect]: ./subscriptions-api.md#3231-filter-dialects
+[subscriptions-filter-dialect]: /subscriptions/spec.md#3241-filter-dialects
 [ebnf-xml-spec]: https://www.w3.org/TR/REC-xml/#sec-notation
 [modulo-operation-wiki]: https://en.wikipedia.org/wiki/Modulo_operation


### PR DESCRIPTION
Fixes #

This PR  fixes a link in the CE SQL spec that was broken during the latest repository restructuring. 