### PR TITLE
fix: use SHOULD instead of needs

### DIFF
--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -49,10 +49,16 @@ For clarity, when a feature is marked as "OPTIONAL" this means that it is
 OPTIONAL for both the [Producer](#producer) and [Consumer](#consumer) of a
 message to support that feature. In other words, a producer can choose to
 include that feature in a message if it wants, and a consumer can choose to
-support that feature if it wants. A consumer that does not support that feature
-will then silently ignore that part of the message. The producer SHOULD be
+support that feature if it wants. A consumer that does not support that feature 
+is free to take any action it wishes, including no action or generating an error, as
+long as doing so does not violate other requirements defined by this specification.
+However, the RECOMMENDED action is to ignore it. The producer SHOULD be
 prepared for the situation where a consumer ignores that feature. An
 [Intermediary](#intermediary) SHOULD forward OPTIONAL attributes.
+
+```
+
+```
 
 ### Terminology
 

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -50,7 +50,7 @@ OPTIONAL for both the [Producer](#producer) and [Consumer](#consumer) of a
 message to support that feature. In other words, a producer can choose to
 include that feature in a message if it wants, and a consumer can choose to
 support that feature if it wants. A consumer that does not support that feature
-will then silently ignore that part of the message. The producer needs to be
+will then silently ignore that part of the message. The producer SHOULD be
 prepared for the situation where a consumer ignores that feature. An
 [Intermediary](#intermediary) SHOULD forward OPTIONAL attributes.
 

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -56,10 +56,6 @@ However, the RECOMMENDED action is to ignore it. The producer SHOULD be
 prepared for the situation where a consumer ignores that feature. An
 [Intermediary](#intermediary) SHOULD forward OPTIONAL attributes.
 
-```
-
-```
-
 ### Terminology
 
 This specification defines the following terms:


### PR DESCRIPTION
Fixes #1044

## Proposed Changes

- Change the word "needs" to "SHOULD" under the [Notational Conventions](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#notational-conventions) section in the CloudEvents spec to avoid ambiguity 

**Release Note**

```release-note
Change the word "needs" to "SHOULD" under the Notational Conventions section in the CloudEvents spec to avoid ambiguity 
```
