### PR TITLE
Add C# namespace option to proto

### DIFF
--- a/cloudevents/formats/cloudevents.proto
+++ b/cloudevents/formats/cloudevents.proto
@@ -13,6 +13,7 @@ package io.cloudevents.v1;
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
+option csharp_namespace = "CloudNative.CloudEvents.V1";
 option go_package = "cloudevents.io/genproto/v1";
 option java_package = "io.cloudevents.v1.proto";
 option java_multiple_files = true;


### PR DESCRIPTION
The naming choice is based on the C# SDK core being
"CloudNative.CloudEvents". This creates a bias towards using the C#
SDK instead of "roll-your-own" - but I think that's okay,
personally. Happy to consider other options.

## Proposed Changes

- Add a C# namespace option to cloudevents.proto

**Release Note**

```release-note
Adds a C# namespace option of `CloudNative.CloudEvents.V1` to the proto representation.
```
