### PR TITLE
Remove hardcoded reference to JSON since we have Avro now

### DIFF
--- a/cloudevents/bindings/kafka-protocol-binding.md
+++ b/cloudevents/bindings/kafka-protocol-binding.md
@@ -84,8 +84,8 @@ message's [header section][kafka-message-header].
 
 Implementations that use Kafka 0.11.0.0 and above MAY use either _binary_ or
 _structured_ modes. Implementations that use Kafka 0.10.x.x and below MUST only
-use _structured_ mode and encode the event in JSON. This is because older
-versions of Kafka lacked support for message level headers.
+use _structured_ mode. This is because older versions of Kafka lacked
+support for message level headers.
 
 ### 1.4. Event Formats
 


### PR DESCRIPTION
Fixes #591

Signed-off-by: Doug Davis <dug@microsoft.com>

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note
Allow for non-JSON formats (e.g. Avro) with older version of Kafka
```
