### PR TITLE
[Subscription] Remove exactly one attribute restriction for exact, prefix and suffix filters

### DIFF
--- a/subscriptions/spec.md
+++ b/subscriptions/spec.md
@@ -761,11 +761,10 @@ implementations MUST support:
 
 ###### `exact` filter dialect
 
-Use of this MUST include exactly one nested property, where the key is the
-name of the CloudEvents attribute to be matched, and its value is the String
-value to use in the comparison. To evaluate to true the value of the
-matching CloudEvents attribute MUST exactly match the value String specified
-(case sensitive).
+The keys are the names of the CloudEvents attributes to be matched,
+and their values are the String values to use in the comparison.
+To evaluate to true the values of the matching CloudEvents attributes MUST
+all exactly match with the associated value String specified (case sensitive).
 
 The attribute name and value specified in the filter express MUST NOT be
 empty strings.
@@ -773,16 +772,15 @@ empty strings.
 For example:
 
 ```json
-{ "exact": { "type": "com.github.push" } }
+{ "exact": { "type": "com.github.push", "subject": "https://github.com/cloudevents/spec" } }
 ```
 
 ###### `prefix` filter dialect
 
-Use of this MUST include exactly one nested property, where the key is the
-name of the CloudEvents attribute to be matched, and its value is the String
-value to use in the comparison. To evaluate to true the value of the
-matching CloudEvents attribute MUST start with the value String specified
-(case sensitive).
+The keys are the names of the CloudEvents attributes to be matched,
+and their values are the String values to use in the comparison.
+To evaluate to true the values of the matching CloudEvents attributes MUST
+all start with the associated value String specified (case sensitive).
 
 The attribute name and value specified in the filter express MUST NOT be
 empty strings.
@@ -790,16 +788,15 @@ empty strings.
 For example:
 
 ```json
-{ "prefix": { "type": "com.github." } }
+{ "prefix": { "type": "com.github.", "subject": "https://github.com/cloudevents" } }
 ```
 
 ###### `suffix` filter dialect
 
-Use of this MUST include exactly one nested property, where the key is the
-name of the CloudEvents attribute to be matched, and its value is the String
-value to use in the comparison. To evaluate to true the value of the
-matching CloudEvents attribute MUST end with the value String specified
-(case sensitive).
+The keys are the names of the CloudEvents attributes to be matched,
+and their values are the String values to use in the comparison.
+To evaluate to true the values of the matching CloudEvents attributes MUST
+all end with the associated value String specified (case sensitive).
 
 The attribute name and value specified in the filter express MUST NOT be
 empty strings.
@@ -807,7 +804,7 @@ empty strings.
 For example:
 
 ```json
-{ "suffix": { "type": ".created" } }
+{ "suffix": { "type": ".created", "subject": "/cloudevents/spec" } }
 ```
 
 ###### `all` filter dialect

--- a/subscriptions/subscriptions-openapi.yaml
+++ b/subscriptions/subscriptions-openapi.yaml
@@ -319,54 +319,33 @@ components:
     CloudEventsAttribute:
       type: object
       description: "CloudEvents defined attributes."
-      additionalProperties: false
-      oneOf:
-        - type: object
-          properties:
-            id:
-              type: string
-              description: Identifies the event.
-        - type: object
-          properties:
-            source:
-              type: string
-              description: Identifies the context in which an event happened.
-        - type: object
-          properties:
-            specversion:
-              type: string
-              description: The version of the CloudEvents specification which the event uses.
-        - type: object
-          properties:
-            type:
-              type: string
-              description: Describes the type of event related to the originating occurrence.
-        - type: object
-          properties:
-            datacontenttype:
-              type: string
-              description: Content type of the data value.
-        - type: object
-          properties:
-            dataschema:
-              type: string
-              description: Identifies the schema that data adheres to.
-        - type: object
-          properties:
-            subject:
-              type: string
-              description: Describes the subject of the event in the context of the event producer.
-        - type: object
-          properties:
-            time:
-              type: string
-              description: Timestamp of when the occurrence happened.
-        - $ref: "#/components/schemas/CloudEventAttributeExtenion"
-    CloudEventAttributeExtenion:
-      type: object
-      description: "CloudEvents defined attributes."
-      additionalProperties:
+      additionalProperties: # extension attributes
         type: string
+      properties:
+        id:
+          type: string
+          description: Identifies the event.
+        source:
+          type: string
+          description: Identifies the context in which an event happened.
+        specversion:
+          type: string
+          description: The version of the CloudEvents specification which the event uses.
+        type:
+          type: string
+          description: Describes the type of event related to the originating occurrence.
+        datacontenttype:
+          type: string
+          description: Content type of the data value.
+        dataschema:
+          type: string
+          description: Identifies the schema that data adheres to.
+        subject:
+          type: string
+          description: Describes the subject of the event in the context of the event producer.
+        time:
+          type: string
+          description: Timestamp of when the occurrence happened.
     ProtocolSettings:
       type: object
       additionalProperties: false


### PR DESCRIPTION
To improve the usage of the API in the common case, I'm removing
the restriction for `exact`, `prefix` and `suffix` filters of only
containing exactly one attribute.

When multiple attributes are specified, all attributes must match (
like in [1]), for example, these filters:

```yaml
filters:
  - suffix:
      type: "com.github.push"
  - suffix:
      subject: "https//github.com/cloudevents/spec"
```

can be written as:

```yaml
filters:
  - suffix:
      type: "com.github.push"
      subject: "https//github.com/cloudevents/spec"
```

[1]: https://github.com/cloudevents/spec/pull/803

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Remove exactly one attribute restriction for exact, prefix and suffix filters

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note
Remove exactly one attribute restriction for exact, prefix and suffix filters
```
