### PR TITLE
Update processing of Epoch on all operations

### DIFF
--- a/discovery/discovery.yaml
+++ b/discovery/discovery.yaml
@@ -34,7 +34,7 @@ paths:
         '400':
           description: Bad Request - constraint failure
         '409':
-          description: Conflict - epoch not greater
+          description: Conflict - epoch does not match
     delete:
       operationId: deleteServices
       requestBody:
@@ -42,12 +42,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/servicesdeleteresponse'
-        '400':
-          description: Bad Request - constraint failure
-        '404':
-          description: Not Found
         '409':
-          description: Conflict - epoch not greater
+          description: Conflict - epoch does not match
   /services/{id}:
     get:
       operationId: getService
@@ -76,9 +72,16 @@ paths:
         '404':
           description: Not Found
         '409':
-          description: Conflict - epoch not greater
+          description: Conflict - epoch does not match
     delete:
       operationId: deleteService
+      parameters:
+       - in: query
+         name: epoch
+         description: The epoch of the service to be deleted
+         required: false
+         schema:
+           $ref: '#/components/schemas/service/properties/epoch'
       parameters:
         - $ref: '#/components/parameters/id'
       requestBody:
@@ -86,12 +89,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/servicedeleteresponse'
-        '400':
-          description: Bad Request - constraint failure
-        '404':
-          description: Not Found
         '409':
-          description: Conflict - epoch not greater
+          description: Conflict - epoch does not match
 components:
   parameters:
     id:

--- a/discovery/discovery.yaml
+++ b/discovery/discovery.yaml
@@ -34,7 +34,7 @@ paths:
         '400':
           description: Bad Request - constraint failure
         '409':
-          description: Conflict - epoch does not match
+          description: Conflict - invalid epoch value
     delete:
       operationId: deleteServices
       requestBody:
@@ -43,7 +43,7 @@ paths:
         '200':
           $ref: '#/components/responses/servicesdeleteresponse'
         '409':
-          description: Conflict - epoch does not match
+          description: Conflict - invalid epoch value
   /services/{id}:
     get:
       operationId: getService
@@ -72,7 +72,7 @@ paths:
         '404':
           description: Not Found
         '409':
-          description: Conflict - epoch does not match
+          description: Conflict - invalid epoch value
     delete:
       operationId: deleteService
       parameters:
@@ -90,7 +90,7 @@ paths:
         '200':
           $ref: '#/components/responses/servicedeleteresponse'
         '409':
-          description: Conflict - epoch does not match
+          description: Conflict - invalid epoch value
 components:
   parameters:
     id:

--- a/discovery/discovery.yaml
+++ b/discovery/discovery.yaml
@@ -34,7 +34,7 @@ paths:
         '400':
           description: Bad Request - constraint failure
         '409':
-          description: Conflict - invalid epoch value
+          description: Conflict - epoch not greater
     delete:
       operationId: deleteServices
       requestBody:
@@ -42,8 +42,10 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/servicesdeleteresponse'
+        '400':
+          description: Bad Request - constraint failure
         '409':
-          description: Conflict - invalid epoch value
+          description: Conflict - epoch not greater
   /services/{id}:
     get:
       operationId: getService
@@ -56,6 +58,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/service'
+        '400':
+          description: Bad Request - constraint failure
         '404':
           description: Not Found
     put:
@@ -72,7 +76,7 @@ paths:
         '404':
           description: Not Found
         '409':
-          description: Conflict - invalid epoch value
+          description: Conflict - epoch not greater
     delete:
       operationId: deleteService
       parameters:
@@ -84,13 +88,13 @@ paths:
            $ref: '#/components/schemas/service/properties/epoch'
       parameters:
         - $ref: '#/components/parameters/id'
-      requestBody:
-        $ref: '#/components/requestBodies/servicedeleterequest'
       responses:
         '200':
           $ref: '#/components/responses/servicedeleteresponse'
+        '400':
+          description: Bad Request - constraint failure
         '409':
-          description: Conflict - invalid epoch value
+          description: Conflict - epoch not greater
 components:
   parameters:
     id:
@@ -122,13 +126,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/service'
-    servicedeleterequest:
-      description: A request to remove the given service from the discovery endpoint's collection of services
-      required: false
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/serviceinstance'
   responses:
     servicespostresponse:
       description: A list of the resulting Service values resulting from processing the request, in the same order as in the request
@@ -350,8 +347,6 @@ components:
           $ref: '#/components/schemas/changedelete'
         path:
           $ref: '#/components/schemas/changeservicepath'
-        request:
-          $ref: '#/components/requestBodies/servicedeleterequest'
         response:
           $ref: '#/components/responses/servicedeleteresponse'
       required: [operation, path, request, response]

--- a/discovery/spec.md
+++ b/discovery/spec.md
@@ -279,7 +279,7 @@ The following sections define the attributes that appear in a Service entity.
   Note: this value will most likely be Discovery Endpoint defined and therefore
   will most likely be ignored when provided by clients.
 - Constraints:
-  - MUST be read-only, Discovery Endpoint, manageg
+  - MUST be specified by the Discovery Endpoint and otherwise read-only
   - REQUIRED in responses from the Discovery Endpoint.
   - MUST be a non-empty URL
   - MUST end with `fsegments` (per RFC1738) of: `/services/{id}` where `id` is
@@ -813,7 +813,7 @@ The following rules apply to processing the Services specified in the request:
 
 There is no requirement that the incoming Services be processed in the
 order in which they appear. Constraints apply only to the result of the
-entire request. For eaxmple, if a Service with a name of `dog` exists and
+entire request. For example, if a Service with a name of `dog` exists and
 the incoming request is creating a new Service called `dog` as well as
 renaming the existing Service to `cat` then the request is expected to succeed
 even if it would cause two Services to temporarily have the same name.
@@ -870,11 +870,11 @@ This MUST delete all of the Services in the Discovery Endpoint that are
 contained in the request. If any of those Services cannot be deleted for any
 reason then the entire request MUST fail with no effect.
 
-If an `id` is not specified in any of the Services the entire request MUST
-fail. If no Service can be found that corresponds to a specified `id`, the
-endpoint MUST behave as though the Service was deleted. An `epoch` value MAY
-be omitted in the incoming Service.  If present and the request value is not
-greater than existing value, then the request MUST fail.
+If any of the Services in the incoming request are missing an `id` then the
+entire request MUST fail. If no Service can be found that corresponds to a
+specified `id`, the endpoint MUST behave as though the Service was deleted.
+An `epoch` value MAY be omitted in the incoming Service.  If present and the
+request value is not greater than existing value, then the request MUST fail.
 
 If other service attributes are included in the request, those SHOULD be
 ignored for the purposes of processing the request.
@@ -999,7 +999,9 @@ is no Service with the specified `id` then it is considered to have already
 been deleted and the request will have no change to the Discovery Endpoint.
 A missing Service is not considered an error condition.
 
-This specification does not define a Body for the request message.
+This specification does not define a Body for the request message and the
+presence of a Body (even with a Service definition, valid or not) MUST NOT
+result in an error.
 
 The request URL MAY include an OPTIONAL `epoch` query parameter, and if
 present and is not greater than the Service's current `epoch` value, then the

--- a/discovery/spec.md
+++ b/discovery/spec.md
@@ -867,8 +867,8 @@ exist) then the entire request MUST fail with no effect.
 If an `id` is not specified in any of the Services the entire request MUST
 fail. If no Service can be found that corresponds to a specified `id`, the
 entire request MUST fail. An `epoch` value MAY be omitted. If a Service
-corresponding to a specified `id` has a higher recorded `epoch` value than the
-one given the entire request MUST fail.
+corresponding to a specified `id` has a different recorded `epoch` value than
+the one given the entire request MUST fail.
 
 If other service attributes are included in the request, those SHOULD be
 ignored for the purposes of processing the request.
@@ -877,15 +877,13 @@ Service deletions MUST be processed in the order in which they are given. Thus,
 if a Service is specified multiple times the entire request MUST fail.
 
 The follow responses are defined by this specification:
-- `200 OK` if all the specified Services were deleted successfully.
+- `200 OK` if none of the specified Services remain in the Discovery Endpoint.
   - The HTTP Response Body MUST include an array of the Service values at the
     time of deletion. The order of those values MUST match that of the
     Services in the request.
 - `400 Bad Request` if the first error encountered is a missing `id`
-- `404 Not Found` if the first error encountered is that there is no Service
-  with a given `id`
-- `409 Conflict` if the first error encountered is that a given epoch was less
-  than or equal to the existing epoch of the Service with a given `id`
+- `409 Conflict` if the first error encountered is that a given epoch was not
+  equal to the recorded epoch of the Service with a given `id`
 
 The format of the HTTP Request MUST adhere to the following:
 ```
@@ -973,52 +971,29 @@ Content-Type: application/json
 
 This MUST delete the Service at the referenced URL.
 
-The request MAY include a body. Any such body MUST be an object containing an
-`id` matching the `{id}` in the path. That object MAY include an `epoch`
-value. If the Service corresponding with the specified `id` has a higher
-recorded `epoch` value than given, the request MUST fail.
-
-If other service attributes are included in the request, those MUST be
-ignored for the purposes of processing the request.
+The request URL MAY include an OPTIONAL `epoch` query parameter, and if
+present, the Discovery Endpoint MUST reject the request if the corresponding
+Service has a different recorded `epoch` value than the query parameter.
 
 The follow responses are defined by this specification:
-- `200 OK` if the new Service was deleted.
+- `200 OK` if the Service was deleted or does not exist.
   - The HTTP Response Body MUST include the Service values at the time of
     deletion.
-- `400 Bad Request` if `id` is in the body and does not match the `{id}` in the
-  path
-- `404 Not Found` if there is no Service with the specified `id`
-- `409 Conflict` if the given epoch was less than or equal to the existing
-  epoch of the Service with the given `id`
+- `409 Conflict` if the given epoch was not equal to the existing epoch of the
+  Service with the given `id`
 
 Other responses are allowed, but not defined by this specification.
-
-The format of the OPTIONAL HTTP Request body MUST adhere to the following:
-```
-Content-Type: application/json
-
-[
-  {
-    id: "{id}",      // REQUIRED
-    epoch: "{epoch}" // OPTIONAL
-  },
-  ...
-]
-```
 
 The format of the `200 OK` HTTP Response MUST adhere to the following:
 ```
 200 OK
 Content-Type: application/json
 
-[
-  {
-    "url": "{url}",
-    "name": "{name}",
-    ... remainder of Service attributes ...
-  }
-  ...
-]
+{
+  "url": "{url}",
+  "name": "{name}",
+  ... remainder of Service attributes ...
+}
 ```
 
 ### Discovery Endpoint Service Change Events

--- a/discovery/spec.md
+++ b/discovery/spec.md
@@ -769,7 +769,7 @@ original request. The following responses are defined:
 - `202 Accepted` indicates that the original request is still being processed.
   The response body MAY be empty.
 - `406 Not Acceptable` to indicate that the original request failed to be
-  processed correctly. The HTTP response Body SHOULD include additional
+  processed correctly. The HTTP response body SHOULD include additional
   information as to why it failed.
 
 Other responses are allowed, but not defined by this specification, however
@@ -808,8 +808,6 @@ The following rules apply to processing the Services specified in the request:
 - aside from `id` and `epoch`, unless there is an out of band agreement,
   all mandatory attributes MUST be present in the request, and a Discovery
   Endpoint MUST reject requests that are missing such attributes.
-- the Discovery Endpoint MUST ignore attempts to modify read-only or immutable
-  attributes - such as `id` and `url`.
 
 There is no requirement that the incoming Services be processed in the
 order in which they appear. Constraints apply only to the result of the
@@ -887,7 +885,7 @@ an array of Services that match the order of the array of Services specified
 in the request. The Services in the response MUST include at least the `id`
 attribute and SHOULD include the remaining Service attributes as they existed
 immediately prior to the Service being deleted, if possible. If the Service
-was deleted prior the processing of this request the Service values might not
+was deleted prior the processing of this request the Service might not
 be available to be returned.
 
 If the response Services include `epoch` values then they MUST be the values
@@ -931,7 +929,7 @@ Content-Type: application/json
 
 #### `PUT /services/{id}`
 
-This MUST update, or create, the Service referenced by the specified URL.
+This MUST update, or create, the Service as identified by the `id` in the URL.
 Upon successful processing of the request, any existing Service MUST be
 completely replaced by the Service definition, except where noted below.
 
@@ -953,10 +951,10 @@ all mandatory attributes MUST be present in the request, and a Discovery
 Endpoint MUST reject requests that are missing such attributes.
 
 The Discovery Endpoint MUST ignore attempts to modify read-only or immutable
-attributes - such as `id` and `url`.
+attributes - such as `url`.
 
 Upon successfully processing the request, the HTTP response body MUST be
-the Service values resulting from the successful processing of the request.
+the Service resulting from the successful processing of the request.
 The response SHOULD include the current values for all attributes, even if
 the Discovery Endpoint added or modified some value during the processing
 of the request.
@@ -999,16 +997,13 @@ is no Service with the specified `id` then it is considered to have already
 been deleted and the request will have no change to the Discovery Endpoint.
 A missing Service is not considered an error condition.
 
-This specification does not define a Body for the request message and the
-presence of a Body (even with a Service definition, valid or not) MUST NOT
+This specification does not define a body for the request message and the
+presence of a body (even with a Service definition, valid or not) MUST NOT
 result in an error.
 
 The request URL MAY include an OPTIONAL `epoch` query parameter, and if
 present and is not greater than the Service's current `epoch` value, then the
 request MUST fail.
-
-If other service attributes are included in the request, those SHOULD be
-ignored for the purposes of processing the request.
 
 Upon successfully processing the request, the HTTP response body MUST be
 a Service definition that includes at least the `id` attribute and SHOULD
@@ -1017,7 +1012,7 @@ to the Service being deleted, if possible. If the Service was deleted prior
 to the processing of this request the Service value might not be available
 to be returned.
 
-If the response Services include an `epoch` value then each MUST be greater
+If the response Service include an `epoch` value then it MUST be greater
 than the Service's value prior to the delete operation.
 
 The following responses are defined by this specification:


### PR DESCRIPTION
Based on last week's call I updated our "epoch" processing for the APIs to be more consistent:
- epoch is used for version checking. If present on the request then the current value in the DE must match
- PUT is used to update - not create
- POST is used for create or update (mainly for bulk update)
- import/sync'ing is no supported (and I removed any text that implies it)
- I removed the ability to specify the same Service more than once in a POST or DELETE

We can add import/sync support in another PR.

OLD:
Also:
- reject requests if the passed-in epoch value doesn't exactly match current value
- make DELETE idempotent by returning a 200 (instead of 404) of the Service is already deleted
- removed the Body on the `DELETE /services/ID` since we don't really need it if we have the query param
- reply should be singleton, not an array

Signed-off-by: Doug Davis <dug@us.ibm.com>

Fixes #925 