### PR TITLE
Make it clear each CE attribute is a singleton

### DIFF
--- a/cloudevents/bindings/kafka-protocol-binding.md
+++ b/cloudevents/bindings/kafka-protocol-binding.md
@@ -185,7 +185,7 @@ message.
 #### 3.2.3. Metadata Headers
 
 All [CloudEvents][ce] attributes and
-[CloudEvent Attributes Extensions](../primer.md#cloudevent-attribute-extensions)
+[CloudEvent Attributes Extensions](../primer.md#cloudevent-extension-attributes)
 with exception of `data` MUST be individually mapped to and from the Header
 fields in the Kafka message. Both header keys and header values MUST be encoded
 as UTF-8 strings.

--- a/cloudevents/primer.md
+++ b/cloudevents/primer.md
@@ -18,7 +18,7 @@ itself to focus on the normative technical details.
 - [Architecture](#architecture)
 - [Versioning of CloudEvents](#versioning-of-cloudevents)
 - [CloudEvent Attributes](#cloudevent-attributes)
-- [CloudEvent Attribute Extensions](#cloudevent-attribute-extensions)
+- [CloudEvent Extension Attributes](#cloudevent-extension-attributes)
 - [Creating CloudEvents](#creating-cloudevents)
 - [Qualifying Protocols and Encodings](#qualifying-protocols-and-encodings)
 - [Proprietary Protocols and Encodings](#proprietary-protocols-and-encodings)
@@ -192,12 +192,12 @@ Confidentiality, as the current intention behind this spec is not to define
 Security principles with regards to CloudEvents. Every implementor has a
 different principle for enhancing their security model. We leave it up to the
 implementor of the spec to provide additional details for hardening their
-security model as an extension field, which can be furthermore interpreted by
-the components implemented by the implementor of the specification themselves.
-However, if the community observes a pattern in usage of certain extension
-fields, as a standard way to deal with the topic of data integrity. In that
-case, such extension fields can be declared as official extension to the
-CloudEvent specification.
+security model as an extension attribute, which can be furthermore interpreted
+by the components implemented by the implementor of the specification
+themselves. However, if the community observes a pattern in usage of certain
+extension attributes, as a standard way to deal with the topic of data
+integrity. In that case, such extension attributes can be declared as official
+extensions to the CloudEvent specification.
 
 ## Architecture
 
@@ -348,7 +348,7 @@ context, for the purposes of this CloudEvent attribute those meanings are not
 relevant and therefore using `id` for some other purpose beyond uniqueness
 checking is out of scope of the specification and not recommended.
 
-## CloudEvent Attribute Extensions
+## CloudEvent Extension Attributes
 
 In order to achieve the stated goals, the specification authors will attempt to
 constrain the number of metadata attributes they define in CloudEvents. To that
@@ -612,8 +612,8 @@ single application context can always take on multiple roles concurrently,
 including being both a producer and a consumer of events.
 
 1. Applications produce events for consumption by other parties. Examples of
-   this include: providing consumers with insights about end-user activities, state
-   changes or environment observations, or for allowing complementing the
+   this include: providing consumers with insights about end-user activities,
+   state changes or environment observations, or for allowing complementing the
    application's capabilities with event-driven extensions.
 
    Events are typically produced related to a context or a producer-chosen

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -153,7 +153,9 @@ together into a transport envelope body.
 
 Every CloudEvent conforming to this specification MUST include context
 attributes designated as REQUIRED, MAY include one or more OPTIONAL context
-attributes and MAY include one or more extension attributes.
+attributes and MAY include one or more
+[extension context attributes](#extension-context-attributes). Each
+context attribute MUST only appear at most once in a CloudEvent.
 
 These attributes, while descriptive of the event, are designed such that they
 can be serialized independent of the event data. This allows for them to be
@@ -451,7 +453,7 @@ messages if the copied values differ from the cloud-event serialized values.
 #### Defining Extensions
 
 See
-[CloudEvent Attributes Extensions](primer.md#cloudevent-attribute-extensions)
+[CloudEvent Attributes Extensions](primer.md#cloudevent-extension-attributes)
 for additional information concerning the use and definition of extensions.
 
 The definition of an extension SHOULD fully define all aspects of the


### PR DESCRIPTION
Per [this chat](https://github.com/cloudevents/spec/pull/972/files#r829061428), we should be very clear that each CE attribute can only appear at most once in an Event. While this introduces a MUST, it doesn't change the semantics of our intent and therefore could be seen as a clarification (or bug to not have had this in the past).

Signed-off-by: Doug Davis <dug@microsoft.com>

**Release Note**

```release-note
Make it clear each CE attribute can only appear at most once per event
```

/cc @jskeet 
