### PR TITLE
Skip problematic file during link check

### DIFF
--- a/cloudevents/formats/json-format.md
+++ b/cloudevents/formats/json-format.md
@@ -141,7 +141,7 @@ MUST be represented as a [JSON string][json-string] expression containing the
 store it inside the JSON representation. If present, the `datacontenttype` MUST
 reflect the format of the original binary data. If a `datacontenttype` value is
 not provided, no assumptions can be made as to the format of the data and
-therefore the `datacontenttype` attribute MUST not be present in the resulting
+therefore the `datacontenttype` attribute MUST NOT be present in the resulting
 CloudEvent.
 
 If the type of data is not `Binary`, the implementation will next determine

--- a/community/contributors.md
+++ b/community/contributors.md
@@ -1,5 +1,7 @@
 ## CloudEvents contributors
 
+<!-- no verify-links -->
+
 We welcome you to join us! This list acknowledges those who contribute whether
 it be via GitHub pull request or in real life in the project, as well as those
 who contributed before this became a CNCF project. If you are participating in

--- a/misc/tools/verify-links.sh
+++ b/misc/tools/verify-links.sh
@@ -149,6 +149,10 @@ for file in ${mdFiles}; do
 
   [[ -n "$verbose" ]] && echo "> $file"
 
+  if grep -i "<!-- *no verify-links" $file > /dev/null 2>&1 ; then
+    continue
+  fi
+
   # Replace ) with )\n so that each possible href is on its own line.
   # Then only grab lines that have [..](..) in them - put results in tmp file.
   # If the file doesn't have any lines with [..](..) then skip this file


### PR DESCRIPTION
I think github thinks we're ddos-ing it with all of these GETs so let's just
skip the file since it's not that important anyway.

Signed-off-by: Doug Davis <duglin@gmail.com>