### PR TITLE
Add some reasoning to why we limit things.

### DIFF
--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -170,9 +170,11 @@ the available character set of all attributes such that case-sensitivity issues
 or clashes with the permissible character set for identifiers in common
 languages are prevented.
 
-CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or
-digits ('0' to '9') from the ASCII character set. Attribute names SHOULD be
-descriptive and terse and SHOULD NOT exceed 20 characters in length.
+In order to maximize the likelihood of interoperability and portability across
+transport protocols and messaging formats, CloudEvents attribute names MUST
+consist of lower-case letters ('a' to 'z') or digits ('0' to '9') from the
+ASCII character set. Attribute names SHOULD be descriptive and terse and SHOULD
+NOT exceed 20 characters in length.
 
 CloudEvent attributes MUST NOT have the name `data`; this name is reserved as it
 is used in some event formats.


### PR DESCRIPTION
Fixes #955

Signed-off-by: Doug Davis <duglin@gmail.com>

**Release Note**

```release-note
Add some text to explain why we're so restrictive on attribute names
```
