### PR TITLE
Add checks for bookmarks & fix bad links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CloudEvents
 
+<!-- no verify-specs -->
+
 ![CloudEvents logo](https://github.com/cncf/artwork/blob/master/projects/cloudevents/horizontal/color/cloudevents-horizontal-color.png)
 
 Events are everywhere. However, event producers tend to describe events

--- a/cesql/spec.md
+++ b/cesql/spec.md
@@ -285,7 +285,7 @@ Both `%` and `_` can be escaped with `\`, in order to be matched literally. For 
 | ----------------------------------- | --------------------------------------------------------------------------- |
 | `EXISTS identifier: Any -> Boolean` | Returns `true` if the attribute `identifier` exists in the input CloudEvent |
 
-Note: `EXISTS` MUST always return `true` for the required context attributes because the input CloudEvent is always
+Note: `EXISTS` MUST always return `true` for the REQUIRED context attributes because the input CloudEvent is always
 assumed valid, e.g. `EXISTS id` MUST always return `true`.
 
 #### 3.4.5. In operator
@@ -462,9 +462,9 @@ hop < ttl
 [rfc2119]: https://tools.ietf.org/html/rfc2119
 [total-programming-language-wiki]: https://en.wikipedia.org/wiki/Total_functional_programming
 [referential-transparency-wiki]: https://en.wikipedia.org/wiki/Referential_transparency
-[ce-attribute-naming-convention]: ./spec.md#attribute-naming-convention
-[ce-type-system]: ./spec.md#type-system
-[ce-id-attribute]: ./spec.md#id
-[subscriptions-filter-dialect]: /subscriptions/spec.md#3241-filter-dialects
+[ce-attribute-naming-convention]: ../cloudevents/spec.md#attribute-naming-convention
+[ce-type-system]: ../cloudevents/spec.md#type-system
+[ce-id-attribute]: ../cloudevents/spec.md#id
+[subscriptions-filter-dialect]: ../subscriptions/spec.md#3241-filter-dialects
 [ebnf-xml-spec]: https://www.w3.org/TR/REC-xml/#sec-notation
 [modulo-operation-wiki]: https://en.wikipedia.org/wiki/Modulo_operation

--- a/cloudevents/SDK.md
+++ b/cloudevents/SDK.md
@@ -1,5 +1,7 @@
 # CloudEvents SDK Requirements
 
+<!-- no verify-specs -->
+
 The intent of this document to describe a minimum set of requirements for new
 Software Development Kits (SDKs) for CloudEvents. These SDKs are designed and
 implemented to enhance and speed up CloudEvents integration. As part of

--- a/cloudevents/adapters.md
+++ b/cloudevents/adapters.md
@@ -1,5 +1,7 @@
 # CloudEvents Adapters
 
+<!-- no verify-specs -->
+
 Not all event producers will produce CloudEvents natively. As a result,
 some "adapter" might be needed to convert these events into CloudEvents.
 This will typically mean extracting metadata from the events to be used as

--- a/cloudevents/adapters/aws-s3.md
+++ b/cloudevents/adapters/aws-s3.md
@@ -26,7 +26,8 @@ Comments:
 - While the "eventSource" value will always be static (`aws:s3`) when
   the event is coming from S3, if some other cloud provider is supporting
   the S3 event format it is expected that this value will not be
-  `aws:s3` for them - it should be something specific to their environment.
+  `aws:s3` for them - it is expected to be something specific to their
+  environment.
 - Consumers of these events will therefore be able to know if the event
   is an S3 type of event (regardless of whether it is coming from S3 or
   an S3-compatible provider) by detecting the `com.amazonaws.s3` prefix

--- a/cloudevents/bindings/amqp-protocol-binding.md
+++ b/cloudevents/bindings/amqp-protocol-binding.md
@@ -313,8 +313,8 @@ content-type: application/cloudevents+json; charset=utf-8
 - [OASIS-AMQP-1.0][oasis-amqp-1.0] OASIS Advanced Message Queuing Protocol
   (AMQP) Version 1.0
 
-[ce]: ./spec.md
-[json-format]: ./formats/json-format.md
+[ce]: ../spec.md
+[json-format]: ../formats/json-format.md
 [content-type]: https://tools.ietf.org/html/rfc7231#section-3.1.1.5
 [json-value]: https://tools.ietf.org/html/rfc7159#section-3
 [rfc2046]: https://tools.ietf.org/html/rfc2046
@@ -327,3 +327,8 @@ content-type: application/cloudevents+json; charset=utf-8
 [message-format]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
 [data]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-data
 [app-properties]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties
+[amqp-boolean]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-boolean
+[amqp-long]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-long
+[amqp-binary]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-binary
+[amqp-string]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-string
+[amqp-timestamp]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-timestamp

--- a/cloudevents/bindings/kafka-protocol-binding.md
+++ b/cloudevents/bindings/kafka-protocol-binding.md
@@ -325,8 +325,8 @@ content-type: application/cloudevents+json; charset=UTF-8
 - [RFC7159][rfc7159] The JavaScript Object Notation (JSON) Data Interchange
   Format
 
-[ce]: ./spec.md
-[json-format]: ./formats/json-format.md
+[ce]: ../spec.md
+[json-format]: ../formats/json-format.md
 [kafka]: https://kafka.apache.org
 [kafka-message-format]: https://kafka.apache.org/documentation/#messageformat
 [kafka-message-header]: https://kafka.apache.org/documentation/#recordheader

--- a/cloudevents/bindings/mqtt-protocol-binding.md
+++ b/cloudevents/bindings/mqtt-protocol-binding.md
@@ -319,12 +319,14 @@ Topic Name: mytopic
 - [RFC7159][rfc7159] The JavaScript Object Notation (JSON) Data Interchange
   Format
 
-[ce]: ./spec.md
-[ce-types]: ./spec.md#type-system
-[json-format]: ./formats/json-format.md
+[ce]: ../spec.md
+[ce-types]: ../spec.md#type-system
+[json-format]: ../formats/json-format.md
 [oasis-mqtt-3.1.1]: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html
 [oasis-mqtt-5]: http://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html
+[3-publish]: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html#_Toc442180850
 [5-content-type]: http://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html#_Toc502667341
+[5-publish]: https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901100
 [json-value]: https://tools.ietf.org/html/rfc7159#section-3
 [rfc2046]: https://tools.ietf.org/html/rfc2046
 [rfc2119]: https://tools.ietf.org/html/rfc2119

--- a/cloudevents/bindings/nats-protocol-binding.md
+++ b/cloudevents/bindings/nats-protocol-binding.md
@@ -155,11 +155,11 @@ Subject: mySubject
 - [RFC7159][rfc7159] The JavaScript Object Notation (JSON) Data Interchange
   Format
 
-[ce]: ./spec.md
-[json-format]: ./formats/json-format.md
+[ce]: ../spec.md
+[json-format]: ../formats/json-format.md
 [nats]: https://nats.io
-[nats-pub-proto]: https://nats.io/documentation/internals/nats-protocol/#PUB
-[nats-msg-proto]: https://nats.io/documentation/internals/nats-protocol/#MSG
+[nats-pub-proto]: https://docs.nats.io/reference/reference-protocols/nats-protocol#pub
+[nats-msg-proto]: https://docs.nats.io/reference/reference-protocols/nats-protocol#protocol-messages
 [json-value]: https://tools.ietf.org/html/rfc7159#section-3
 [rfc2046]: https://tools.ietf.org/html/rfc2046
 [rfc2119]: https://tools.ietf.org/html/rfc2119

--- a/cloudevents/bindings/websockets-protocol-binding.md
+++ b/cloudevents/bindings/websockets-protocol-binding.md
@@ -154,15 +154,17 @@ format specification and the resulting data becomes the payload.
 - [RFC2119][rfc2119] Key words for use in RFCs to Indicate Requirement Levels
 - [RFC6455][rfc6455] The WebSocket Protocol
 
-[ce]: ./spec.md
-[ce-message]: ./spec.md#message
-[ce-event-format]: ./spec.md#event-format
-[json-format]: ./formats/json-format.md
-[json-batch-format]: ./formats/json-format.md#4-json-batch-format
-[avro-format]: ./formats/avro-format.md
-[proto-format]: ./formats/protobuf-format.md
+[ce]: ../spec.md
+[ce-message]: ../spec.md#message
+[ce-event-format]: ../spec.md#event-format
+[json-format]: ../formats/json-format.md
+[json-batch-format]: ../formats/json-format.md#4-json-batch-format
+[avro-format]: ../formats/avro-format.md
+[proto-format]: ../formats/protobuf-format.md
 [rfc2119]: https://tools.ietf.org/html/rfc2119
 [rfc6455]: https://tools.ietf.org/html/rfc6455
 [rfc6455-section-1-3]: https://tools.ietf.org/html/rfc6455#section-1.3
 [rfc6455-section-4]: https://tools.ietf.org/html/rfc6455#section-4
 [rfc6455-section-1-9]: https://tools.ietf.org/html/rfc6455#section-1.9
+[rfc7230-section-5-1]: https://datatracker.ietf.org/doc/html/rfc7230#section-5.1
+[rfc6455-section-5-1]: https://datatracker.ietf.org/doc/html/rfc6455#section-5.1

--- a/cloudevents/formats/avro-format.md
+++ b/cloudevents/formats/avro-format.md
@@ -177,7 +177,7 @@ The following table shows exemplary mappings:
 [avro-primitives]: http://avro.apache.org/docs/1.9.0/spec.html#schema_primitive
 [avro-logical-types]: http://avro.apache.org/docs/1.9.0/spec.html#Logical+Types
 [avro-unions]: http://avro.apache.org/docs/1.9.0/spec.html#Unions
-[ce]: ./spec.md
+[ce]: ../spec.md
 [rfc2119]: https://tools.ietf.org/html/rfc2119
 [rfc3986-section41]: https://tools.ietf.org/html/rfc3986#section-4.1
 [rfc3986-section43]: https://tools.ietf.org/html/rfc3986#section-4.3

--- a/cloudevents/formats/json-format.md
+++ b/cloudevents/formats/json-format.md
@@ -433,12 +433,12 @@ also valid in a request):
   Format
 
 [base64]: https://tools.ietf.org/html/rfc4648#section-4
-[ce]: ./spec.md
-[ce-types]: ./spec.md#type-system
+[ce]: ../spec.md
+[ce-types]: ../spec.md#type-system
 [content-type]: https://tools.ietf.org/html/rfc7231#section-3.1.1.5
-[datacontenttype]: ./spec.md#datacontenttype
+[datacontenttype]: ../spec.md#datacontenttype
 [http-binary]: ../bindings/http-protocol-binding.md#31-binary-content-mode
-[json-format]: ./formats/json-format.md
+[json-format]: ../formats/json-format.md
 [json-geoseq]:https://www.iana.org/assignments/media-types/application/geo+json-seq
 [json-object]: https://tools.ietf.org/html/rfc7159#section-4
 [json-seq]: https://www.iana.org/assignments/media-types/application/json-seq

--- a/cloudevents/formats/protobuf-format.md
+++ b/cloudevents/formats/protobuf-format.md
@@ -240,15 +240,15 @@ private static Spec.CloudEvent protoExample() {
 * [Protocol Buffer 3 Specification][proto-3]
 * [CloudEvents Protocol Buffers format schema][proto-schema]
 
-[Proto-3]: https://developers.google.com/protocol-buffers/docs/reference/proto3-spec
+[proto-3]: https://developers.google.com/protocol-buffers/docs/reference/proto3-spec
 [proto-home]: https://developers.google.com/protocol-buffers
 [proto-scalars]: https://developers.google.com/protocol-buffers/docs/proto3#scalar
 [proto-wellknown]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf
 [proto-timestamp]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
 [proto-schema]: ./cloudevents.proto
 [json-format]: ./json-format.md
-[ce]: ./spec.md
-[ce-types]: ./spec.md#type-system
+[ce]: ../spec.md
+[ce-types]: ../spec.md#type-system
 [rfc2119]: https://tools.ietf.org/html/rfc2119
 [rfc3986-section41]: https://tools.ietf.org/html/rfc3986#section-4.1
 [rfc3986-section43]: https://tools.ietf.org/html/rfc3986#section-4.3

--- a/cloudevents/primer.md
+++ b/cloudevents/primer.md
@@ -1,5 +1,7 @@
 # CloudEvents Primer - Version 1.0.2-wip
 
+<!-- no verify-specs -->
+
 ## Abstract
 
 This non-normative document provides an overview of the CloudEvents

--- a/cloudevents/proprietary-specs.md
+++ b/cloudevents/proprietary-specs.md
@@ -1,5 +1,7 @@
 # CloudEvent Specs for Proprietary Protocols and Encodings
 
+<!-- no verify-specs -->
+
 Disclaimer: CloudEvents does not endorse these protocols or specs, and does not
 ensure that they are up to date with the current version of CloudEvents. That is
 the responsibility of the respective project maintainers.

--- a/cloudevents/translated/zh-cn/README_CN.md
+++ b/cloudevents/translated/zh-cn/README_CN.md
@@ -1,5 +1,7 @@
 # CloudEvents 中文规范
 
+<!-- no verify-specs -->
+
 ![CloudEvents logo](https://github.com/cncf/artwork/blob/master/projects/cloudevents/horizontal/color/cloudevents-horizontal-color.png)
 
 ## Purpose/规范目的

--- a/community/CONTRIBUTING.md
+++ b/community/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to CloudEvents
 
+<!-- no verify-specs -->
+
 This page contains information about reporting issues, how to suggest changes as
 well as the guidelines we follow for how our documents are formatted.
 

--- a/community/GOVERNANCE.md
+++ b/community/GOVERNANCE.md
@@ -1,5 +1,7 @@
 # Governance
 
+<!-- no verify-specs -->
+
 This document describes the governance process under which the CloudEvents
 project will manage this repository.
 

--- a/community/SDK-GOVERNANCE.md
+++ b/community/SDK-GOVERNANCE.md
@@ -1,5 +1,7 @@
 ## SDK Community
 
+<!-- no verify-specs -->
+
 The community is organized as follows:
 
 - Every SDK has its own

--- a/community/SDK-PR-guidelines.md
+++ b/community/SDK-PR-guidelines.md
@@ -1,5 +1,7 @@
 # Pull Request Guidelines
 
+<!-- no verify-specs -->
+
 Here you will find step by step guidance for creating, submitting and updating
 a pull request for an SDK repository. We hope it will help you have an easy time
 managing your work and a positive, satisfying experience when contributing

--- a/community/SDK-maintainer-guidelines.md
+++ b/community/SDK-maintainer-guidelines.md
@@ -1,5 +1,7 @@
 # SDK Maintainer's Guide
 
+<!-- no verify-specs -->
+
 This guide is meant to provide SDK maintainers with some recommended common
 practices. New and existing SDK maintainers are encouraged to copy this file
 to their repositories and adopt these guidelines so that contributors may

--- a/community/demos.md
+++ b/community/demos.md
@@ -1,3 +1,5 @@
+<!-- no verify-specs -->
+
 If you have a demo of CloudEvents in action, please add a link here. If there
 isn't an associated blog or github repo, feel free to add descriptive text as a
 markdown file in `community/demos/`.

--- a/discovery/primer.md
+++ b/discovery/primer.md
@@ -1,5 +1,7 @@
 # Discovery and Subscription Primer - WIP
 
+<!-- no verify-specs -->
+
 ## Abstract
 
 This non-normative document provides an overview of the Discovery and

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -5,22 +5,6 @@ verify:
 	@# Use "-x" if you want to skip external links
 	@misc/tools/verify-links.sh -t -v .
 	@echo Running the spec phrase checker:
-	@misc/tools/verify-specs.sh -v \
-		cloudevents/bindings/amqp-protocol-binding.md \
-		cloudevents/formats/avro-format.md \
-		cloudevents/documented-extensions.md \
-		cloudevents/bindings/http-protocol-binding.md \
-		cloudevents/http-webhook.md \
-		cloudevents/formats/json-format.md \
-		cloudevents/bindings/kafka-protocol-binding.md \
-		cloudevents/bindings/mqtt-protocol-binding.md \
-		cloudevents/bindings/nats-protocol-binding.md \
-		cloudevents/formats/protobuf-format.md \
-		cloudevents/spec.md \
-		cloudevents/bindings/websockets-protocol-binding.md \
-		\
-		discovery/spec.md \
-		pagination/spec.md \
-		subscriptions/spec.md 
+	@misc/tools/verify-specs.sh -v .
 	@echo Running the doc phrase checker:
 	@misc/tools/verify-docs.sh -v .

--- a/misc/roadmap.md
+++ b/misc/roadmap.md
@@ -1,5 +1,7 @@
 ## Roadmap
 
+<!-- no verify-specs -->
+
 The CloudEvents Roadmap.
 
 _Note: The ordered lists for each milestone provide a way to reference each

--- a/schemaregistry/spec.md
+++ b/schemaregistry/spec.md
@@ -26,7 +26,7 @@ deserialize the event or message payload need access to the schema used to
 publish it.
 
 For formats that do not depend on external schemas for serialization, schemas
-might still be required in some scenarios to allow for consumers or inspecting
+might still be needed in some scenarios to allow for consumers or inspecting
 intermediaries to validate the data structure's compliance with a set of rules.
 
 This specification defines a very simple API focused on storing, organizing, and
@@ -63,7 +63,7 @@ subject matter context.
 Implementations of this specification MAY associate access control rules with
 schema groups. For instance, a user or a group of users might be given write
 access only to a particular schema group that their organization owns. If trade
-secret protection is required for an application or parts of it and the schema
+secret protection is needed for an application or parts of it and the schema
 structure would give some of those away, read access to a group of schemas might
 likewise be restricted.
 
@@ -317,7 +317,7 @@ document or binary stream. An implementation SHOULD validate whether a
 schema version is valid according to the rules of its format, for instance
 whether it is a valid Avro schema document when the format is Apache Avro.
 
-The schema version MAY also have an additional, optional unique identifier
+The schema version MAY also have an additional, OPTIONAL unique identifier
 within the scope of the registry.
 
 #### `version` (schema version)
@@ -382,7 +382,7 @@ This section is therefore non-normative.
 ### 3.1. Path hierarchy
 
 Schema groups contain schemas and those contain schema versions, which are the
-documents required for serialization or validation.
+documents needed for serialization or validation.
 
 These dependencies are reflected in the path structure:
 
@@ -505,11 +505,11 @@ Each schema version has a URI as a unique identifier, as defined in
 schema registry that holds a copy of that schema version.
 
 As discussed in 2.2.2, the URI might not be network resolvable or the network
-location may not be reachable from everywhere. That is a key motivation for
+location might not be reachable from everywhere. That is a key motivation for
 replication.
 
 The operation to obtain a schema version is a GET on `/schema?uri={uri}`, with
-the required parameter being the schema version URI.
+the REQUIRED parameter being the schema version URI.
 
 The returned payload is the schema document. Further attributes such as the
 `description` and the `format` indicator are returned as HTTP headers.
@@ -539,7 +539,7 @@ between these distinct registries, parallel to the event flow.
 
 For the discussion in this section, we will use the term "source" for a registry
 from which schemas originate and "target" for a registry into which those
-schemas shall be added.
+schemas will be added.
 
 The synchronization is accomplished by a combination of two mechanisms:
 


### PR DESCRIPTION
- Add support for href checking bookmarks & fixed bad links
- Speed up the checkers.
- Change Makefile so that it checks ALL files w/o needed to state which ones. So, now we have a flag in each md file that we DON'T want checked instead. We were missing some files. Look for the `<!-- no verify-specs -->`  line
- fixed some RFC keywords that were not checked before

Signed-off-by: Doug Davis <dug@us.ibm.com>