### PR TITLE
Support CDATA for textual data

### DIFF
--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -135,19 +135,35 @@ Example:
 
 ### 3.2 Text Data
 
-Text MUST be carried in an element with a defined type of `xs:string`.
-The element MUST NOT contain any child elements.
+Text MUST be carried in an element with a defined type of `xs:string`. The content
+of this element is either:
 
-Example:
+* Regular XML textual content, or
+* A CDATA section.
+
+Implementations MUST accept both textual representations.
+
+
+Examples:
 
 ``` xml
 <data xsi:type="xs:string">This is text</data>
 ```
 
+The following are equivalent representions of the string `if (X < Y) { .. }` :
+
+```xml
+<data xsi:type="xs:string">if X &lt; Y { .. }</data>
+```
+
+```xml
+<data xsi:type="xs:string"><![CDATA[if X < Y { .. }]]></data>
+```
+
 ### 3.3 XML Data
 
 XML data MUST be carried in an element with a defined type of `xs:any` with
-exactly one child XML element (with any mandatory namespace definitions).
+exactly one child XML element (including any mandatory namespace definitions).
 
 All XML nodes (including comments) within the child XML element MUST
 be preserved during processing.


### PR DESCRIPTION
Signed-off-by: Jem Day <Jem.Day@cliffhanger.com>

Fixes: #1013 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Update XML Format specification to include support for CDATA textual content.

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note
Allows for textual content in an XML Format to be carried in a CDATA section if preferred.

```
