### PR TITLE
Sync with v1.0.2

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,20 @@
+Fixes #
+
+<!-- Please include the 'why' behind your changes if no issue exists -->
+
+## Proposed Changes
+
+-
+-
+-
+
+**Release Note**
+
+<!--
+If this change has user-visible impact, write a release note in the block
+below. If this change has no user-visible impact, no release note is needed.
+-->
+
+```release-note
+
+```

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -1,0 +1,91 @@
+# Copyright 2021 The CloudEvents Authors.
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Release Notes'
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch? (master)'
+        required: true
+        default: 'master'
+      start-sha:
+        description: 'Starting SHA? (last tag on branch)'
+      end-sha:
+        description: 'Ending SHA? (latest HEAD)'
+
+jobs:
+  release-notes:
+    name: Release Notes
+    runs-on: 'ubuntu-latest'
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+
+      - name: Install Dependencies
+        run: GO111MODULE=on go get k8s.io/release/cmd/release-notes
+
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Note: Defaults needs to run after we check out the repo.
+      - name: Defaults
+        run: |
+          echo ORG=$(echo '${{ github.repository }}' | awk -F '/' '{print $1}') >> $GITHUB_ENV
+          echo REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}') >> $GITHUB_ENV
+
+          echo "BRANCH=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+
+          if [[ "${{ github.event.inputs.start-sha }}" != "" ]]; then
+            echo "START_SHA=${{ github.event.inputs.start-sha }}" >> $GITHUB_ENV
+          else
+            # Default Starting SHA (thanks @dprotaso)
+            export semver=$(git describe --match "v[0-9]*" --abbrev=0)
+            echo "Using ${semver} tag for starting sha."
+            echo START_SHA=$(git rev-list -n 1 "${semver}") >> $GITHUB_ENV
+          fi
+
+          if [[ "${{ github.event.inputs.end-sha }}" != "" ]]; then
+            echo "END_SHA=${{ github.event.inputs.end-sha }}" >> $GITHUB_ENV
+          else
+            # Default Ending SHA (thanks @dprotaso)
+            echo "END_SHA=$(git rev-list -n 1 HEAD)" >> $GITHUB_ENV
+          fi
+
+      - name: Generate Notes
+        run: |
+          # See  https://github.com/kubernetes/release/tree/master/cmd/release-notes for options.
+          # Note: we are setting env vars in the Defaults step.
+          release-notes \
+            --required-author "" \
+            --repo-path       "$(pwd)" \
+            --output          release-notes.md
+
+      - name: Display Notes
+        run: |
+          cat release-notes.md
+
+      - name: Archive Release Notes
+        uses: actions/upload-artifact@v2
+        with:
+          name: release-notes.md
+          path: release-notes.md

--- a/README.md
+++ b/README.md
@@ -24,31 +24,34 @@ a Cloud Native sandbox level project on
 
 ## CloudEvents Documents
 
-The following documents are available:
+The following documents are available ([Release Notes](misc/RELEASE_NOTES.md)):
 
 |                               |                                 Latest Release                                  |                                      Working Draft                                       |
 | :---------------------------- | :-----------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------: |
 | **Core Specification:**       |
-| CloudEvents                   |          [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md)          |            [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md)             |
+| CloudEvents                   |          [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/spec.md)          |            [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md)             |
 |                               |
 | **Optional Specifications:**  |
-| AMQP Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/amqp-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/amqp-protocol-binding.md)    |
-| AVRO Event Format             |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/avro-format.md)       |         [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/avro-format.md)         |
-| HTTP Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md)    |
-| JSON Event Format             |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/json-format.md)       |         [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/json-format.md)         |
-| Kafka Protocol Binding        | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/kafka-protocol-binding.md) |   [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/kafka-protocol-binding.md)    |
-| MQTT Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/mqtt-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/mqtt-protocol-binding.md)    |
-| NATS Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/nats-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/nats-protocol-binding.md)    |
+| AMQP Protocol Binding         | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/amqp-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/amqp-protocol-binding.md)    |
+| AVRO Event Format             |      [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/avro-format.md)       |         [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/avro-format.md)         |
+| HTTP Protocol Binding         | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/http-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md)    |
+| JSON Event Format             |      [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/json-format.md)       |         [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/json-format.md)         |
+| Kafka Protocol Binding        | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/kafka-protocol-binding.md) |   [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/kafka-protocol-binding.md)    |
+| MQTT Protocol Binding         | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/mqtt-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/mqtt-protocol-binding.md)    |
+| NATS Protocol Binding         | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/nats-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/nats-protocol-binding.md)    |
 | WebSockets Protocol Binding   |                                        -                                        | [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/websockets-protocol-binding.md) |
 | Protobuf Event Format         |                                                                                 | [v1.0-rc1](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/protobuf-format.md)                                  |
-| Web hook                      |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-webhook.md)      |        [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md)         |
+| Web hook                      |      [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/http-webhook.md)      |        [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md)         |
 |                               |
 | **Additional Documentation:** |
 | CloudEvents Adapters          |                                        -                                        |          [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/adapters.md)           |
 | CloudEvents SDK Requirements  |                                        -                                        |             [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/SDK.md)             |
 | Documented Extensions         |                                        -                                        |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/documented-extensions.md)    |
-| Primer                        |         [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/primer.md)         |           [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/primer.md)            |
+| Primer                        |         [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/primer.md)         |           [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/primer.md)            |
 | Proprietary Specifications    |                                        -                                        |      [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/proprietary-specs.md)      |
+
+There might be additional work-in-progress specifications being developed
+in the [`main`](https://github.com/cloudevents/spec/tree/main) branch.
 
 If you are new to CloudEvents, it is recommended that you start by reading the
 [Primer](cloudevents/primer.md) for an overview of the specification's goals
@@ -90,8 +93,8 @@ native ecosystem by making our systems interoperable with CloudEvents.
 ## Process
 
 The CloudEvents project is working to formalize the
-[specification](cloudevents/spec.md)
-based on [design goals](cloudevents/primer.md#design-goals) which focus on
+[specification](cloudevents/spec.md) based on
+[design goals](cloudevents/primer.md#design-goals) which focus on
 interoperability between systems which generate and respond to events.
 
 In order to achieve these goals, the project must describe:

--- a/cesql/spec.md
+++ b/cesql/spec.md
@@ -5,10 +5,6 @@
 The goal of this specification is to define a SQL-like expression language which can be used to express predicates on
 CloudEvent instances.
 
-## Status of this document
-
-This document is a working draft.
-
 ## Table of Contents
 
 1. [Introduction](#1-introduction)

--- a/cloudevents/bindings/amqp-protocol-binding.md
+++ b/cloudevents/bindings/amqp-protocol-binding.md
@@ -1,13 +1,9 @@
-# AMQP Protocol Binding for CloudEvents - Version 1.0.2-wip
+# AMQP Protocol Binding for CloudEvents - Version 1.0.3-wip
 
 ## Abstract
 
 The AMQP Protocol Binding for CloudEvents defines how events are mapped to
 OASIS AMQP 1.0 ([OASIS][oasis-amqp-1.0]; ISO/IEC 19464:2014) messages.
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/bindings/http-protocol-binding.md
+++ b/cloudevents/bindings/http-protocol-binding.md
@@ -1,13 +1,9 @@
-# HTTP Protocol Binding for CloudEvents - Version 1.0.2-wip
+# HTTP Protocol Binding for CloudEvents - Version 1.0.3-wip
 
 ## Abstract
 
 The HTTP Protocol Binding for CloudEvents defines how events are mapped to HTTP
 1.1 request and response messages.
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/bindings/kafka-protocol-binding.md
+++ b/cloudevents/bindings/kafka-protocol-binding.md
@@ -1,13 +1,9 @@
-# Kafka Protocol Binding for CloudEvents - Version 1.0.2-wip
+# Kafka Protocol Binding for CloudEvents - Version 1.0.3-wip
 
 ## Abstract
 
 The [Kafka][kafka] Protocol Binding for CloudEvents defines how events are
 mapped to [Kafka messages][kafka-message-format].
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/bindings/mqtt-protocol-binding.md
+++ b/cloudevents/bindings/mqtt-protocol-binding.md
@@ -1,14 +1,10 @@
-# MQTT Protocol Binding for CloudEvents - Version 1.0.2-wip
+# MQTT Protocol Binding for CloudEvents - Version 1.0.3-wip
 
 ## Abstract
 
 The MQTT Protocol Binding for CloudEvents defines how events are mapped to MQTT
 3.1.1 ([OASIS][oasis-mqtt-3.1.1]; ISO/IEC 20922:2016) and MQTT 5.0
 ([OASIS][oasis-mqtt-5]) messages.
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/bindings/nats-protocol-binding.md
+++ b/cloudevents/bindings/nats-protocol-binding.md
@@ -1,13 +1,9 @@
-# NATS Protocol Binding for CloudEvents - Version 1.0.2-wip
+# NATS Protocol Binding for CloudEvents - Version 1.0.3-wip
 
 ## Abstract
 
 The [NATS][nats] Protocol Binding for CloudEvents defines how events are mapped
 to [NATS messages][nats-msg-proto].
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/bindings/websockets-protocol-binding.md
+++ b/cloudevents/bindings/websockets-protocol-binding.md
@@ -1,13 +1,9 @@
-# WebSockets Protocol Binding for CloudEvents - Version 1.0.2-wip
+# WebSockets Protocol Binding for CloudEvents - Version 1.0.3-wip
 
 ## Abstract
 
 The WebSockets Protocol Binding for CloudEvents defines how to establish and use
 full-duplex CloudEvents streams using [WebSockets][rfc6455].
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/formats/avro-format.md
+++ b/cloudevents/formats/avro-format.md
@@ -1,13 +1,9 @@
-# Avro Event Format for CloudEvents - Version 1.0.2-wip
+# Avro Event Format for CloudEvents - Version 1.0.3-wip
 
 ## Abstract
 
 The Avro Format for CloudEvents defines how events attributes are expressed in
 the [Avro 1.9.0 Specification][avro-spec].
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/formats/json-format.md
+++ b/cloudevents/formats/json-format.md
@@ -1,13 +1,9 @@
-# JSON Event Format for CloudEvents - Version 1.0.2-wip
+# JSON Event Format for CloudEvents - Version 1.0.3-wip
 
 ## Abstract
 
 The JSON Format for CloudEvents defines how events are expressed in JavaScript
 Object Notation (JSON) Data Interchange Format ([RFC8259][rfc8259]).
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/formats/protobuf-format.md
+++ b/cloudevents/formats/protobuf-format.md
@@ -1,4 +1,4 @@
-# Protobuf Event Format for CloudEvents - Version 1.0-rc1
+# Protobuf Event Format for CloudEvents - Version 1.0.3-wip
 
 ## Abstract
 
@@ -8,10 +8,6 @@ of that specification.
 
 In this document the terms *Protocol Buffers*, *protobuf*, and *proto* are used
 interchangeably.
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/http-webhook.md
+++ b/cloudevents/http-webhook.md
@@ -1,4 +1,4 @@
-# HTTP 1.1 Web Hooks for Event Delivery - Version 1.0.2-wip
+# HTTP 1.1 Web Hooks for Event Delivery - Version 1.0.3-wip
 
 ## Abstract
 
@@ -7,10 +7,6 @@ and via HTTP endpoints. In spite of pattern usage being widespread, there is no
 formal definition for Web Hooks. This specification aims to provide such a
 definition for use with [CNCF CloudEvents][ce], but is considered generally
 usable beyond the scope of CloudEvents.
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/primer.md
+++ b/cloudevents/primer.md
@@ -1,4 +1,4 @@
-# CloudEvents Primer - Version 1.0.2-wip
+# CloudEvents Primer - Version 1.0.3-wip
 
 <!-- no verify-specs -->
 
@@ -9,10 +9,6 @@ specification. It is meant to complement the CloudEvent specification to provide
 additional background and insight into the history and design decisions made
 during the development of the specification. This allows the specification
 itself to focus on the normative technical details.
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -1,13 +1,9 @@
-# CloudEvents - Version 1.0.2-wip
+# CloudEvents - Version 1.0.3-wip
 
 ## Abstract
 
 CloudEvents is a vendor-neutral specification for defining the format of event
 data.
-
-## Status of this document
-
-This document is a working draft.
 
 ## Table of Contents
 

--- a/cloudevents/translated/zh-cn/README_CN.md
+++ b/cloudevents/translated/zh-cn/README_CN.md
@@ -30,25 +30,25 @@ CloudEvents是一个以通用格式来描述事件数据的标准。它提供了
 |                               |                                 最新版本                                 |                                      工作草案                                      |
 | :---------------------------- | :-----------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------: |
 | **核心标准:**       |
-| CloudEvents                   |          [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md)          |            [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md)             |
+| CloudEvents                   |          [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/spec.md)          |            [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md)             |
 |                               |
 | **可选标准:**  |
-| AMQP Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/amqp-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/amqp-protocol-binding.md)    |
-| AVRO Event Format             |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/avro-format.md)       |         [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/avro-format.md)         |
-| HTTP Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md)    |
-| JSON Event Format             |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/json-format.md)       |         [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/json-format.md)         |
-| Kafka Protocol Binding        | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/kafka-protocol-binding.md) |   [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/kafka-protocol-binding.md)    |
-| MQTT Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/mqtt-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/mqtt-protocol-binding.md)    |
-| NATS Protocol Binding         | [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/nats-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/nats-protocol-binding.md)    |
+| AMQP Protocol Binding         | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/amqp-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/amqp-protocol-binding.md)    |
+| AVRO Event Format             |      [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/avro-format.md)       |         [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/avro-format.md)         |
+| HTTP Protocol Binding         | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/http-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md)    |
+| JSON Event Format             |      [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/json-format.md)       |         [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/json-format.md)         |
+| Kafka Protocol Binding        | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/kafka-protocol-binding.md) |   [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/kafka-protocol-binding.md)    |
+| MQTT Protocol Binding         | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/mqtt-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/mqtt-protocol-binding.md)    |
+| NATS Protocol Binding         | [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/nats-protocol-binding.md)  |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/nats-protocol-binding.md)    |
 | WebSockets Protocol Binding   |                                        -                                        | [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/websockets-protocol-binding.md) |
 | Protobuf Event Format         |                                                                                 | [v1.0-rc1](https://github.com/cloudevents/spec/blob/main/cloudevents/formats/protobuf-format.md)                                  |
-| Web hook                      |      [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/http-webhook.md)      |        [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md)         |
+| Web hook                      |      [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/http-webhook.md)      |        [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/http-webhook.md)         |
 |                               |
 | **附加文件:** |
 | CloudEvents Adapters          |                                        -                                        |          [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/adapters.md)           |
 | CloudEvents SDK Requirements  |                                        -                                        |             [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/SDK.md)             |
 | Documented Extensions         |                                        -                                        |    [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/documented-extensions.md)    |
-| Primer                        |         [v1.0.1](https://github.com/cloudevents/spec/blob/v1.0.1/primer.md)         |           [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/primer.md)            |
+| Primer                        |         [v1.0.2](https://github.com/cloudevents/spec/blob/v1.0.2/primer.md)         |           [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/primer.md)            |
 | Proprietary Specifications    |                                        -                                        |      [WIP](https://github.com/cloudevents/spec/blob/main/cloudevents/proprietary-specs.md)      |
 
 推荐先行阅读[入门文档](primer_CN.md)了解CloudEvents规范的目标和设计理念，再阅读[核心规范](spec_CN.md)。

--- a/discovery/primer.md
+++ b/discovery/primer.md
@@ -10,10 +10,6 @@ to provide additional background and insight into the history and design
 decisions made during their development. This allows the specification itself
 to focus on the normative technical details.
 
-## Status of this document
-
-This document is a working draft.
-
 ## Table of Contents
 
 - History

--- a/discovery/spec.md
+++ b/discovery/spec.md
@@ -6,11 +6,6 @@ CloudSubscriptions Discovery API is a vendor-neutral API specification for
 determining what events are available from a particular service, as well as how
 to subscribe to those events.
 
-## Status of this document
-
-This is a working draft. Breaking changes could be made in the next minor
-version.
-
 ## Table of Contents
 
 - [Overview](#overview)

--- a/misc/RELEASE_NOTES.md
+++ b/misc/RELEASE_NOTES.md
@@ -1,0 +1,91 @@
+# CloudEvents Release Notes
+
+## v1.0.2 - 2022/02/03
+
+- Add C# namespace option to proto - #937
+- Tweak SDK requirements wording - #915
+- Re-organized repo directory structure - #904/#905
+- Translate CE specs into Chinese - #899/#898
+- Explicitly state application/json defaulting when serializing - #881
+- Add PowerShell SDK to the list of SDKs - #875
+- WebHook "Origin" header concept clashes with RFC6454 - #870
+- Clarify data encoding in JSON format with a JSON datacontenttype - #861
+- Webhook-Allowed-Origin instead of Webhook-Request-Origin - #836
+- Clean-up of Sampled Rate Extension - #832
+- Remove the conflicting sentence in Kafka Binding - #823/#813
+- Fix the sentences conflict in Kafka Binding - #814
+- Clarify HTTP header value encoding and decoding requirements - #793
+- Expand versioning suggestions in Primer - #799
+- Add support for protobuf batch format - #801
+- Clarify HTTP header value encoding and decoding requirements - #816
+- Primer guidance for dealing with errors - #763
+- Information Classification Extension - #785
+- Clarify the role of partitioning extension in Kafka - #727
+
+## v1.0.1 - 2020/12/12
+- Add protobuf format as a sub-protocol - #721
+- Allow JSON values to be null, meaning unset - #713
+- [Primer] Adding a Non-Goal w.r.t Security - #712
+- WebSockets protocol binding - #697
+- Clarify difference between message mode and HTTP content mode - #672
+- add missing sdks to readme - #666
+- New sdk maintainers rules - #665
+- move sdk governance and cleanup - #663
+- Bring 'datadef' definition into line with specification - #658
+- Add CoC and move some governance docs into 'community' - #656
+- Add blog post around understanding Cloud Events interactions - #651
+- SDK governance draft - #649
+- docs: add common processes for SDK maintainers and contributors - #648
+- Adding Demo for Cloud Events Orchestration - #646
+- Clarified MUST requirement for JSON format - #644
+- Re-Introducing Protocol Buffer Representation - #626
+- Closes #615 - #616
+- Reworked Distributed Tracing Extension - #607
+- Minor updates to Cloud Events Primer - #600
+- Kafka clarifications - #599
+- Proprietary binding spec inclusion guide - #595
+- Adding link to Pub/Sub binding - #588
+- Add some clarity around SDK milestones - #584
+- How to determine binary CE vs random non-CE message - #577
+- Adding Visual Studio Code extension to community open-source doc - #573
+- Specify encoding of kafka header keys and values and message key - #572
+- Fix distributed tracing example - #569
+- Paragraph about nested events to the primer - #567
+- add rules for changing Admins- #564
+- Updating JSON Schema - #563
+- Say it's ok to ignore non-MUST recommendations - at your own risk - #562
+- Update Distributed Tracing extension spec links - #550
+- Add Ruby SDK to SDK lists - #548
+
+## v1.0.0 - 2019/10/24
+- Use "producer" and "consumer" instead of "sender" and "receiver"
+- Clarification that intermediaries should forward optional attributes
+- Remove constraint that attribute names must start with a letter
+- Remove suggestion that attributes names should be descriptive and terse
+- Clarify that a single occurrence may result in more than one event
+- Add an Event Data section (replacing `data`), making event data a top level
+  concept rather than an attribute
+- Introduce an Event Format section
+- Define structured-mode and binary-mode messages
+- Define protocol binding
+- Add extension attributes into "context attributes" description
+- Move mention of attribute serialization mechanism from "context attributes"
+  description into "type system"
+- Change "transport" to "protocol" universally
+- Introduce the Boolean, URI and URI-reference types for attributes
+- Remove the Any and Map types for attributes
+- Clarify which Unicode characters are permitted in String attributes
+- Require all context attribute values to be one of the listed types,
+  and state that they may be presented as native types or strings.
+- Require `source` to be non-empty; recommend an absolute URI
+- Update version number from 0.3 to 1.0
+- Clarify that `type` is related to "the originating occurrence"
+- Remove `datacontentencoding` section
+- Clarify handling of missing `datacontenttype` attribute
+- Rename `schemaurl` to `dataschema`, and change type from URI-reference to URI
+- Constrain `dataschema` to be non-empty (when present)
+- Add details of how `time` can be generated when it can't be determined,
+  specifically around consistency within a source
+- Add details of extension context attribute handling
+- Add recommendation that CloudEvent receivers pass on non-CloudEvent metadata
+- Sample CloudEvent no longer has a JSON object as a sample extension value

--- a/misc/roadmap.md
+++ b/misc/roadmap.md
@@ -87,6 +87,11 @@ _1.0.1_ - Completed - 2020/12/10
 1. See [V1.0.1 Release](https://github.com/cloudevents/spec/releases/tag/v1.0.1)
    for details.
 
+_1.0.2_ - Completed - 2022/02/03
+
+1. See [V1.0.2 Release](https://github.com/cloudevents/spec/releases/tag/v1.0.2)
+   for details.
+
 _Future_
 
 - All remaining issues and PRs will be examined.

--- a/schemaregistry/spec.md
+++ b/schemaregistry/spec.md
@@ -9,10 +9,6 @@ as Apache Avro and JSON Schema.
 It also defines a set of CloudEvent event type definitions and topology models
 for synchronizing schemas across different schema registries.
 
-## Status of this document
-
-This document is a working draft.
-
 ## 1. Introduction
 
 Schema-dependent serialization formats and related frameworks such as Apache

--- a/subscriptions/spec.md
+++ b/subscriptions/spec.md
@@ -8,10 +8,6 @@ producers on behalf of event sources. The software entity handling these
 subscriptions and responsible for distributing events is abstractly referred to
 as a "subscription manager".
 
-## Status of this document
-
-This document is a working draft.
-
 ## 1. Introduction
 
 A subscription manager responsible for a specific set of events can reside


### PR DESCRIPTION
- Sync with v1.0.2 - 'main' is missing a lot of admin files
- update refs from v1.0.1 to v1.0.2
- update titles from v1.0.2-wip to v1.0.3-wip

Signed-off-by: Doug Davis <dug@us.ibm.com>
