### PR TITLE
adapter: add aws-sns-adapter

### DIFF
--- a/cloudevents/adapters/aws-sns.md
+++ b/cloudevents/adapters/aws-sns.md
@@ -1,10 +1,9 @@
 # Amazon Simple Notification Service CloudEvents Adapter
 
-This document describes how to convert
-[AWS SNS messages][sns-messages]
-into CloudEvents.
+This document describes how to convert [AWS SNS messages][sns-messages] into CloudEvents.
 
-Amazon SNS MAY send a subscription confirmation, notification, or unsubscribe confirmation message to your HTTP/HTTPS endpoints.
+Amazon SNS MAY send a subscription confirmation, notification, or unsubscribe confirmation 
+message to your HTTP/HTTPS endpoints.
 
 Each section below describes how to determine the CloudEvents attributes
 based on the specified type of SNS messages.

--- a/cloudevents/adapters/aws-sns.md
+++ b/cloudevents/adapters/aws-sns.md
@@ -16,7 +16,7 @@ based on the specified type of SNS messages.
 | `id`                  | "x-amz-sns-message-id" value |
 | `source`              | "x-amz-sns-topic-arn" value |
 | `specversion`         | `1.0`                                           |
-| `type`                | "x-amz-sns-message-type" value    |
+| `type`                | `com.amazonaws.sns.` + "x-amz-sns-message-type" value    |
 | `datacontenttype`     | `application/json`         |
 | `dataschema`          | Omit                                            |
 | `subject`             | Omit                        |
@@ -30,7 +30,7 @@ based on the specified type of SNS messages.
 | `id`                  | "x-amz-sns-message-id" value |
 | `source`              | "x-amz-sns-subscription-arn" value |
 | `specversion`         | `1.0`                                           |
-| `type`                | "x-amz-sns-message-type" value    |
+| `type`                | `com.amazonaws.sns.` + "x-amz-sns-message-type" value    |
 | `datacontenttype`     | `application/json`         |
 | `dataschema`          | Omit                                            |
 | `subject`             | "Subject" value (if present)                    |
@@ -44,7 +44,7 @@ based on the specified type of SNS messages.
 | `id`                  | "x-amz-sns-message-id" value |
 | `source`              | "x-amz-sns-subscription-arn" value |
 | `specversion`         | `1.0`                                           |
-| `type`                | "x-amz-sns-message-type" value    |
+| `type`                | `com.amazonaws.sns.` + "x-amz-sns-message-type" value    |
 | `datacontenttype`     | `application/json`         |
 | `dataschema`          | Omit                                            |
 | `subject`             | Omit                    |

--- a/cloudevents/adapters/aws-sns.md
+++ b/cloudevents/adapters/aws-sns.md
@@ -1,7 +1,7 @@
 # Amazon Simple Notification Service CloudEvents Adapter
 
 This document describes how to convert
-[AWS SQS messages][sns-messages]
+[AWS SNS messages][sns-messages]
 into CloudEvents.
 
 Amazon SNS MAY send a subscription confirmation, notification, or unsubscribe confirmation message to your HTTP/HTTPS endpoints.

--- a/cloudevents/adapters/aws-sns.md
+++ b/cloudevents/adapters/aws-sns.md
@@ -1,0 +1,54 @@
+# Amazon Simple Notification Service CloudEvents Adapter
+
+This document describes how to convert
+[AWS SQS messages][sns-messages]
+into CloudEvents.
+
+Amazon SNS MAY send a subscription confirmation, notification, or unsubscribe confirmation message to your HTTP/HTTPS endpoints.
+
+Each section below describes how to determine the CloudEvents attributes
+based on the specified type of SNS messages.
+
+### Subscription Confirmation
+
+| CloudEvents Attribute | Value                                           |
+| :-------------------- | :---------------------------------------------- |
+| `id`                  | "x-amz-sns-message-id" value |
+| `source`              | "x-amz-sns-topic-arn" value |
+| `specversion`         | `1.0`                                           |
+| `type`                | "x-amz-sns-message-type" value    |
+| `datacontenttype`     | `application/json`         |
+| `dataschema`          | Omit                                            |
+| `subject`             | Omit                        |
+| `time`                | "Timestamp" value                               |
+| `data`                | HTTP payload                                       |
+
+### Notification
+
+| CloudEvents Attribute | Value                                           |
+| :-------------------- | :---------------------------------------------- |
+| `id`                  | "x-amz-sns-message-id" value |
+| `source`              | "x-amz-sns-subscription-arn" value |
+| `specversion`         | `1.0`                                           |
+| `type`                | "x-amz-sns-message-type" value    |
+| `datacontenttype`     | `application/json`         |
+| `dataschema`          | Omit                                            |
+| `subject`             | "Subject" value (if present)                    |
+| `time`                | "Timestamp" value                               |
+| `data`                | HTTP payload                                       |
+
+### Unsubscribe Confirmation
+
+| CloudEvents Attribute | Value                                           |
+| :-------------------- | :---------------------------------------------- |
+| `id`                  | "x-amz-sns-message-id" value |
+| `source`              | "x-amz-sns-subscription-arn" value |
+| `specversion`         | `1.0`                                           |
+| `type`                | "x-amz-sns-message-type" value    |
+| `datacontenttype`     | `application/json`         |
+| `dataschema`          | Omit                                            |
+| `subject`             | Omit                    |
+| `time`                | "Timestamp" value                               |
+| `data`                | HTTP payload                                       |
+
+[sns-messages]: https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html


### PR DESCRIPTION
Recently, I need to convert SNS messages into CloudEvents. I thought this might be a common case for other folks.

So I propose this adapter to describe how to convert SNS messages into CloudEvents. 

All Suggestions are extremely welcome.

Signed-off-by: Jie Ding <jie.ding@linkall.com>

