### PR TITLE
Make it clear that datacontenttype MAY appear w/o data

### DIFF
--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -384,6 +384,9 @@ on the definition of OPTIONAL.
   different format or protocol binding, the target `datacontenttype` SHOULD be
   set explicitly to the implied `datacontenttype` of the source.
 
+  The `datacontenttype` attribute MAY appear even if there is no `data` value
+  present.
+
 - Constraints:
   - OPTIONAL
   - If present, MUST adhere to the format specified in


### PR DESCRIPTION
Fixes #1072

```release-note
Make it clear that `datacontenttype` MAY appear even when `data` is not present.
```
