### PR TITLE
Clarify Primer around tracing correlation

### DIFF
--- a/cloudevents/primer.md
+++ b/cloudevents/primer.md
@@ -825,9 +825,10 @@ transited and allow for better introspection of the data.
 #### Event Tracing
 
 An event sent from a source may result in a sequence of additional events sent
-from various middleware devices such as event brokers and gateways. CloudEvents
-includes metadata in events to associate these events as being part of an event
-sequence for the purpose of event tracing and troubleshooting.
+from various middleware devices such as event brokers and gateways. A
+CloudEvents extension could be defined to include the metadata required to
+associate each individual CloudEvent with an event sequence, for the purpose of
+event tracing and troubleshooting.
 
 #### IoT
 


### PR DESCRIPTION
Clarify that CE doesn't define this correlation stuff, but it could be an extension.

Primer has this text:
- - -
"An event sent from a source may result in a sequence of additional events sent from various middleware devices such as event brokers and gateways. CloudEvents includes metadata in events to associate these events as being part of an event sequence for the purpose of event tracing and troubleshooting."
- - -
And someone on Slack asked "what metadata?"

Signed-off-by: Doug Davis <dug@microsoft.com>
