### PR TITLE
refactor(discovery): change metadata to attrschema

### DIFF
--- a/discovery/spec.md
+++ b/discovery/spec.md
@@ -446,7 +446,7 @@ Talk about how each has metadata and data
     "docs": "URL", ?
 
     "format": "STRING",
-    "metadata": {
+    "attrschema": {
         "attributes": {
             "ATTRIBUTE_NAME": {
                 "required": true|false,
@@ -457,8 +457,10 @@ Talk about how each has metadata and data
             }
         } *
     }, ?
-    "schema": { ... }, ?
-    "schemaurl": "URL", ?
+    "attrschemaurl": "URL", ?
+    
+    "dataschema": { ... }, ?
+    "dataschemaurl": "URL", ?
 
     "groups": [ GROUP-reference, ... ], ?
     "endpoints": [ ENDPOINT-reference, ... ] ?


### PR DESCRIPTION
In preparation for the `attrschema` extension I think these names are better for the field names in the discovery spec 