### PR TITLE
SDK should validate context attribute values

### DIFF
--- a/cloudevents/SDK.md
+++ b/cloudevents/SDK.md
@@ -131,6 +131,9 @@ Validation MUST be possible on an individual Event. Validation MUST take into
 account the spec version, and all the requirements put in-place by the spec at
 each version.
 
+SDKs SHOULD perform validation on context attribute values provided to it by
+the SDK user. This will help ensure that only valid CloudEvents are generated.
+
 ## Documentation
 
 Each SDK must provide examples using at least HTTP transport of:


### PR DESCRIPTION
Per a chat we had in a previous SDK call, the SDK SHOULD validate attributes
so users can be notified if they gave an invalid value.

Signed-off-by: Doug Davis <duglin@gmail.com>
