### PR TITLE
Group/Resource/Format Details for Registry

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -1,3 +1,3 @@
-# Registry Service - Version 0.3-wip
+# Registry Service - Version 0.5-wip
 
 See the [Registry Service specification](spec.md).

--- a/registry/samples/contoso-crm.cereg
+++ b/registry/samples/contoso-crm.cereg
@@ -1,0 +1,692 @@
+{
+    "$schema": "https://cloudevents.io/schemas/registry",
+    "specversion": "0.5-wip",
+    "endpoints": {
+        "Contoso.CRM.Eventing.Http": {
+            "id": "Contoso.CRM.Eventing.Http",
+            "usage": "producer",
+            "config": {
+                "protocol": "HTTP",
+                "strict": false,
+                "endpoints": [
+                    "https://erpsystem.com/events"
+                ]
+            },
+            "definitionGroups": [
+                "#/definitionGroups/Contoso.CRM.Events"
+            ],
+            "format": "CloudEvents/1.0"
+        }
+    },
+    "definitionGroups": {
+        "Contoso.CRM.Events": {
+            "id": "Contoso.CRM.Events",
+            "definitions": {
+                "Contoso.CRM.Events.CustomerCreated": {
+                    "id": "Contoso.CRM.Events.CustomerCreated",
+                    "description": "An order has been placed",
+                    "format": "CloudEvents/1.0",
+                    "metadata": {
+                        "attributes": {
+                            "id": {
+                                "type": "string",
+                                "required": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "value": "Contoso.CRM.Events.CustomerCreated",
+                                "required": true
+                            },
+                            "time": {
+                                "type": "datetime",
+                                "required": true
+                            },
+                            "source": {
+                                "type": "uritemplate",
+                                "value": "/crm/customers",
+                                "required": true
+                            }
+                        }
+                    },
+                    "schemaurl": "#/schemaGroups/Contoso.CRM.Events/schemas/customerCreatedEventData"
+                },
+                "Contoso.CRM.Events.CustomerUpdated": {
+                    "id": "Contoso.CRM.Events.CustomerUpdated",
+                    "description": "An order has been placed",
+                    "format": "CloudEvents/1.0",
+                    "metadata": {
+                        "attributes": {
+                            "id": {
+                                "type": "string",
+                                "required": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "value": "Contoso.CRM.Events.CustomerUpdated",
+                                "required": true
+                            },
+                            "time": {
+                                "type": "datetime",
+                                "required": true
+                            },
+                            "source": {
+                                "type": "uritemplate",
+                                "value": "/crm/customers",
+                                "required": true
+                            }
+                        }
+                    },
+                    "schemaurl": "#/schemaGroups/Contoso.CRM.Events/schemas/customerUpdatedEventData"
+                },
+                "Contoso.CRM.Events.CustomerDeleted": {
+                    "id": "Contoso.CRM.Events.CustomerDeleted",
+                    "description": "A customer has been deleted",
+                    "format": "CloudEvents/1.0",
+                    "metadata": {
+                        "attributes": {
+                            "id": {
+                                "type": "string",
+                                "required": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "value": "Contoso.CRM.Events.CustomerDeleted",
+                                "required": true
+                            },
+                            "time": {
+                                "type": "datetime",
+                                "required": true
+                            },
+                            "source": {
+                                "type": "uritemplate",
+                                "value": "/crm/customers",
+                                "required": true
+                            }
+                        }
+                    },
+                    "schemaurl": "#/schemaGroups/Contoso.CRM.Events/schemas/customerDeletedEventData"
+                },
+                "Contoso.CRM.Events.CustomerStatusUpdated": {
+                    "id": "Contoso.CRM.Events.CustomerStatusUpdated",
+                    "description": "A customer's status has been updated",
+                    "format": "CloudEvents/1.0",
+                    "metadata": {
+                        "attributes": {
+                            "id": {
+                                "type": "string",
+                                "required": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "value": "Contoso.CRM.Events.CustomerStatusUpdated",
+                                "required": true
+                            },
+                            "time": {
+                                "type": "datetime",
+                                "required": true
+                            },
+                            "source": {
+                                "type": "uritemplate",
+                                "value": "/crm/customers",
+                                "required": true
+                            }
+                        }
+                    },
+                    "schemaurl": "#/schemaGroups/Contoso.CRM.Events/schemas/customerStatusUpdatedEventData"
+                },
+                "Contoso.CRM.Events.CustomerAddressUpdated": {
+                    "id": "Contoso.CRM.Events.CustomerAddressUpdated",
+                    "description": "A customer's address has been updated",
+                    "format": "CloudEvents/1.0",
+                    "metadata": {
+                        "attributes": {
+                            "id": {
+                                "type": "string",
+                                "required": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "value": "Contoso.CRM.Events.CustomerAddressUpdated",
+                                "required": true
+                            },
+                            "time": {
+                                "type": "datetime",
+                                "required": true
+                            },
+                            "source": {
+                                "type": "uritemplate",
+                                "value": "/crm/customers",
+                                "required": true
+                            }
+                        }
+                    },
+                    "schemaurl": "#/schemaGroups/Contoso.CRM.Events/schemas/customerAddressUpdatedEventData"
+                },
+                "Contoso.CRM.Events.CustomerContactUpdated": {
+                    "id": "Contoso.CRM.Events.CustomerContactUpdated",
+                    "description": "A customer's contact information has been updated",
+                    "format": "CloudEvents/1.0",
+                    "metadata": {
+                        "attributes": {
+                            "id": {
+                                "type": "string",
+                                "required": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "value": "Contoso.CRM.Events.CustomerContactUpdated",
+                                "required": true
+                            },
+                            "time": {
+                                "type": "datetime",
+                                "required": true
+                            },
+                            "source": {
+                                "type": "uritemplate",
+                                "value": "/crm/customers",
+                                "required": true
+                            }
+                        }
+                    },
+                    "schemaurl": "#/schemaGroups/Contoso.CRM.Events/schemas/customerContactUpdatedEventData"
+                },
+                "Contoso.CRM.Events.CustomerNoteAdded": {
+                    "id": "Contoso.CRM.Events.CustomerNoteAdded",
+                    "description": "A note has been added to a customer",
+                    "format": "CloudEvents/1.0",
+                    "metadata": {
+                        "attributes": {
+                            "id": {
+                                "type": "string",
+                                "required": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "value": "Contoso.CRM.Events.CustomerNoteAdded",
+                                "required": true
+                            },
+                            "time": {
+                                "type": "datetime",
+                                "required": true
+                            },
+                            "source": {
+                                "type": "uritemplate",
+                                "value": "/crm/customers",
+                                "required": true
+                            }
+                        }
+                    },
+                    "schemaurl": "#/schemaGroups/Contoso.CRM.Events/schemas/customerNoteAddedEventData"
+                },
+                "Contoso.CRM.Events.CustomerNoteDeleted": {
+                    "id": "Contoso.CRM.Events.CustomerNoteDeleted",
+                    "description": "A note has been deleted from a customer",
+                    "format": "CloudEvents/1.0",
+                    "metadata": {
+                        "attributes": {
+                            "id": {
+                                "type": "string",
+                                "required": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "value": "Contoso.CRM.Events.CustomerNoteDeleted",
+                                "required": true
+                            },
+                            "time": {
+                                "type": "datetime",
+                                "required": true
+                            },
+                            "source": {
+                                "type": "uritemplate",
+                                "value": "/crm/customers",
+                                "required": true
+                            }
+                        }
+                    },
+                    "schemaurl": "#/schemaGroups/Contoso.CRM.Events/schemas/customerNoteDeletedEventData"
+                },
+                "Contoso.CRM.Events.CustomerNoteUpdated": {
+                    "id": "Contoso.CRM.Events.CustomerNoteUpdated",
+                    "description": "A note has been updated on a customer",
+                    "format": "CloudEvents/1.0",
+                    "metadata": {
+                        "attributes": {
+                            "id": {
+                                "type": "string",
+                                "required": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "value": "Contoso.CRM.Events.CustomerNoteUpdated",
+                                "required": true
+                            },
+                            "time": {
+                                "type": "datetime",
+                                "required": true
+                            },
+                            "source": {
+                                "type": "uritemplate",
+                                "value": "/crm/customers",
+                                "required": true
+                            }
+                        }
+                    },
+                    "schemaurl": "#/schemaGroups/Contoso.CRM.Events/schemas/customerNoteUpdatedEventData"
+                },
+                "Contoso.CRM.Events.CustomerContactAdded": {
+                    "id": "Contoso.CRM.Events.CustomerContactAdded",
+                    "description": "A contact has been added to a customer",
+                    "format": "CloudEvents/1.0",
+                    "metadata": {
+                        "attributes": {
+                            "id": {
+                                "type": "string",
+                                "required": true,
+                                "description": "The unique identifier of the event"
+                            },
+                            "type": {
+                                "type": "string",
+                                "value": "Contoso.CRM.Events.CustomerContactAdded",
+                                "required": true,
+                                "description": "The type of the event"
+                            },
+                            "time": {
+                                "type": "datetime",
+                                "required": true,
+                                "description": "The time the event occurred"
+                            },
+                            "source": {
+                                "type": "uritemplate",
+                                "value": "/crm/customers",
+                                "required": true,
+                                "description": "The source of the event"
+                            },
+                            "subject": {
+                                "type": "string",
+                                "required": false,
+                                "description": "The subject of the event"
+                            }
+                        }
+                    },
+                    "schemaurl": "#/schemaGroups/Contoso.CRM.Events/schemas/customerContactAddedEventData"
+                }
+            }
+        }
+    },
+    "schemaGroups": {
+        "Contoso.CRM.Events": {
+            "id": "Contoso.CRM.Events",
+            "schemas": {
+                "customerAddressUpdatedEventData": {
+                    "format" : "JSONSchema/draft-07",
+                    "id": "customerAddressUpdatedEventData",
+                    "versions": {
+                        "1.0": {
+                            "type": "schemaversion",
+                            "id": "1.0",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "customerId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the customer"
+                                    },
+                                    "address": {
+                                        "type": "object",
+                                        "description": "The customer's address",
+                                        "properties": {
+                                            "street": {
+                                                "type": "string",
+                                                "description": "The customer's street"
+                                            },
+                                            "city": {
+                                                "type": "string",
+                                                "description": "The customer's city"
+                                            },
+                                            "state": {
+                                                "type": "string",
+                                                "description": "The customer's state"
+                                            },
+                                            "zip": {
+                                                "type": "string",
+                                                "description": "The customer's zip code"
+                                            }
+                                        },
+                                        "required": [
+                                            "street",
+                                            "city",
+                                            "state",
+                                            "zip"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "customerId",
+                                    "address"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "customerNoteAddedEventData": {
+                    "format" : "JSONSchema/draft-07",
+                    "id": "customerNoteAddedEventData",
+                    "versions": {
+                        "1.0": {
+                            "type": "schemaversion",
+                            "id": "1.0",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "customerId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the customer"
+                                    },
+                                    "note": {
+                                        "type": "object",
+                                        "description": "The note that was added to the customer",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "description": "The unique identifier of the note"
+                                            },
+                                            "text": {
+                                                "type": "string",
+                                                "description": "The text of the note"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "customerNoteDeletedEventData": {
+                    "format" : "JSONSchema/draft-07",
+                    "id": "customerNoteDeletedEventData",
+                    "versions": {
+                        "1.0": {
+                            "type": "schemaversion",
+                            "id": "1.0",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "customerId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the customer"
+                                    },
+                                    "noteId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the note that was deleted"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "customerNoteUpdatedEventData": {
+                    "format" : "JSONSchema/draft-07",
+                    "id": "customerNoteUpdatedEventData",
+                    "versions": {
+                        "1.0": {
+                            "type": "schemaversion",
+                            "id": "1.0",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "customerId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the customer"
+                                    },
+                                    "note": {
+                                        "type": "object",
+                                        "description": "The note that was updated on the customer",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "description": "The unique identifier of the note"
+                                            },
+                                            "text": {
+                                                "type": "string",
+                                                "description": "The text of the note"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "customerContactAddedEventData": {
+                    "format" : "JSONSchema/draft-07",
+                    "id" : "customerContactAddedEventData",
+                    "versions": {
+                        "1.0": {
+                            "type": "schemaversion",
+                            "id": "1.0",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "customerId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the customer"
+                                    },
+                                    "contact": {
+                                        "type": "object",
+                                        "description": "The contact that was added to the customer",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "description": "The unique identifier of the contact"
+                                            },
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the contact"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "customerContactDeletedEventData": {
+                    "format" : "JSONSchema/draft-07",
+                    "id" : "customerContactDeletedEventData",
+                    "versions": {
+                        "1.0": {
+                            "type": "schemaversion",
+                            "id": "1.0",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "customerId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the customer"
+                                    },
+                                    "contactId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the contact that was deleted"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "customerContactUpdatedEventData": {
+                    "format" : "JSONSchema/draft-07",
+                    "id" : "customerContactUpdatedEventData",
+                    "versions": {
+                        "1.0": {
+                            "type": "schemaversion",
+                            "id": "1.0",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "customerId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the customer"
+                                    },
+                                    "contact": {
+                                        "type": "object",
+                                        "description": "The contact that was updated on the customer",
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "description": "The unique identifier of the contact"
+                                            },
+                                            "name": {
+                                                "type": "string",
+                                                "description": "The name of the contact"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "customerCreatedEventData": {
+                    "format" : "JSONSchema/draft-07",
+                    "id" : "customerCreatedEventData",
+                    "versions": {
+                        "1.0": {
+                            "type": "schemaversion",
+                            "id": "1.0",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "customerId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the customer"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the customer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "customerStatusUpdatedEventData": {
+                    "format" : "JSONSchema/draft-07",
+                    "id" : "customerStatusUpdatedEventData",
+                    "versions": {
+                        "1.0": {
+                            "type": "schemaversion",
+                            "id": "1.0",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "customerId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the customer"
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "description": "The status of the customer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "customerDeletedEventData": {
+                    "format" : "JSONSchema/draft-07",
+                    "id" : "customerDeletedEventData",
+                    "versions": {
+                        "1.0": {
+                            "type": "schemaversion",
+                            "id": "1.0",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "customerId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the customer"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the customer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "customerUpdatedEventData": {
+                    "format" : "JSONSchema/draft-07",
+                    "id" : "customerUpdatedEventData",
+                    "versions": {
+                        "1.0": {
+                            "type": "schemaversion",
+                            "id": "1.0",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "customerId": {
+                                        "type": "string",
+                                        "description": "The unique identifier of the customer"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The name of the customer"
+                                    },
+                                    "address": {
+                                        "type": "object",
+                                        "description": "The address of the customer",
+                                        "properties": {
+                                            "street": {
+                                                "type": "string",
+                                                "description": "The street of the address"
+                                            },
+                                            "city": {
+                                                "type": "string",
+                                                "description": "The city of the address"
+                                            },
+                                            "state": {
+                                                "type": "string",
+                                                "description": "The state of the address"
+                                            },
+                                            "zip": {
+                                                "type": "string",
+                                                "description": "The zip code of the address"
+                                            }
+                                        },
+                                        "required": [
+                                            "street",
+                                            "city",
+                                            "state",
+                                            "zip"
+                                        ]
+                                    },
+                                    "phone": {
+                                        "type": "string",
+                                        "description": "The phone number of the customer"
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "description": "The email address of the customer"
+                                    },
+                                    "website": {
+                                        "type": "string",
+                                        "description": "The website of the customer"
+                                    }
+                                },
+                                "required": [
+                                    "customerId",
+                                    "name",
+                                    "phone",
+                                    "email",
+                                    "website"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/registry/samples/contoso-crm.cereg.yaml
+++ b/registry/samples/contoso-crm.cereg.yaml
@@ -1,0 +1,503 @@
+$schema: https://cloudevents.io/schemas/registry
+specversion: 0.5-wip
+endpoints:
+  Contoso.CRM.Eventing.Http:
+    id: Contoso.CRM.Eventing.Http
+    usage: producer
+    config:
+      protocol: HTTP
+      strict: false
+      endpoints:
+        - https://erpsystem.com/events
+    definitionGroups:
+      - "#/definitionGroups/Contoso.CRM.Events"
+    format: CloudEvents/1.0
+definitionGroups:
+  Contoso.CRM.Events:
+    id: Contoso.CRM.Events
+    type: definitiongroup
+    definitions:
+      Contoso.CRM.Events.CustomerCreated:
+        id: Contoso.CRM.Events.CustomerCreated
+        description: An order has been placed
+        format: CloudEvents/1.0
+        metadata:
+          attributes:
+            id:
+              type: string
+              required: true
+            type:
+              type: string
+              value: Contoso.CRM.Events.CustomerCreated
+              required: true
+            time:
+              type: datetime
+              required: true
+            source:
+              type: uritemplate
+              value: /crm/customers
+              required: true
+        schemaurl: "#/schemagroups/Contoso.CRM.Events/schemas/customerCreatedEventData"
+      Contoso.CRM.Events.CustomerUpdated:
+        id: Contoso.CRM.Events.CustomerUpdated
+        description: An order has been placed
+        format: CloudEvents/1.0
+        metadata:
+          attributes:
+            id:
+              type: string
+              required: true
+            type:
+              type: string
+              value: Contoso.CRM.Events.CustomerUpdated
+              required: true
+            time:
+              type: datetime
+              required: true
+            source:
+              type: uritemplate
+              value: /crm/customers
+              required: true
+        schemaurl: "#/schemagroups/Contoso.CRM.Events/schemas/customerUpdatedEventData"
+      Contoso.CRM.Events.CustomerDeleted:
+        id: Contoso.CRM.Events.CustomerDeleted
+        description: A customer has been deleted
+        format: CloudEvents/1.0
+        metadata:
+          attributes:
+            id:
+              type: string
+              required: true
+            type:
+              type: string
+              value: Contoso.CRM.Events.CustomerDeleted
+              required: true
+            time:
+              type: datetime
+              required: true
+            source:
+              type: uritemplate
+              value: /crm/customers
+              required: true
+        schemaurl: "#/schemagroups/Contoso.CRM.Events/schemas/customerDeletedEventData"
+      Contoso.CRM.Events.CustomerStatusUpdated:
+        id: Contoso.CRM.Events.CustomerStatusUpdated
+        description: A customer's status has been updated
+        format: CloudEvents/1.0
+        metadata:
+          attributes:
+            id:
+              type: string
+              required: true
+            type:
+              type: string
+              value: Contoso.CRM.Events.CustomerStatusUpdated
+              required: true
+            time:
+              type: datetime
+              required: true
+            source:
+              type: uritemplate
+              value: /crm/customers
+              required: true
+        schemaurl: "#/schemagroups/Contoso.CRM.Events/schemas/customerStatusUpdatedEventData"
+      Contoso.CRM.Events.CustomerAddressUpdated:
+        id: Contoso.CRM.Events.CustomerAddressUpdated
+        description: A customer's address has been updated
+        format: CloudEvents/1.0
+        metadata:
+          attributes:
+            id:
+              type: string
+              required: true
+            type:
+              type: string
+              value: Contoso.CRM.Events.CustomerAddressUpdated
+              required: true
+            time:
+              type: datetime
+              required: true
+            source:
+              type: uritemplate
+              value: /crm/customers
+              required: true
+        schemaurl: "#/schemagroups/Contoso.CRM.Events/schemas/customerAddressUpdatedEventData"
+      Contoso.CRM.Events.CustomerContactUpdated:
+        id: Contoso.CRM.Events.CustomerContactUpdated
+        description: A customer's contact information has been updated
+        format: CloudEvents/1.0
+        metadata:
+          attributes:
+            id:
+              type: string
+              required: true
+            type:
+              type: string
+              value: Contoso.CRM.Events.CustomerContactUpdated
+              required: true
+            time:
+              type: datetime
+              required: true
+            source:
+              type: uritemplate
+              value: /crm/customers
+              required: true
+        schemaurl: "#/schemagroups/Contoso.CRM.Events/schemas/customerContactUpdatedEventData"
+      Contoso.CRM.Events.CustomerNoteAdded:
+        id: Contoso.CRM.Events.CustomerNoteAdded
+        description: A note has been added to a customer
+        format: CloudEvents/1.0
+        metadata:
+          attributes:
+            id:
+              type: string
+              required: true
+            type:
+              type: string
+              value: Contoso.CRM.Events.CustomerNoteAdded
+              required: true
+            time:
+              type: datetime
+              required: true
+            source:
+              type: uritemplate
+              value: /crm/customers
+              required: true
+        schemaurl: "#/schemagroups/Contoso.CRM.Events/schemas/customerNoteAddedEventData"
+      Contoso.CRM.Events.CustomerNoteDeleted:
+        id: Contoso.CRM.Events.CustomerNoteDeleted
+        description: A note has been deleted from a customer
+        format: CloudEvents/1.0
+        metadata:
+          attributes:
+            id:
+              type: string
+              required: true
+            type:
+              type: string
+              value: Contoso.CRM.Events.CustomerNoteDeleted
+              required: true
+            time:
+              type: datetime
+              required: true
+            source:
+              type: uritemplate
+              value: /crm/customers
+              required: true
+        schemaurl: "#/schemagroups/Contoso.CRM.Events/schemas/customerNoteDeletedEventData"
+      Contoso.CRM.Events.CustomerNoteUpdated:
+        id: Contoso.CRM.Events.CustomerNoteUpdated
+        description: A note has been updated on a customer
+        format: CloudEvents/1.0
+        metadata:
+          attributes:
+            id:
+              type: string
+              required: true
+            type:
+              type: string
+              value: Contoso.CRM.Events.CustomerNoteUpdated
+              required: true
+            time:
+              type: datetime
+              required: true
+            source:
+              type: uritemplate
+              value: /crm/customers
+              required: true
+        schemaurl: "#/schemagroups/Contoso.CRM.Events/schemas/customerNoteUpdatedEventData"
+      Contoso.CRM.Events.CustomerContactAdded:
+        id: Contoso.CRM.Events.CustomerContactAdded
+        description: A contact has been added to a customer
+        format: CloudEvents/1.0
+        metadata:
+          attributes:
+            id:
+              type: string
+              required: true
+              description: The unique identifier of the event
+            type:
+              type: string
+              value: Contoso.CRM.Events.CustomerContactAdded
+              required: true
+              description: The type of the event
+            time:
+              type: datetime
+              required: true
+              description: The time the event occurred
+            source:
+              type: uritemplate
+              value: /crm/customers
+              required: true
+              description: The source of the event
+            subject:
+              type: string
+              required: false
+              description: The subject of the event
+        schemaurl: "#/schemagroups/Contoso.CRM.Events/schemas/customerContactAddedEventData"
+schemagroups:
+  Contoso.CRM.Events:
+    format: JSONSchema/draft-07
+    id: Contoso.CRM.Events
+    schemas:
+      customerAddressUpdatedEventData:
+        format: JSONSchema/draft-07
+        id: customerAddressUpdatedEventData
+        versions:
+          "1.0":
+            format: JSONSchema/draft-07version
+            id: "1.0"
+            schema:
+              type: object
+              properties:
+                customerId:
+                  type: string
+                  description: The unique identifier of the customer
+                address:
+                  type: object
+                  description: The customer's address
+                  properties:
+                    street:
+                      type: string
+                      description: The customer's street
+                    city:
+                      type: string
+                      description: The customer's city
+                    state:
+                      type: string
+                      description: The customer's state
+                    zip:
+                      type: string
+                      description: The customer's zip code
+                  required:
+                    - street
+                    - city
+                    - state
+                    - zip
+              required:
+                - customerId
+                - address
+      customerNoteAddedEventData:
+        format: JSONSchema/draft-07
+        id: customerNoteAddedEventData
+        versions:
+          "1.0":
+            format: JSONSchema/draft-07version
+            id: "1.0"
+            schema:
+              type: object
+              properties:
+                customerId:
+                  type: string
+                  description: The unique identifier of the customer
+                note:
+                  type: object
+                  description: The note that was added to the customer
+                  properties:
+                    id:
+                      type: string
+                      description: The unique identifier of the note
+                    text:
+                      type: string
+                      description: The text of the note
+      customerNoteDeletedEventData:
+        format: JSONSchema/draft-07
+        id: customerNoteDeletedEventData
+        versions:
+          "1.0":
+            format: JSONSchema/draft-07version
+            id: "1.0"
+            schema:
+              type: object
+              properties:
+                customerId:
+                  type: string
+                  description: The unique identifier of the customer
+                noteId:
+                  type: string
+                  description: The unique identifier of the note that was deleted
+      customerNoteUpdatedEventData:
+        format: JSONSchema/draft-07
+        id: customerNoteUpdatedEventData
+        versions:
+          "1.0":
+            format: JSONSchema/draft-07version
+            id: "1.0"
+            schema:
+              type: object
+              properties:
+                customerId:
+                  type: string
+                  description: The unique identifier of the customer
+                note:
+                  type: object
+                  description: The note that was updated on the customer
+                  properties:
+                    id:
+                      type: string
+                      description: The unique identifier of the note
+                    text:
+                      type: string
+                      description: The text of the note
+      customerContactAddedEventData:
+        format: JSONSchema/draft-07
+        id: customerContactAddedEventData
+        versions:
+          "1.0":
+            format: JSONSchema/draft-07version
+            id: "1.0"
+            schema:
+              type: object
+              properties:
+                customerId:
+                  type: string
+                  description: The unique identifier of the customer
+                contact:
+                  type: object
+                  description: The contact that was added to the customer
+                  properties:
+                    id:
+                      type: string
+                      description: The unique identifier of the contact
+                    name:
+                      type: string
+                      description: The name of the contact
+      customerContactDeletedEventData:
+        format: JSONSchema/draft-07
+        id: customerContactDeletedEventData
+        versions:
+          "1.0":
+            format: JSONSchema/draft-07version
+            id: "1.0"
+            schema:
+              type: object
+              properties:
+                customerId:
+                  type: string
+                  description: The unique identifier of the customer
+                contactId:
+                  type: string
+                  description: The unique identifier of the contact that was deleted
+      customerContactUpdatedEventData:
+        format: JSONSchema/draft-07
+        id: customerContactUpdatedEventData
+        versions:
+          "1.0":
+            format: JSONSchema/draft-07version
+            id: "1.0"
+            schema:
+              type: object
+              properties:
+                customerId:
+                  type: string
+                  description: The unique identifier of the customer
+                contact:
+                  type: object
+                  description: The contact that was updated on the customer
+                  properties:
+                    id:
+                      type: string
+                      description: The unique identifier of the contact
+                    name:
+                      type: string
+                      description: The name of the contact
+      customerCreatedEventData:
+        format: JSONSchema/draft-07
+        id: customerCreatedEventData
+        versions:
+          "1.0":
+            format: JSONSchema/draft-07version
+            id: "1.0"
+            schema:
+              type: object
+              properties:
+                customerId:
+                  type: string
+                  description: The unique identifier of the customer
+                name:
+                  type: string
+                  description: The name of the customer
+      customerStatusUpdatedEventData:
+        format: JSONSchema/draft-07
+        id: customerStatusUpdatedEventData
+        versions:
+          "1.0":
+            format: JSONSchema/draft-07version
+            id: "1.0"
+            schema:
+              type: object
+              properties:
+                customerId:
+                  type: string
+                  description: The unique identifier of the customer
+                status:
+                  type: string
+                  description: The status of the customer
+      customerDeletedEventData:
+        format: JSONSchema/draft-07
+        id: customerDeletedEventData
+        versions:
+          "1.0":
+            format: JSONSchema/draft-07version
+            id: "1.0"
+            schema:
+              type: object
+              properties:
+                customerId:
+                  type: string
+                  description: The unique identifier of the customer
+                name:
+                  type: string
+                  description: The name of the customer
+      customerUpdatedEventData:
+        format: JSONSchema/draft-07
+        id: customerUpdatedEventData
+        versions:
+          "1.0":
+            format: JSONSchema/draft-07version
+            id: "1.0"
+            schema:
+              type: object
+              properties:
+                customerId:
+                  type: string
+                  description: The unique identifier of the customer
+                name:
+                  type: string
+                  description: The name of the customer
+                address:
+                  type: object
+                  description: The address of the customer
+                  properties:
+                    street:
+                      type: string
+                      description: The street of the address
+                    city:
+                      type: string
+                      description: The city of the address
+                    state:
+                      type: string
+                      description: The state of the address
+                    zip:
+                      type: string
+                      description: The zip code of the address
+                  required:
+                    - street
+                    - city
+                    - state
+                    - zip
+                phone:
+                  type: string
+                  description: The phone number of the customer
+                email:
+                  type: string
+                  description: The email address of the customer
+                website:
+                  type: string
+                  description: The website of the customer
+              required:
+                - customerId
+                - name
+                - phone
+                - email
+                - website

--- a/registry/schemas/generate_openapis.sh
+++ b/registry/schemas/generate_openapis.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sed -f xregistry_openapi_template_endpoint_registry_sed_args.txt xregistry_openapi_template.json > xregistry_openapi_endpoint.json
+sed -f xregistry_openapi_template_messagedefinition_registry_sed_args.txt xregistry_openapi_template.json > xregistry_openapi_messagedefinition.json
+sed -f xregistry_openapi_template_schema_registry_sed_args.txt xregistry_openapi_template.json > xregistry_openapi_schema.json

--- a/registry/schemas/xregistry_endpoint_protocol_options.json
+++ b/registry/schemas/xregistry_endpoint_protocol_options.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "allOf": [
+    {
+      "title": "endpointConfigOption",
+      "properties": {
+        "options": {
+          "$ref": "#/definitions/endpointOptions"
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/endpointConfigBase"
+    }
+  ],
+  "definitions": {
+    "endpointConfigBase": {
+      "properties": {
+        "protocol": {
+          "type": "string",
+          "description": "Specifies the `protocol` of this endpoint.",
+          "enum": [
+            "AMQP",
+            "AMQP/1.0",
+            "HTTP",
+            "HTTP/1.1",
+            "HTTP/2",
+            "HTTP/3",
+            "Kafka",
+            "MQTT",
+            "MQTT/3.1.1",
+            "MQTT/5.0",
+            "NATS",
+            "NATS/1.0.0"
+          ]
+        },
+        "options": {
+          "anyOf": [
+            { "$ref": "xregistry_endpoint_registry_amqp.json#/definitions/endpointOptionsAmqp" },
+            { "$ref": "xregistry_endpoint_registry_http.json#/definitions/endpointOptionsHttp" },
+            { "$ref": "xregistry_endpoint_registry_mqtt.json#/definitions/endpointOptionsMqtt" },
+            { "$ref": "xregistry_endpoint_registry_nats.json#/definitions/endpointOptionsNats" },
+            { "$ref": "xregistry_endpoint_registry_kafka.json#/definitions/endpointOptionsKafka" }
+          ]
+        }
+      }
+    },
+    "endpointOptions": {
+      "type": "object",
+      "title": "endpointOptions",
+      "properties": {
+        "protocol": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/registry/schemas/xregistry_endpoint_registry.json
+++ b/registry/schemas/xregistry_endpoint_registry.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "properties": {
+    "endpoints": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/endpoint"
+      }
+    }
+  },
+  "required": [
+    "endpoints"
+  ],
+  "definitions": {
+    "endpoint": {
+      "allOf": [
+        {
+          "$ref": "xregistry_resources.json#/definitions/resource"
+        },
+        {
+          "$ref": "xregistry_messagedefinition_definition.json"
+        },
+        {
+          "type": "object",
+          "title": "endpoint",
+          "properties": {
+            "channel": {
+              "type": "string",
+              "description": "A string that can be used to correlate Endpoints"
+            },
+            "usage": {
+              "description": "The interaction model supported by this Endpoint",
+              "type": "string",
+              "enum": [
+                "consumer",
+                "producer",
+                "subscriber"
+              ]
+            },
+            "config": {
+              "$ref": "#/definitions/endpointConfig"
+            },
+            "deprecated": {
+              "type": "object",
+              "properties": {
+                "effective": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The time at which the endpoint will enter a deprecated state"
+                },
+                "removal": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "The time at which the endpoint will be removed"
+                },
+                "alternative": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "A URL to an possible alternative endpoint"
+                },
+                "docs": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "A URL to additional information concerning the deprecation of this endpoint. Possible information might include rationale behind the action, or discussion of alternatives"
+                }
+              }
+            },
+            "authscope": {
+              "type": "string",
+              "description": "Authorization scope needed for creating subscriptions. The actual meaning of this field is determined on a per-endpoint basis",
+              "example": "storage.read"
+            },
+            "definitionGroups": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uri-reference"
+              }
+            }
+          },
+          "required": [
+            "usage",
+            "format"
+          ]
+        }
+      ]
+    },
+    "endpointConfig": {
+      "allOf": [
+        {
+          "type": "object",
+          "title": "endpointConfig",
+          "properties": {
+            "strict": {
+              "type": "boolean"
+            },
+            "endpoints": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          }
+        },
+        {
+          "title": "endpointConfigBase",
+          "$ref": "xregistry_endpoint_protocol_options.json"
+        }
+      ]
+    },
+    "endpointConfigSubscriber": {
+      "type": "object",
+      "title": "endpointConfigSubscriber",
+      "properties": {
+        "subscriptionConfig": {
+          "type": "object",
+          "description": "A map indicating supported options for the config parameter for the CloudSubscriptions subscribe() API call. Keys are the name of keys in the allowed config map, the values indicate the type of that parameter, confirming to the CloudEvents type system. TODO: Needs resolution with CloudSubscriptions API",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "filterDialects": {
+          "type": "array",
+          "description": "Filter dialects that can be used in subscriptions for this endpoint",
+          "items": {
+            "type": "string",
+            "description": "filter dialect"
+          },
+          "example": "[ \"basic\" ]"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/endpointConfig"
+        }
+      ]
+    },
+    "endpointConfigConsumer": {
+      "type": "object",
+      "title": "endpointConfigConsumer",
+      "allOf": [
+        {
+          "$ref": "#/definitions/endpointConfig"
+        }
+      ]
+    },
+    "endpointConfigProducer": {
+      "type": "object",
+      "title": "endpointConfigProducer",
+      "allOf": [
+        {
+          "$ref": "#/definitions/endpointConfig"
+        }
+      ]
+    }
+  }
+}

--- a/registry/schemas/xregistry_endpoint_registry_amqp.json
+++ b/registry/schemas/xregistry_endpoint_registry_amqp.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "description": "These are the endpoint options for the AMQP protocol",
+  "properties": {
+    "options": {
+      "$ref": "#/definitions/endpointOptionsAmqp"
+    }
+  },
+  "definitions": {
+    "endpointOptionsAmqp": {
+      "type": "object",
+      "properties": {
+        "node": {
+          "type": "string",
+          "description": "The node to connect to"
+        },
+        "durable": {
+          "type": "boolean",
+          "description": "Whether to retain messages for this endpoint"
+        },
+        "ttl": {
+          "type": "integer",
+          "description": "The time in milliseconds after which messages are discarded for this endpoint"
+        },
+        "distribution-mode": {
+          "type": "string",
+          "description": "The distribution mode to use for this endpoint",
+          "enum": [
+            "move",
+            "copy"
+          ]
+        },
+        "link-properties": {
+          "type": "object",
+          "description": "The link properties to set",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "connection-properties": {
+          "type": "object",
+          "description": "The connection prooperties to set",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "xregistry_endpoint_protocol_options.json#/definitions/endpointOptions"
+        }
+      ]
+    }
+  }
+}

--- a/registry/schemas/xregistry_endpoint_registry_http.json
+++ b/registry/schemas/xregistry_endpoint_registry_http.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "description": "These are the endpoint options for the HTTP protocol",
+  "properties": {
+    "options": {
+      "$ref": "#/definitions/endpointOptionsHttp"
+    }
+  },
+  "definitions": {
+    "endpointOptionsHttp": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "The HTTP method to use for this endpoint"
+        },
+        "headers": {
+          "type": "array",
+          "description": "The default HTTP request headers to use for this endpoint",
+          "items": {
+            "$ref": "#/definitions/httpRequestHeaders"
+          }
+        },
+        "query": {
+          "type": "object",
+          "description": "The HTTP query parameters to use for this endpoint",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "xregistry_endpoint_protocol_options.json#/definitions/endpointOptions"
+        }
+      ]
+    },
+    "httpRequestHeaders": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The HTTP header name"
+        },
+        "value": {
+          "type": "string",
+          "description": "The HTTP header value"
+        }
+      }
+    }
+  }
+}

--- a/registry/schemas/xregistry_endpoint_registry_kafka.json
+++ b/registry/schemas/xregistry_endpoint_registry_kafka.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "description": "These are the endpoint options for the Kafka protocol",
+  "properties": {
+    "options": {
+      "$ref": "#/definitions/endpointOptionsKafka"
+    }
+  },
+  "definitions": {
+    "endpointOptionsKafka": {
+      "type": "object",
+      "properties": {
+        "topic": {
+          "type": "string",
+          "description": "The Kafka topic to use for this endpoint"
+        },
+        "acks": {
+          "type": "integer",
+          "description": "The Kafka acks to use for this endpoint"
+        },
+        "key": {
+          "type": "string",
+          "description": "The Kafka key to use for this endpoint"
+        },
+        "partition": {
+          "type": "integer",
+          "description": "The Kafka partition to use for this endpoint"
+        },
+        "consumer-group": {
+          "type": "string",
+          "description": "The Kafka consumer group to use for this endpoint"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "xregistry_endpoint_protocol_options.json#/definitions/endpointOptions"
+        }
+      ]
+    }
+  }
+}

--- a/registry/schemas/xregistry_endpoint_registry_mqtt.json
+++ b/registry/schemas/xregistry_endpoint_registry_mqtt.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "description": "These are the endpoint options for the MQTT protocol",
+  "properties": {
+    "options": {
+      "$ref": "#/definitions/endpointOptionsMqtt"
+    }
+  },
+  "definitions": {
+    "endpointOptionsMqtt": {
+      "type": "object",
+      "properties": {
+        "topic": {
+          "type": "string",
+          "description": "The topic to use for this endpoint"
+        },
+        "qos": {
+          "type": "integer",
+          "description": "The quality of service level to use for this endpoint"
+        },
+        "retain": {
+          "type": "boolean",
+          "description": "Whether to retain messages for this endpoint"
+        },
+        "clean-session": {
+          "type": "boolean",
+          "description": "Whether to use a clean session for this endpoint"
+        },
+        "will-topic": {
+          "type": "string",
+          "format": "uritemplate",
+          "description": "The topic to use for the will message for this endpoint"
+        },
+        "will-message": {
+          "type": "string",
+          "format": "urireference",
+          "description": "The will message to use (message definition reference)"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "xregistry_endpoint_protocol_options.json#/definitions/endpointOptions"
+        }
+      ]
+    }
+  }
+}

--- a/registry/schemas/xregistry_endpoint_registry_nats.json
+++ b/registry/schemas/xregistry_endpoint_registry_nats.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "description": "These are the endpoint options for the NATS protocol",
+  "properties": {
+    "options": {
+      "$ref": "#/definitions/endpointOptionsNats"
+    }
+  },
+  "definitions": {
+    "endpointOptionsNats": {
+      "type": "object",
+      "properties": {
+        "topic": {
+          "type": "string",
+          "description": "The NATS topic to use for this endpoint"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "xregistry_endpoint_protocol_options.json#/definitions/endpointOptions"
+        }
+      ]
+    }
+  }
+}

--- a/registry/schemas/xregistry_messagedefinition_definition.json
+++ b/registry/schemas/xregistry_messagedefinition_definition.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "description": "This schema declares the 'definitions' property for message definition groups along with all well-known extensions to the 'definition' type.",
+  "$comment": "New message definition formats MUST be added to the 'oneOf' array in the 'definitions' property and the format identifiers MUST be registered in the 'format' property.",
+  "allOf": [
+    {
+      "title": "definitionBase",
+      "properties": {
+        "definitions": {
+          "type": "object",
+          "description": "A collection of Message Definitions.",
+          "additionalProperties": {
+            "$ref": "#/definitions/definition"
+          }
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/definitionGroupBase"
+    }
+  ],
+  "definitions": {
+    "definitionGroupBase": {
+      "properties": {
+        "format": {
+          "type": "string",
+          "description": "Specifies the `format` of this definition.",
+          "enum": [
+            "AMQP",
+            "AMQP/1.0",
+            "HTTP",
+            "HTTP/1.1",
+            "HTTP/2",
+            "HTTP/3",
+            "Kafka",
+            "Kafka/0.11",
+            "MQTT",
+            "MQTT/3.1.1",
+            "MQTT/5.0",
+            "CloudEvents",
+            "CloudEvents/1.0"
+          ]
+        },
+        "definitions": {
+          "type": "object",
+          "description": "A collection of Message Definitions.",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "xregistry_messagedefinition_registry_amqp.json#/definitions/amqpDefinition"
+              },
+              {
+                "$ref": "xregistry_messagedefinition_registry_mqtt.json#/definitions/mqttDefinition"
+              },
+              {
+                "$ref": "xregistry_messagedefinition_registry_http.json#/definitions/httpDefinition"
+              },
+              {
+                "$ref": "xregistry_messagedefinition_registry_kafka.json#/definitions/kafkaDefinition"
+              },
+              {
+                "$ref": "xregistry_messagedefinition_registry_cloudevents.json#/definitions/cloudEventDefinition"
+              }
+            ]
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "xregistry_resources.json#/definitions/resource"
+        }
+      ]
+    },
+    "definition": {
+      "type": "object",
+      "description": "a message definition",
+      "properties": {
+        "schemaUrl": {
+          "type": "string",
+          "description": "A URL to the schema of the message's data.",
+          "format": "uri-reference"
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "type": "object",
+              "description": "An in-line definition of the schema of the message's data."
+            },
+            {
+              "type": "string",
+              "description": "An in-line definition of the schema of the message's data."
+            }
+          ]
+        },
+        "schemaFormat": {
+          "type": "string",
+          "description": "Declares the schema format"
+        },
+        "format": {
+          "type": "string",
+          "description": "Specifies the `format` of this definition."
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "format"
+      ],
+      "anyOf": [
+        {
+          "required": [
+            "format",
+            "schema",
+            "schemaFormat"
+          ]
+        },
+        {
+          "required": [
+            "format",
+            "schemaUrl",
+            "schemaFormat"
+          ]
+        },
+        {
+          "required": [
+            "format"
+          ],
+          "not": {
+            "required": [
+              "schema",
+              "schemaUrl",
+              "schemaFormat"
+            ]
+          }
+        }
+      ],
+      "allOf": [
+        {
+          "$ref": "xregistry_resources.json#/definitions/resource"
+        }
+      ]
+    }
+  }
+}

--- a/registry/schemas/xregistry_messagedefinition_registry.json
+++ b/registry/schemas/xregistry_messagedefinition_registry.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "description": "Universal message definition registry.",
+  "$comment": "Message definition formats are registered in the `xregistry_messagedefinition_definition.json` schema.",
+  "properties": {
+    "definitionGroups": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/definitionGroup"
+      }
+    }
+  },
+  "required": [
+    "definitionGroups"
+  ],
+  "definitions": {
+    "definitionGroup": {
+      "allOf": [
+        {
+          "$ref": "xregistry_messagedefinition_definition.json"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "definitionsUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "definitionGroups": {
+              "type": "object",
+              "description": "A set of Definition Groups.",
+              "additionalProperties": {
+                "$ref": "#/definitions/definitionGroup"
+              }
+            },
+            "definitionGroupsUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            }
+          },
+          "required": [
+            "format"
+          ],
+          "allOf": [
+            {
+              "$ref": "xregistry_resources.json#/definitions/resource"
+            }
+          ]
+        }
+      ]
+    },
+    "metadataProperty": {
+      "type": "object",
+      "description": "Base class for all metadata properties.",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "specurl": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "metadataPropertyBoolean": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/metadataProperty"
+        }
+      ]
+    },
+    "metadataPropertyString": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/metadataProperty"
+        }
+      ]
+    },
+    "metadataPropertySymbol": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "pattern": "^[\\x32-\\x7F]*$"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/metadataProperty"
+        }
+      ]
+    },
+    "metadataPropertyBinary": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "format": "binary"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/metadataProperty"
+        }
+      ]
+    },
+    "metadataPropertyTimeStamp": {
+      "description": "This is a date-time property, holding RFC3339 string expressions.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/metadataProperty"
+        }
+      ]
+    },
+    "metadataPropertyDuration": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "format": "duration"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/metadataProperty"
+        }
+      ]
+    },
+    "metadataPropertyUriTemplate": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "format": "uri-template"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/metadataProperty"
+        }
+      ]
+    },
+    "metadataPropertyInteger": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "integer"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/metadataProperty"
+        }
+      ]
+    },
+    "metadataPropertyNumber": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "number"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/metadataProperty"
+        }
+      ]
+    },
+    "metadataPropertyUri": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/metadataProperty"
+        }
+      ]
+    },
+    "metadataPropertyUriReference": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/metadataProperty"
+        }
+      ]
+    }
+  }
+}

--- a/registry/schemas/xregistry_messagedefinition_registry_amqp.json
+++ b/registry/schemas/xregistry_messagedefinition_registry_amqp.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "ref": {
+      "$ref": "#/definitions/amqpDefinition"
+    }
+  },
+  "definitions": {
+    "amqpDefinition": {
+      "type": "object",
+      "title": "amqpDefinition",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/amqpMetadata"
+        },
+        "format": {
+          "type": "string",
+          "description": "Specifies the `format` of this definition.",
+          "enum": [
+            "AMQP", "AMQP/1.0"
+          ]
+        }
+      },
+      "required": [
+        "metadata", "format"
+      ],
+      "allOf": [
+        {
+          "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+        }
+      ]
+    },
+    "amqpMetadata": {
+      "type": "object",
+      "title": "amqpMetadata",
+      "properties": {
+        "application-properties": {
+          "$ref": "#/definitions/amqpAnnotations"
+        },
+        "properties": {
+          "$ref": "#/definitions/amqpProperties"
+        },
+        "delivery-annotations": {
+          "$ref": "#/definitions/amqpAnnotations"
+        },
+        "message-annotations": {
+          "$ref": "#/definitions/amqpAnnotations"
+        },
+        "header": {
+          "$ref": "#/definitions/amqpHeader"
+        },
+        "footer": {
+          "$ref": "#/definitions/amqpAnnotations"
+        }
+      }
+    },
+    "amqpProperties": {
+      "type": "object",
+      "properties": {
+        "message-id": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyString"
+        },
+        "user-id": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyBinary"
+        },
+        "to": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyUriTemplate"
+        },
+        "subject": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyString"
+        },
+        "reply-to": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyUriTemplate"
+        },
+        "correlation-id": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyString"
+        },
+        "content-type": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertySymbol"
+        },
+        "content-encoding": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertySymbol"
+        },
+        "absolute-expiry-time": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyTimeStamp"
+        },
+        "creation-time": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyTimeStamp"
+        },
+        "group-id": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyString"
+        },
+        "group-sequence": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyInteger"
+        },
+        "reply-to-group-id": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyUriTemplate"
+        }
+      }
+    },
+    "amqpHeader": {
+      "type": "object",
+      "properties": {
+        "durable": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyBoolean"
+        },
+        "priority": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyInteger"
+        },
+        "ttl": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyInteger"
+        },
+        "first-acquirer": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyBoolean"
+        },
+        "delivery-count": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyInteger"
+        }
+      }
+    },
+    "amqpAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataProperty"
+      }
+    }
+  }
+}

--- a/registry/schemas/xregistry_messagedefinition_registry_cloudevents.json
+++ b/registry/schemas/xregistry_messagedefinition_registry_cloudevents.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "anyOf": [
+    { "$ref" : "#/definitions/cloudEventMetadata"}
+  ],
+  "properties": {
+    "ref": {
+      "$ref": "#/definitions/cloudEventDefinition"
+    }
+  },
+  "definitions": {
+    "cloudEventDefinition": {
+      "type": "object",
+      "title": "cloudEventDefinition",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/cloudEventMetadata"
+        },
+        "format": {
+          "type": "string",
+          "description": "Specifies the `format` of this definition.",
+          "enum": [
+            "CloudEvents", "CloudEvents/1.0"
+          ]
+        }
+      },
+      "required": [
+        "metadata", "format"
+      ],
+      "allOf": [
+        {
+          "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+        }
+      ]
+    },
+    "cloudEventMetadata": {
+      "type": "object",
+      "title": "cloudEventMetadata",
+      "properties": {
+        "attributes": {
+          "$ref": "#/definitions/cloudEventMetadataAttributes"
+        }
+      },
+      "required": [
+        "attributes"
+      ]
+    },
+    "cloudEventMetadataAttributes": {
+      "type": "object",
+      "title": "cloudEventMetadataAttributes",
+      "properties": {
+        "id": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyString"
+        },
+        "type": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyString"
+        },
+        "time": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyTimeStamp"
+        },
+        "source": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyUriTemplate"
+        },
+        "subject": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyString"
+        },
+        "dataschema": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyUriTemplate"
+        },
+        "datacontenttype": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertySymbol"
+        }
+      },
+      "additionalProperties": {
+        "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataProperty"
+      }
+    }
+  }
+}

--- a/registry/schemas/xregistry_messagedefinition_registry_http.json
+++ b/registry/schemas/xregistry_messagedefinition_registry_http.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "ref": {
+      "$ref": "#/definitions/httpDefinition"
+    }
+  },
+  "definitions": {
+    "httpDefinition": {
+      "type": "object",
+      "title": "httpDefinition",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/httpMetadata"
+        },
+        "format": {
+          "type": "string",
+          "description": "Specifies the `format` of this definition.",
+          "enum": [
+            "HTTP", "HTTP/1.1", "HTTP/2", "HTTP/3"
+          ]
+        }
+      },
+      "required": [
+        "metadata", "format"
+      ],
+      "allOf": [
+        {
+          "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+        }
+      ]
+    },
+    "httpMetadata": {
+      "type": "object",
+      "title": "httpMetadata",
+      "properties": {
+        "method": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyString"
+        },
+        "status": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyString"
+        },
+        "path": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyUriTemplate"
+        },
+        "requestHeaders": {
+          "type": "array",
+          "description": "HTTP Header is allowed to appear multiple times to represent multiple name, value pairs. The same name is allowed to appear more than once.",
+          "items": {
+            "$ref": "#/definitions/httpHeaderProperty"
+          }
+        },
+        "query": {
+          "type": "object",
+          "description": "HTTP Query Parameters are key value pairs",
+          "additionalProperties": {
+            "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataProperty"
+          }
+        }
+      }
+    },
+    "httpHeaderProperty": {
+      "type": "object",
+      "title": "httpHeaderProperty",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+        }
+      ]
+    }
+  }
+}

--- a/registry/schemas/xregistry_messagedefinition_registry_kafka.json
+++ b/registry/schemas/xregistry_messagedefinition_registry_kafka.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "ref": {
+      "$ref": "#/definitions/kafkaDefinition"
+    }
+  },
+  "definitions": {
+    "kafkaDefinition": {
+      "type": "object",
+      "title": "kafkaDefinition",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/kafkaMetadata"
+        },
+        "format": {
+          "type": "string",
+          "description": "Specifies the `format` of this definition.",
+          "enum": [
+            "KAFKA", "KAFKA/0.11"
+          ]
+        }
+      },
+      "required": [
+        "metadata", "format"
+      ],
+      "allOf": [
+        {
+          "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+        }
+      ]
+    },
+    "kafkaMetadata": {
+      "type": "object",
+      "title": "kafkaMetadata",
+      "properties": {
+        "topic": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyString"
+        },
+        "partition": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyInteger"
+        },
+        "key": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyBinary"
+        },
+        "timestamp": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyInteger"
+        },
+        "recordHeaders": {
+          "type": "object",
+          "description": "Apache Kafka headers are key value pairs",
+          "additionalProperties": {
+            "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataProperty"
+          }
+        }
+      }
+    }
+  }
+}

--- a/registry/schemas/xregistry_messagedefinition_registry_mqtt.json
+++ b/registry/schemas/xregistry_messagedefinition_registry_mqtt.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "ref": {
+      "$ref": "#/definitions/mqttDefinition"
+    }
+  },
+  "definitions": {
+    "mqttDefinition": {
+      "type": "object",
+      "title": "mqttDefinition",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/mqttMetadata"
+        },
+        "format": {
+          "type": "string",
+          "description": "Specifies the `format` of this definition.",
+          "enum": [
+            "MQTT", "MQTT/3.1.1", "MQTT/5.0"
+          ]
+        }
+      },
+      "required": [
+        "metadata","format"
+      ],
+      "allOf": [
+        {
+          "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+        }
+      ]
+    },
+    "mqttMetadata": {
+      "type": "object",
+      "title": "mqttMetadata",
+      "properties": {
+        "qos": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyInteger"
+        },
+        "retain": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyBoolean"
+        },
+        "topic-name": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyUriTemplate"
+        },
+        "payload-format": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyInteger"
+        },
+        "message-expiry-interval": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyInteger"
+        },
+        "response-topic": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyUriTemplate"
+        },
+        "correlation-data": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertyBinary"
+        },
+        "content-type": {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataPropertySymbol"
+        },
+        "user-properties": {
+          "type": "array",
+          "description": "User Property is allowed to appear multiple times to represent multiple name, value pairs. The same name is allowed to appear more than once.",
+          "items": {
+            "$ref": "#/definitions/mqttUserProperty"
+          }
+        }
+      }
+    },
+    "mqttUserProperty": {
+      "type": "object",
+      "title": "mqttUserProperty",
+      "allOf": [
+        {
+          "$ref": "xregistry_messagedefinition_registry.json#/definitions/metadataProperty"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/registry/schemas/xregistry_messaging_catalog.json
+++ b/registry/schemas/xregistry_messaging_catalog.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "title": "catalog",
+  "description": "A catalog is a collection of definition groups, schema groups, and endpoints.",
+  "type": "object",
+  "properties": {
+    "definitionGroups": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "xregistry_messagedefinition_registry.json#/definitions/definitionGroup"
+      }
+    },
+    "definitionGroupsUrl": {
+      "type": "string",
+      "format": "uri"
+    },
+    "schemaGroups": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "xregistry_schema_registry.json#/definitions/schemaGroup"
+      }
+    },
+    "schemaGroupsUrl": {
+      "type": "string",
+      "format": "uri"
+    },
+    "endpoints": {
+      "additionalProperties": {
+        "$ref": "xregistry_endpoint_registry.json#/definitions/endpoint"
+      }
+    },
+    "endpointsUrl": {
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "xregistry_resources.json#/definitions/document"
+    }
+  ]
+}

--- a/registry/schemas/xregistry_openapi.json
+++ b/registry/schemas/xregistry_openapi.json
@@ -1,0 +1,1004 @@
+{
+  "openapi": "3.0.6",
+  "info": {
+    "title": "xRegistry API",
+    "description": "xRegistry API",
+    "version": "0.5-wip"
+  },
+  "servers": [],
+  "security": [
+    {
+      "api_key": []
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "getAll",
+        "description": "Gets the root document",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The root document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/document"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "uploadDoc",
+        "description": "Uploads a registry document and upserts its contents into the registry",
+        "requestBody": {
+          "description": "A request to create or update the discovery endpoint's collection of endpoints with the given endpoints",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/document"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The resulting document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/document"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{groupType}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        }
+      ],
+      "get": {
+        "operationId": "getResourceGroupAll",
+        "description": "Gets all entries of the resource group",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "description": "Query expression",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter expression"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource groups that match the query or all available resource groups if no query was specified",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_resources.json#/definitions/resource"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No groups found"
+          }
+        }
+      },
+      "post": {
+        "operationId": "postResourceGroup",
+        "requestBody": {
+          "description": "Create a new resource group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The resulting resource group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            },
+            "headers": {
+              "Location": {
+                "description": "The location of the created resource",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/{groupType}/{groupId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
+          "$ref": "#/components/parameters/groupId"
+        }
+      ],
+      "get": {
+        "operationId": "getResourceGroup",
+        "responses": {
+          "200": {
+            "description": "The schema group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "operationId": "putResourceGroup",
+        "description": "creates or updates the resource group",
+        "requestBody": {
+          "description": "A request to create or update the discovery group's collection of groups with the given group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResourceGroup",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Ok"            
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/{groupType}/{groupId}/{resourceType}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
+        }
+      ],
+      "get": {
+        "operationId": "getResourcesAll",
+        "description": "Get an optionally filtered collection of resources",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "description": "Query expression",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter expression"
+            }
+          },
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resources (optionally matching the query parameter)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_resources.json#/definitions/resource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "putResources",
+        "requestBody": {
+          "description": "A request to create or update the discovery group's collection of groups with the given group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated list of resources",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                     "$ref": "xregistry_resources.json#/definitions/resource"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResources",
+        "responses": {
+          "204": {
+            "description": "Ok"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/{groupType}/{groupId}/{resourceType}/{resourceId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResource",
+        "responses": {
+          "200": {
+            "description": "The corresponding resource",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              },
+              "Content-Location": {
+                "description": "permalink location of the returned version",
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "summary": "Post new resource version",
+        "description": "Register resource version If resource of specified name does not exist in specified group, resource and resource version is created at version 1. If resource of specified name exists already in specified group, resource is created at latest version + 1. If resource with identical content already exists, existing resource's ID is returned. \n",
+        "operationId": "postResource",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/resource-description"
+          },
+          {
+            "$ref": "#/components/parameters/resource-docs"
+          },
+          {
+            "$ref": "#/components/parameters/resource-origin"
+          },
+          {
+            "$ref": "#/components/parameters/resource-tags"
+          },
+          {
+            "in": "header",
+            "description": "format",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "A request to add a new resource to the version collection",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created resource",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete resource",
+        "description": "Delete resource",
+        "operationId": "deleteResource",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/{groupType}/{groupId}/{resourceType}/{resourceId}/versions/{versionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "$ref": "#/components/parameters/versionId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResourceVersion",
+        "description": "Gets the document stored for the schema version",
+        "responses": {
+          "200": {
+            "description": "The schema version document",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResourceVersion",
+        "responses": {
+          "204": {
+            "description": "Ok"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "code",
+        "in": "query"
+      }
+    },
+    "parameters": {
+      "groupType": {
+        "in": "path",
+        "name": "groupType",
+        "description": "The groupType (plural)",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resourceType": {
+        "in": "path",
+        "name": "id",
+        "description": "The resourceType (plural)",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "id": {
+        "in": "path",
+        "name": "id",
+        "description": "The id of the endpoint",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "groupId": {
+        "in": "path",
+        "name": "groupId",
+        "description": "The id of the group",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "resourceId": {
+        "in": "path",
+        "name": "resourceId",
+        "description": "The id of the schema",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "versionId": {
+        "in": "path",
+        "name": "versionId",
+        "description": "The id of the schema",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "resource-type": {
+        "in": "header",
+        "name": "resource-type",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-id": {
+        "in": "header",
+        "name": "resource-id",
+        "required": false,
+        "description": "A unique identifier for this resource. This value MUST be globally unique",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-version": {
+        "in": "header",
+        "name": "resource-version",
+        "required": false,
+        "description": "A number representing the version number of the resource.",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "resource-self": {
+        "in": "header",
+        "name": "resource-self",
+        "required": false,
+        "description": "A unique URI for the resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-description": {
+        "in": "header",
+        "name": "resource-description",
+        "required": false,
+        "description": "A summary of the purpose of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-name": {
+        "in": "header",
+        "name": "resource-name",
+        "required": false,
+        "description": "The name of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-docs": {
+        "in": "header",
+        "required": false,
+        "name": "resource-docs",
+        "description": "Absolute URL that provides a link to additional documentation about the resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-origin": {
+        "in": "header",
+        "required": false,
+        "name": "resource-origin",
+        "description": "A URI reference to the original source of this resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-tags": {
+        "in": "header",
+        "name": "resource-tags",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/resource-tag"
+          }
+        }
+      },
+      "resource-createdby": {
+        "in": "header",
+        "name": "resource-createdby",
+        "required": false,
+        "description": "Identity of who created this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-createdon": {
+        "in": "header",
+        "name": "resource-createdon",
+        "required": false,
+        "description": "Time when this entity was created",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "resource-modifiedby": {
+        "in": "header",
+        "name": "resource-modifiedby",
+        "required": false,
+        "description": "Identity of who last modified this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-modifiedon": {
+        "in": "header",
+        "name": "resource-modifiedon",
+        "required": false,
+        "description": "Time when this entity was last modified",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "headers": {
+      "resource-type": {
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-id": {
+        "required": false,
+        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-version": {
+        "required": false,
+        "description": "A number representing the version number of the resource.",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "resource-self": {
+        "required": false,
+        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-description": {
+        "required": false,
+        "description": "A summary of the purpose of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-name": {
+        "required": false,
+        "description": "The name of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-docs": {
+        "description": "Absolute URL that provides a link to additional documentation about the resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-origin": {
+        "description": "A URI reference to the original source of this resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-tags": {
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/resource-tag"
+          }
+        }
+      },
+      "resource-createdby": {
+        "required": false,
+        "description": "Identity of who created this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-createdon": {
+        "required": false,
+        "description": "Time when this entity was created",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "resource-modifiedby": {
+        "required": false,
+        "description": "Identity of who last modified this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-modifiedon": {
+        "required": false,
+        "description": "Time when this entity was last modified",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "schemas": {
+      "resource-tag": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/registry/schemas/xregistry_openapi.json
+++ b/registry/schemas/xregistry_openapi.json
@@ -148,7 +148,7 @@
         "operationId": "getResourceGroup",
         "responses": {
           "200": {
-            "description": "The schema group",
+            "description": "The resource group",
             "content": {
               "application/json": {
                 "schema": {
@@ -301,7 +301,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A list of resources (optionally matching the query parameter)",
+            "description": "Updated list of resources",
             "content": {
               "application/json": {
                 "schema": {
@@ -780,6 +780,11 @@
                 "schema": {
                   "type": "string",
                   "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
                 }
               }
             }

--- a/registry/schemas/xregistry_openapi.json
+++ b/registry/schemas/xregistry_openapi.json
@@ -14,7 +14,7 @@
   "paths": {
     "/": {
       "get": {
-        "operationId": "getAll",
+        "operationId": "getRootDocument",
         "description": "Gets the root document",
         "parameters": [
           {
@@ -22,8 +22,22 @@
             "name": "inline",
             "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -41,7 +55,7 @@
         }
       },
       "post": {
-        "operationId": "uploadDoc",
+        "operationId": "upsertDocument",
         "description": "Uploads a registry document and upserts its contents into the registry",
         "requestBody": {
           "description": "A request to create or update the discovery endpoint's collection of endpoints with the given endpoints",
@@ -82,18 +96,22 @@
             "name": "inline",
             "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
               "type": "boolean"
             }
           },
           {
             "in": "query",
-            "name": "name",
-            "description": "Query expression",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
             "required": false,
             "schema": {
-              "type": "string",
-              "description": "Filter expression"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -113,45 +131,6 @@
           },
           "404": {
             "description": "No groups found"
-          }
-        }
-      },
-      "post": {
-        "operationId": "postResourceGroup",
-        "requestBody": {
-          "description": "Create a new resource group",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "xregistry_resources.json#/definitions/resource"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "The resulting resource group",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "xregistry_resources.json#/definitions/resource"
-                }
-              }
-            },
-            "headers": {
-              "Location": {
-                "description": "The location of the created resource",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request - constraint failure"
-          },
-          "409": {
-            "description": "Conflict - epoch not greater"
           }
         }
       }
@@ -187,6 +166,19 @@
         }
       },
       "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be updated",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
         "operationId": "putResourceGroup",
         "description": "creates or updates the resource group",
         "requestBody": {
@@ -228,7 +220,7 @@
             "in": "query",
             "name": "epoch",
             "description": "The epoch of the resource group to be deleted",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "description": "A number representing the version number of the resource.",
@@ -238,7 +230,7 @@
         ],
         "responses": {
           "204": {
-            "description": "Ok"            
+            "description": "Ok"
           },
           "400": {
             "description": "Bad Request - constraint failure"
@@ -267,21 +259,43 @@
         "parameters": [
           {
             "in": "query",
-            "name": "query",
-            "description": "Query expression",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
-              "type": "string",
-              "description": "Filter expression"
+              "type": "boolean"
             }
           },
           {
             "in": "query",
-            "name": "inline",
-            "description": "Set if references shall be inlined",
+            "name": "skip",
+            "description": "The number of resources to skip",
             "required": false,
             "schema": {
-              "type": "boolean"
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "top",
+            "description": "The number of resources to show",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -298,57 +312,6 @@
                 }
               }
             }
-          }
-        }
-      },
-      "put": {
-        "operationId": "putResources",
-        "requestBody": {
-          "description": "A request to create or update the discovery group's collection of groups with the given group",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "additionalProperties": {
-                  "$ref": "xregistry_resources.json#/definitions/resource"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated list of resources",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                     "$ref": "xregistry_resources.json#/definitions/resource"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request - constraint failure"
-          },
-          "409": {
-            "description": "Conflict - epoch not greater"
-          }
-        }
-      },
-      "delete": {
-        "operationId": "deleteResources",
-        "responses": {
-          "204": {
-            "description": "Ok"
-          },
-          "400": {
-            "description": "Bad Request - constraint failure"
-          },
-          "409": {
-            "description": "Conflict - epoch not greater"
           }
         }
       }
@@ -446,6 +409,71 @@
           },
           "404": {
             "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be upserted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/resource-description"
+          },
+          {
+            "$ref": "#/components/parameters/resource-docs"
+          },
+          {
+            "$ref": "#/components/parameters/resource-origin"
+          },
+          {
+            "$ref": "#/components/parameters/resource-tags"
+          }
+        ],
+        "summary": "Create or update a resource",
+        "description": "Create a resource. ",
+        "operationId": "putResource",
+        "requestBody": {
+          "description": "The resource to be created/updated",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
           }
         }
       },
@@ -566,7 +594,7 @@
             "in": "query",
             "name": "epoch",
             "description": "The epoch of the resource to be deleted",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "description": "A number representing the version number of the resource.",
@@ -583,6 +611,94 @@
           },
           "404": {
             "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/{groupType}/{groupId}/{resourceType}/{resourceId}/versions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "allowEmptyValue": true,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResourceVersionsAll",
+        "description": "Get an optionally filtered collection of resources",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "skip",
+            "description": "The number of resources to skip",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "top",
+            "description": "The number of resources to show",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resource versions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_resources.json#/definitions/resource"
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -609,6 +725,7 @@
           "name": "meta",
           "description": "Interact with the metadata",
           "required": false,
+          "allowEmptyValue": true,
           "schema": {
             "type": "boolean"
           }
@@ -675,7 +792,68 @@
           }
         }
       },
+      "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be updated",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "operationId": "updateResourceVersion",
+        "description": "Updates the metadata for the schema version",
+        "requestBody": {
+          "description": "The schema version document",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The schema version metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict"
+          }
+        }
+      },
       "delete": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
         "operationId": "deleteResourceVersion",
         "responses": {
           "204": {

--- a/registry/schemas/xregistry_openapi_endpoint.json
+++ b/registry/schemas/xregistry_openapi_endpoint.json
@@ -1,0 +1,960 @@
+{
+  "openapi": "3.0.6",
+  "info": {
+    "title": "xRegistry API",
+    "description": "xRegistry API",
+    "version": "0.5-wip"
+  },
+  "servers": [],
+  "security": [
+    {
+      "api_key": []
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "getAll",
+        "description": "Gets the root document",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The root document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_endpoint_registry.json"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "uploadDoc",
+        "description": "Uploads a registry document and upserts its contents into the registry",
+        "requestBody": {
+          "description": "A request to create or update the discovery endpoint's collection of endpoints with the given endpoints",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_endpoint_registry.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The resulting document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_endpoint_registry.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/endpoints": {
+      "get": {
+        "operationId": "getResourceGroupAll",
+        "description": "Gets all entries of the resource group",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "description": "Query expression",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter expression"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource groups that match the query or all available resource groups if no query was specified",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_endpoint_registry.json#/definitions/endpoint"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No groups found"
+          }
+        }
+      },
+      "post": {
+        "operationId": "postResourceGroup",
+        "requestBody": {
+          "description": "Create a new resource group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_endpoint_registry.json#/definitions/endpoint"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The resulting resource group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_endpoint_registry.json#/definitions/endpoint"
+                }
+              }
+            },
+            "headers": {
+              "Location": {
+                "description": "The location of the created resource",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/endpoints/{groupId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        }
+      ],
+      "get": {
+        "operationId": "getResourceGroup",
+        "responses": {
+          "200": {
+            "description": "The resource group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_endpoint_registry.json#/definitions/endpoint"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "operationId": "putResourceGroup",
+        "description": "creates or updates the resource group",
+        "requestBody": {
+          "description": "A request to create or update the discovery group's collection of groups with the given group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_endpoint_registry.json#/definitions/endpoint"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_endpoint_registry.json#/definitions/endpoint"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResourceGroup",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Ok"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/endpoints/{groupId}/definitions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        }
+      ],
+      "get": {
+        "operationId": "getResourcesAll",
+        "description": "Get an optionally filtered collection of resources",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "description": "Query expression",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter expression"
+            }
+          },
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resources (optionally matching the query parameter)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "putResources",
+        "requestBody": {
+          "description": "A request to create or update the discovery group's collection of groups with the given group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated list of resources",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                     "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResources",
+        "responses": {
+          "200": {
+            "description": "Ok"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/endpoints/{groupId}/definitions/{resourceId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResource",
+        "responses": {
+          "200": {
+            "description": "The corresponding resource",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              },
+              "Content-Location": {
+                "description": "permalink location of the returned version",
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "summary": "Post new resource version",
+        "description": "Register resource version If resource of specified name does not exist in specified group, resource and resource version is created at version 1. If resource of specified name exists already in specified group, resource is created at latest version + 1. If resource with identical content already exists, existing resource's ID is returned. \n",
+        "operationId": "postResource",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/resource-description"
+          },
+          {
+            "$ref": "#/components/parameters/resource-docs"
+          },
+          {
+            "$ref": "#/components/parameters/resource-origin"
+          },
+          {
+            "$ref": "#/components/parameters/resource-tags"
+          },
+          {
+            "in": "header",
+            "description": "format",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "A request to add a new resource to the version collection",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created resource",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete resource",
+        "description": "Delete resource",
+        "operationId": "deleteResource",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/endpoints/{groupId}/definitions/{resourceId}/versions/{versionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "$ref": "#/components/parameters/versionId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResourceVersion",
+        "description": "Gets the document stored for the schema version",
+        "responses": {
+          "200": {
+            "description": "The schema version document",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResourceVersion",
+        "responses": {
+          "204": {
+            "description": "No content"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "code",
+        "in": "query"
+      }
+    },
+    "parameters": {
+      "id": {
+        "in": "path",
+        "name": "id",
+        "description": "The id of the endpoint",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "groupId": {
+        "in": "path",
+        "name": "groupId",
+        "description": "The id of the group",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "resourceId": {
+        "in": "path",
+        "name": "resourceId",
+        "description": "The id of the schema",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "versionId": {
+        "in": "path",
+        "name": "versionId",
+        "description": "The id of the schema",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "resource-type": {
+        "in": "header",
+        "name": "resource-type",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-id": {
+        "in": "header",
+        "name": "resource-id",
+        "required": false,
+        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-version": {
+        "in": "header",
+        "name": "resource-version",
+        "required": false,
+        "description": "A number representing the version number of the resource.",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "resource-self": {
+        "in": "header",
+        "name": "resource-self",
+        "required": false,
+        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-description": {
+        "in": "header",
+        "name": "resource-description",
+        "required": false,
+        "description": "A summary of the purpose of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-name": {
+        "in": "header",
+        "name": "resource-name",
+        "required": false,
+        "description": "The name of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-docs": {
+        "in": "header",
+        "required": false,
+        "name": "resource-docs",
+        "description": "Absolute URL that provides a link to additional documentation about the resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-origin": {
+        "in": "header",
+        "required": false,
+        "name": "resource-origin",
+        "description": "A URI reference to the original source of this resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-tags": {
+        "in": "header",
+        "name": "resource-tags",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/resource-tag"
+          }
+        }
+      },
+      "resource-createdby": {
+        "in": "header",
+        "name": "resource-createdby",
+        "required": false,
+        "description": "Identity of who created this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-createdon": {
+        "in": "header",
+        "name": "resource-createdon",
+        "required": false,
+        "description": "Time when this entity was created",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "resource-modifiedby": {
+        "in": "header",
+        "name": "resource-modifiedby",
+        "required": false,
+        "description": "Identity of who last modified this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-modifiedon": {
+        "in": "header",
+        "name": "resource-modifiedon",
+        "required": false,
+        "description": "Time when this entity was last modified",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "headers": {
+      "resource-type": {
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-id": {
+        "required": false,
+        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-version": {
+        "required": false,
+        "description": "A number representing the version number of the resource.",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "resource-self": {
+        "required": false,
+        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-description": {
+        "required": false,
+        "description": "A summary of the purpose of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-name": {
+        "required": false,
+        "description": "The name of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-docs": {
+        "description": "Absolute URL that provides a link to additional documentation about the resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-origin": {
+        "description": "A URI reference to the original source of this resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-tags": {
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/resource-tag"
+          }
+        }
+      },
+      "resource-createdby": {
+        "required": false,
+        "description": "Identity of who created this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-createdon": {
+        "required": false,
+        "description": "Time when this entity was created",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "resource-modifiedby": {
+        "required": false,
+        "description": "Identity of who last modified this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-modifiedon": {
+        "required": false,
+        "description": "Time when this entity was last modified",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "schemas": {
+      "resource-tag": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/registry/schemas/xregistry_openapi_endpoint.json
+++ b/registry/schemas/xregistry_openapi_endpoint.json
@@ -83,9 +83,7 @@
     },
     "/endpoints": {
       "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        }
+        
       ],
       "get": {
         "operationId": "getResourceGroupAll",
@@ -135,11 +133,8 @@
         }
       }
     },
-    "/{groupType}/{groupId}": {
+    "/endpoints/{groupId}": {
       "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        },
         {
           "$ref": "#/components/parameters/groupId"
         }
@@ -244,13 +239,7 @@
     "/endpoints/{groupId}/definitions": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         }
       ],
       "get": {
@@ -325,13 +314,7 @@
     "/endpoints/{groupId}/definitions/{resourceId}": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -621,19 +604,16 @@
         }
       }
     },
-    "/endpoints/{groupId}/definitions/{resourceId}/versions/{versionId}": {
+    "/endpoints/{groupId}/definitions/{resourceId}/versions/{versionId1}": {
       "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        },
         {
           "$ref": "#/components/parameters/groupId"
         },
         {
-          "$ref": "#/components/parameters/resourceType"
+          "$ref": "#/components/parameters/resourceId"
         },
         {
-          "$ref": "#/components/parameters/resourceId"
+          "$ref": "#/components/parameters/versionId"
         },
         {
           "in": "query",
@@ -647,78 +627,32 @@
         }
       ],
       "get": {
-        "operationId": "getResourceVersionsAll",
-        "description": "Get an optionally filtered collection of resources",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "inline",
-            "description": "Set if references shall be inlined",
-            "required": false,
-            "allowEmptyValue": true,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "query",
-            "name": "skip",
-            "description": "The number of resources to skip",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "top",
-            "description": "The number of resources to show",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "filter",
-            "description": "Filter criterion(s)",
-            "explode": true,
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
+        "operationId": "getResourceVersion1",
+        "description": "Gets the document stored for the schema version",
         "responses": {
           "200": {
-            "description": "A list of resource versions",
+            "description": "The schema version document",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "xregistry_resources.json#/definitions/resource"
-                  }
+                  "$ref": "xregistry_resources.json#/definitions/resource"
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
     },
-    "/{groupType}/{groupId}/{resourceType}/{resourceId}/versions/{versionId}": {
+    "/endpoints/{groupId}/definitions/{resourceId}/versions/{versionId}": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -786,6 +720,11 @@
                 "schema": {
                   "type": "string",
                   "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
                 }
               }
             }

--- a/registry/schemas/xregistry_openapi_endpoint.json
+++ b/registry/schemas/xregistry_openapi_endpoint.json
@@ -14,7 +14,7 @@
   "paths": {
     "/": {
       "get": {
-        "operationId": "getAll",
+        "operationId": "getRootDocument",
         "description": "Gets the root document",
         "parameters": [
           {
@@ -22,8 +22,22 @@
             "name": "inline",
             "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -41,7 +55,7 @@
         }
       },
       "post": {
-        "operationId": "uploadDoc",
+        "operationId": "upsertDocument",
         "description": "Uploads a registry document and upserts its contents into the registry",
         "requestBody": {
           "description": "A request to create or update the discovery endpoint's collection of endpoints with the given endpoints",
@@ -68,6 +82,11 @@
       }
     },
     "/endpoints": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        }
+      ],
       "get": {
         "operationId": "getResourceGroupAll",
         "description": "Gets all entries of the resource group",
@@ -77,18 +96,22 @@
             "name": "inline",
             "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
               "type": "boolean"
             }
           },
           {
             "in": "query",
-            "name": "query",
-            "description": "Query expression",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
             "required": false,
             "schema": {
-              "type": "string",
-              "description": "Filter expression"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -110,49 +133,13 @@
             "description": "No groups found"
           }
         }
-      },
-      "post": {
-        "operationId": "postResourceGroup",
-        "requestBody": {
-          "description": "Create a new resource group",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "xregistry_endpoint_registry.json#/definitions/endpoint"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "The resulting resource group",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "xregistry_endpoint_registry.json#/definitions/endpoint"
-                }
-              }
-            },
-            "headers": {
-              "Location": {
-                "description": "The location of the created resource",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request - constraint failure"
-          },
-          "409": {
-            "description": "Conflict - epoch not greater"
-          }
-        }
       }
     },
-    "/endpoints/{groupId}": {
+    "/{groupType}/{groupId}": {
       "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
         {
           "$ref": "#/components/parameters/groupId"
         }
@@ -179,6 +166,19 @@
         }
       },
       "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be updated",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
         "operationId": "putResourceGroup",
         "description": "creates or updates the resource group",
         "requestBody": {
@@ -220,7 +220,7 @@
             "in": "query",
             "name": "epoch",
             "description": "The epoch of the resource group to be deleted",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "description": "A number representing the version number of the resource.",
@@ -244,7 +244,13 @@
     "/endpoints/{groupId}/definitions": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         }
       ],
       "get": {
@@ -253,55 +259,46 @@
         "parameters": [
           {
             "in": "query",
-            "name": "query",
-            "description": "Query expression",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
-              "type": "string",
-              "description": "Filter expression"
+              "type": "boolean"
             }
           },
           {
             "in": "query",
-            "name": "inline",
-            "description": "Set if references shall be inlined",
+            "name": "skip",
+            "description": "The number of resources to skip",
             "required": false,
             "schema": {
-              "type": "boolean"
+              "type": "integer"
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of resources (optionally matching the query parameter)",
-            "content": {
-              "application/json": {
+          },
+          {
+            "in": "query",
+            "name": "top",
+            "description": "The number of resources to show",
+            "required": false,
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
-                  }
-                }
-              }
-            }
-          }
+              "type": "integer"
         }
       },
-      "put": {
-        "operationId": "putResources",
-        "requestBody": {
-          "description": "A request to create or update the discovery group's collection of groups with the given group",
-          "content": {
-            "application/json": {
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
               "schema": {
-                "type": "object",
-                "additionalProperties": {
-                  "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+              "type": "array",
+              "items": {
+                "type": "string"
                 }
               }
             }
-          }
-        },
+        ],
         "responses": {
           "200": {
             "description": "Updated list of resources",
@@ -323,26 +320,18 @@
             "description": "Conflict - epoch not greater"
           }
         }
-      },
-      "delete": {
-        "operationId": "deleteResources",
-        "responses": {
-          "200": {
-            "description": "Ok"
-          },
-          "400": {
-            "description": "Bad Request - constraint failure"
-          },
-          "409": {
-            "description": "Conflict - epoch not greater"
-          }
-        }
-      }
+      }      
     },
     "/endpoints/{groupId}/definitions/{resourceId}": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -426,6 +415,71 @@
           },
           "404": {
             "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be upserted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/resource-description"
+          },
+          {
+            "$ref": "#/components/parameters/resource-docs"
+          },
+          {
+            "$ref": "#/components/parameters/resource-origin"
+          },
+          {
+            "$ref": "#/components/parameters/resource-tags"
+          }
+        ],
+        "summary": "Create or update a resource",
+        "description": "Create a resource. ",
+        "operationId": "putResource",
+        "requestBody": {
+          "description": "The resource to be created/updated",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
           }
         }
       },
@@ -546,7 +600,7 @@
             "in": "query",
             "name": "epoch",
             "description": "The epoch of the resource to be deleted",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "description": "A number representing the version number of the resource.",
@@ -570,7 +624,101 @@
     "/endpoints/{groupId}/definitions/{resourceId}/versions/{versionId}": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "allowEmptyValue": true,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResourceVersionsAll",
+        "description": "Get an optionally filtered collection of resources",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "skip",
+            "description": "The number of resources to skip",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "top",
+            "description": "The number of resources to show",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resource versions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_resources.json#/definitions/resource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{groupType}/{groupId}/{resourceType}/{resourceId}/versions/{versionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -583,6 +731,7 @@
           "name": "meta",
           "description": "Interact with the metadata",
           "required": false,
+          "allowEmptyValue": true,
           "schema": {
             "type": "boolean"
           }
@@ -649,11 +798,72 @@
           }
         }
       },
+      "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be updated",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "operationId": "updateResourceVersion",
+        "description": "Updates the metadata for the schema version",
+        "requestBody": {
+          "description": "The schema version document",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The schema version metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict"
+          }
+        }
+      },
       "delete": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
         "operationId": "deleteResourceVersion",
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "Ok"
           },
           "400": {
             "description": "Bad Request - constraint failure"
@@ -674,6 +884,24 @@
       }
     },
     "parameters": {
+      "groupType": {
+        "in": "path",
+        "name": "groupType",
+        "description": "The groupType (plural)",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resourceType": {
+        "in": "path",
+        "name": "id",
+        "description": "The resourceType (plural)",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
       "id": {
         "in": "path",
         "name": "id",
@@ -730,7 +958,7 @@
         "in": "header",
         "name": "resource-id",
         "required": false,
-        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "description": "A unique identifier for this resource. This value MUST be globally unique",
         "schema": {
           "type": "string",
           "format": "uri-reference"
@@ -750,7 +978,7 @@
         "in": "header",
         "name": "resource-self",
         "required": false,
-        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "description": "A unique URI for the resource.",
         "schema": {
           "type": "string",
           "format": "uri"

--- a/registry/schemas/xregistry_openapi_messagedefinition.json
+++ b/registry/schemas/xregistry_openapi_messagedefinition.json
@@ -83,9 +83,7 @@
     },
     "/definitiongroups": {
       "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        }
+        
       ],
       "get": {
         "operationId": "getResourceGroupAll",
@@ -135,11 +133,8 @@
         }
       }
     },
-    "/{groupType}/{groupId}": {
+    "/definitiongroups/{groupId}": {
       "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        },
         {
           "$ref": "#/components/parameters/groupId"
         }
@@ -244,13 +239,7 @@
     "/definitiongroups/{groupId}/definitions": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         }
       ],
       "get": {
@@ -325,13 +314,7 @@
     "/definitiongroups/{groupId}/definitions/{resourceId}": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -624,101 +607,7 @@
     "/definitiongroups/{groupId}/definitions/{resourceId}/versions/{versionId}": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
-        },
-        {
-          "$ref": "#/components/parameters/resourceId"
-        },
-        {
-          "in": "query",
-          "name": "meta",
-          "description": "Interact with the metadata",
-          "required": false,
-          "allowEmptyValue": true,
-          "schema": {
-            "type": "boolean"
-          }
-        }
-      ],
-      "get": {
-        "operationId": "getResourceVersionsAll",
-        "description": "Get an optionally filtered collection of resources",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "inline",
-            "description": "Set if references shall be inlined",
-            "required": false,
-            "allowEmptyValue": true,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "query",
-            "name": "skip",
-            "description": "The number of resources to skip",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "top",
-            "description": "The number of resources to show",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "filter",
-            "description": "Filter criterion(s)",
-            "explode": true,
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of resource versions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "xregistry_resources.json#/definitions/resource"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/{groupType}/{groupId}/{resourceType}/{resourceId}/versions/{versionId}": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
-          "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -786,6 +675,11 @@
                 "schema": {
                   "type": "string",
                   "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
                 }
               }
             }

--- a/registry/schemas/xregistry_openapi_messagedefinition.json
+++ b/registry/schemas/xregistry_openapi_messagedefinition.json
@@ -14,7 +14,7 @@
   "paths": {
     "/": {
       "get": {
-        "operationId": "getAll",
+        "operationId": "getRootDocument",
         "description": "Gets the root document",
         "parameters": [
           {
@@ -22,8 +22,22 @@
             "name": "inline",
             "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -41,7 +55,7 @@
         }
       },
       "post": {
-        "operationId": "uploadDoc",
+        "operationId": "upsertDocument",
         "description": "Uploads a registry document and upserts its contents into the registry",
         "requestBody": {
           "description": "A request to create or update the discovery endpoint's collection of endpoints with the given endpoints",
@@ -68,6 +82,11 @@
       }
     },
     "/definitiongroups": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        }
+      ],
       "get": {
         "operationId": "getResourceGroupAll",
         "description": "Gets all entries of the resource group",
@@ -77,18 +96,22 @@
             "name": "inline",
             "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
               "type": "boolean"
             }
           },
           {
             "in": "query",
-            "name": "query",
-            "description": "Query expression",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
             "required": false,
             "schema": {
-              "type": "string",
-              "description": "Filter expression"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -110,49 +133,13 @@
             "description": "No groups found"
           }
         }
-      },
-      "post": {
-        "operationId": "postResourceGroup",
-        "requestBody": {
-          "description": "Create a new resource group",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "xregistry_messagedefinition_registry.json#/definitions/definitionGroup"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "The resulting resource group",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "xregistry_messagedefinition_registry.json#/definitions/definitionGroup"
-                }
-              }
-            },
-            "headers": {
-              "Location": {
-                "description": "The location of the created resource",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request - constraint failure"
-          },
-          "409": {
-            "description": "Conflict - epoch not greater"
-          }
-        }
       }
     },
-    "/definitiongroups/{groupId}": {
+    "/{groupType}/{groupId}": {
       "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
         {
           "$ref": "#/components/parameters/groupId"
         }
@@ -179,6 +166,19 @@
         }
       },
       "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be updated",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
         "operationId": "putResourceGroup",
         "description": "creates or updates the resource group",
         "requestBody": {
@@ -220,7 +220,7 @@
             "in": "query",
             "name": "epoch",
             "description": "The epoch of the resource group to be deleted",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "description": "A number representing the version number of the resource.",
@@ -244,7 +244,13 @@
     "/definitiongroups/{groupId}/definitions": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         }
       ],
       "get": {
@@ -253,55 +259,46 @@
         "parameters": [
           {
             "in": "query",
-            "name": "query",
-            "description": "Query expression",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
-              "type": "string",
-              "description": "Filter expression"
+              "type": "boolean"
             }
           },
           {
             "in": "query",
-            "name": "inline",
-            "description": "Set if references shall be inlined",
+            "name": "skip",
+            "description": "The number of resources to skip",
             "required": false,
             "schema": {
-              "type": "boolean"
+              "type": "integer"
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of resources (optionally matching the query parameter)",
-            "content": {
-              "application/json": {
+          },
+          {
+            "in": "query",
+            "name": "top",
+            "description": "The number of resources to show",
+            "required": false,
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
-                  }
-                }
-              }
-            }
-          }
+              "type": "integer"
         }
       },
-      "put": {
-        "operationId": "putResources",
-        "requestBody": {
-          "description": "A request to create or update the discovery group's collection of groups with the given group",
-          "content": {
-            "application/json": {
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
               "schema": {
-                "type": "object",
-                "additionalProperties": {
-                  "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+              "type": "array",
+              "items": {
+                "type": "string"
                 }
               }
             }
-          }
-        },
+        ],
         "responses": {
           "200": {
             "description": "Updated list of resources",
@@ -323,26 +320,18 @@
             "description": "Conflict - epoch not greater"
           }
         }
-      },
-      "delete": {
-        "operationId": "deleteResources",
-        "responses": {
-          "200": {
-            "description": "Ok"
-          },
-          "400": {
-            "description": "Bad Request - constraint failure"
-          },
-          "409": {
-            "description": "Conflict - epoch not greater"
-          }
-        }
-      }
+      }      
     },
     "/definitiongroups/{groupId}/definitions/{resourceId}": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -426,6 +415,71 @@
           },
           "404": {
             "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be upserted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/resource-description"
+          },
+          {
+            "$ref": "#/components/parameters/resource-docs"
+          },
+          {
+            "$ref": "#/components/parameters/resource-origin"
+          },
+          {
+            "$ref": "#/components/parameters/resource-tags"
+          }
+        ],
+        "summary": "Create or update a resource",
+        "description": "Create a resource. ",
+        "operationId": "putResource",
+        "requestBody": {
+          "description": "The resource to be created/updated",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
           }
         }
       },
@@ -546,7 +600,7 @@
             "in": "query",
             "name": "epoch",
             "description": "The epoch of the resource to be deleted",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "description": "A number representing the version number of the resource.",
@@ -570,7 +624,101 @@
     "/definitiongroups/{groupId}/definitions/{resourceId}/versions/{versionId}": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "allowEmptyValue": true,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResourceVersionsAll",
+        "description": "Get an optionally filtered collection of resources",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "skip",
+            "description": "The number of resources to skip",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "top",
+            "description": "The number of resources to show",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resource versions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_resources.json#/definitions/resource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{groupType}/{groupId}/{resourceType}/{resourceId}/versions/{versionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -583,6 +731,7 @@
           "name": "meta",
           "description": "Interact with the metadata",
           "required": false,
+          "allowEmptyValue": true,
           "schema": {
             "type": "boolean"
           }
@@ -649,11 +798,72 @@
           }
         }
       },
+      "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be updated",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "operationId": "updateResourceVersion",
+        "description": "Updates the metadata for the schema version",
+        "requestBody": {
+          "description": "The schema version document",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The schema version metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict"
+          }
+        }
+      },
       "delete": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
         "operationId": "deleteResourceVersion",
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "Ok"
           },
           "400": {
             "description": "Bad Request - constraint failure"
@@ -674,6 +884,24 @@
       }
     },
     "parameters": {
+      "groupType": {
+        "in": "path",
+        "name": "groupType",
+        "description": "The groupType (plural)",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resourceType": {
+        "in": "path",
+        "name": "id",
+        "description": "The resourceType (plural)",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
       "id": {
         "in": "path",
         "name": "id",
@@ -730,7 +958,7 @@
         "in": "header",
         "name": "resource-id",
         "required": false,
-        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "description": "A unique identifier for this resource. This value MUST be globally unique",
         "schema": {
           "type": "string",
           "format": "uri-reference"
@@ -750,7 +978,7 @@
         "in": "header",
         "name": "resource-self",
         "required": false,
-        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "description": "A unique URI for the resource.",
         "schema": {
           "type": "string",
           "format": "uri"

--- a/registry/schemas/xregistry_openapi_messagedefinition.json
+++ b/registry/schemas/xregistry_openapi_messagedefinition.json
@@ -1,0 +1,960 @@
+{
+  "openapi": "3.0.6",
+  "info": {
+    "title": "xRegistry API",
+    "description": "xRegistry API",
+    "version": "0.5-wip"
+  },
+  "servers": [],
+  "security": [
+    {
+      "api_key": []
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "getAll",
+        "description": "Gets the root document",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The root document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_messagedefinition_registry.json"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "uploadDoc",
+        "description": "Uploads a registry document and upserts its contents into the registry",
+        "requestBody": {
+          "description": "A request to create or update the discovery endpoint's collection of endpoints with the given endpoints",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_messagedefinition_registry.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The resulting document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_messagedefinition_registry.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/definitiongroups": {
+      "get": {
+        "operationId": "getResourceGroupAll",
+        "description": "Gets all entries of the resource group",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "description": "Query expression",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter expression"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource groups that match the query or all available resource groups if no query was specified",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_messagedefinition_registry.json#/definitions/definitionGroup"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No groups found"
+          }
+        }
+      },
+      "post": {
+        "operationId": "postResourceGroup",
+        "requestBody": {
+          "description": "Create a new resource group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_messagedefinition_registry.json#/definitions/definitionGroup"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The resulting resource group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_messagedefinition_registry.json#/definitions/definitionGroup"
+                }
+              }
+            },
+            "headers": {
+              "Location": {
+                "description": "The location of the created resource",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/definitiongroups/{groupId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        }
+      ],
+      "get": {
+        "operationId": "getResourceGroup",
+        "responses": {
+          "200": {
+            "description": "The resource group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_messagedefinition_registry.json#/definitions/definitionGroup"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "operationId": "putResourceGroup",
+        "description": "creates or updates the resource group",
+        "requestBody": {
+          "description": "A request to create or update the discovery group's collection of groups with the given group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_messagedefinition_registry.json#/definitions/definitionGroup"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_messagedefinition_registry.json#/definitions/definitionGroup"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResourceGroup",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Ok"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/definitiongroups/{groupId}/definitions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        }
+      ],
+      "get": {
+        "operationId": "getResourcesAll",
+        "description": "Get an optionally filtered collection of resources",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "description": "Query expression",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter expression"
+            }
+          },
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resources (optionally matching the query parameter)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "putResources",
+        "requestBody": {
+          "description": "A request to create or update the discovery group's collection of groups with the given group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated list of resources",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                     "$ref": "xregistry_messagedefinition_definition.json#/definitions/definition"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResources",
+        "responses": {
+          "200": {
+            "description": "Ok"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/definitiongroups/{groupId}/definitions/{resourceId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResource",
+        "responses": {
+          "200": {
+            "description": "The corresponding resource",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              },
+              "Content-Location": {
+                "description": "permalink location of the returned version",
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "summary": "Post new resource version",
+        "description": "Register resource version If resource of specified name does not exist in specified group, resource and resource version is created at version 1. If resource of specified name exists already in specified group, resource is created at latest version + 1. If resource with identical content already exists, existing resource's ID is returned. \n",
+        "operationId": "postResource",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/resource-description"
+          },
+          {
+            "$ref": "#/components/parameters/resource-docs"
+          },
+          {
+            "$ref": "#/components/parameters/resource-origin"
+          },
+          {
+            "$ref": "#/components/parameters/resource-tags"
+          },
+          {
+            "in": "header",
+            "description": "format",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "A request to add a new resource to the version collection",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created resource",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete resource",
+        "description": "Delete resource",
+        "operationId": "deleteResource",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/definitiongroups/{groupId}/definitions/{resourceId}/versions/{versionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "$ref": "#/components/parameters/versionId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResourceVersion",
+        "description": "Gets the document stored for the schema version",
+        "responses": {
+          "200": {
+            "description": "The schema version document",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResourceVersion",
+        "responses": {
+          "204": {
+            "description": "No content"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "code",
+        "in": "query"
+      }
+    },
+    "parameters": {
+      "id": {
+        "in": "path",
+        "name": "id",
+        "description": "The id of the endpoint",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "groupId": {
+        "in": "path",
+        "name": "groupId",
+        "description": "The id of the group",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "resourceId": {
+        "in": "path",
+        "name": "resourceId",
+        "description": "The id of the schema",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "versionId": {
+        "in": "path",
+        "name": "versionId",
+        "description": "The id of the schema",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "resource-type": {
+        "in": "header",
+        "name": "resource-type",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-id": {
+        "in": "header",
+        "name": "resource-id",
+        "required": false,
+        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-version": {
+        "in": "header",
+        "name": "resource-version",
+        "required": false,
+        "description": "A number representing the version number of the resource.",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "resource-self": {
+        "in": "header",
+        "name": "resource-self",
+        "required": false,
+        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-description": {
+        "in": "header",
+        "name": "resource-description",
+        "required": false,
+        "description": "A summary of the purpose of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-name": {
+        "in": "header",
+        "name": "resource-name",
+        "required": false,
+        "description": "The name of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-docs": {
+        "in": "header",
+        "required": false,
+        "name": "resource-docs",
+        "description": "Absolute URL that provides a link to additional documentation about the resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-origin": {
+        "in": "header",
+        "required": false,
+        "name": "resource-origin",
+        "description": "A URI reference to the original source of this resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-tags": {
+        "in": "header",
+        "name": "resource-tags",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/resource-tag"
+          }
+        }
+      },
+      "resource-createdby": {
+        "in": "header",
+        "name": "resource-createdby",
+        "required": false,
+        "description": "Identity of who created this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-createdon": {
+        "in": "header",
+        "name": "resource-createdon",
+        "required": false,
+        "description": "Time when this entity was created",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "resource-modifiedby": {
+        "in": "header",
+        "name": "resource-modifiedby",
+        "required": false,
+        "description": "Identity of who last modified this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-modifiedon": {
+        "in": "header",
+        "name": "resource-modifiedon",
+        "required": false,
+        "description": "Time when this entity was last modified",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "headers": {
+      "resource-type": {
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-id": {
+        "required": false,
+        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-version": {
+        "required": false,
+        "description": "A number representing the version number of the resource.",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "resource-self": {
+        "required": false,
+        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-description": {
+        "required": false,
+        "description": "A summary of the purpose of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-name": {
+        "required": false,
+        "description": "The name of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-docs": {
+        "description": "Absolute URL that provides a link to additional documentation about the resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-origin": {
+        "description": "A URI reference to the original source of this resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-tags": {
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/resource-tag"
+          }
+        }
+      },
+      "resource-createdby": {
+        "required": false,
+        "description": "Identity of who created this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-createdon": {
+        "required": false,
+        "description": "Time when this entity was created",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "resource-modifiedby": {
+        "required": false,
+        "description": "Identity of who last modified this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-modifiedon": {
+        "required": false,
+        "description": "Time when this entity was last modified",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "schemas": {
+      "resource-tag": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/registry/schemas/xregistry_openapi_schema.json
+++ b/registry/schemas/xregistry_openapi_schema.json
@@ -14,7 +14,7 @@
   "paths": {
     "/": {
       "get": {
-        "operationId": "getAll",
+        "operationId": "getRootDocument",
         "description": "Gets the root document",
         "parameters": [
           {
@@ -22,8 +22,22 @@
             "name": "inline",
             "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -41,7 +55,7 @@
         }
       },
       "post": {
-        "operationId": "uploadDoc",
+        "operationId": "upsertDocument",
         "description": "Uploads a registry document and upserts its contents into the registry",
         "requestBody": {
           "description": "A request to create or update the discovery endpoint's collection of endpoints with the given endpoints",
@@ -68,6 +82,11 @@
       }
     },
     "/schemagroups": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        }
+      ],
       "get": {
         "operationId": "getResourceGroupAll",
         "description": "Gets all entries of the resource group",
@@ -77,18 +96,22 @@
             "name": "inline",
             "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
               "type": "boolean"
             }
           },
           {
             "in": "query",
-            "name": "query",
-            "description": "Query expression",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
             "required": false,
             "schema": {
-              "type": "string",
-              "description": "Filter expression"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -110,49 +133,13 @@
             "description": "No groups found"
           }
         }
-      },
-      "post": {
-        "operationId": "postResourceGroup",
-        "requestBody": {
-          "description": "Create a new resource group",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "xregistry_schema_registry.json#/definitions/schemaGroup"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "The resulting resource group",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "xregistry_schema_registry.json#/definitions/schemaGroup"
-                }
-              }
-            },
-            "headers": {
-              "Location": {
-                "description": "The location of the created resource",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request - constraint failure"
-          },
-          "409": {
-            "description": "Conflict - epoch not greater"
-          }
-        }
       }
     },
-    "/schemagroups/{groupId}": {
+    "/{groupType}/{groupId}": {
       "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
         {
           "$ref": "#/components/parameters/groupId"
         }
@@ -179,6 +166,19 @@
         }
       },
       "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be updated",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
         "operationId": "putResourceGroup",
         "description": "creates or updates the resource group",
         "requestBody": {
@@ -220,7 +220,7 @@
             "in": "query",
             "name": "epoch",
             "description": "The epoch of the resource group to be deleted",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "description": "A number representing the version number of the resource.",
@@ -244,7 +244,13 @@
     "/schemagroups/{groupId}/schemas": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         }
       ],
       "get": {
@@ -253,55 +259,46 @@
         "parameters": [
           {
             "in": "query",
-            "name": "query",
-            "description": "Query expression",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
-              "type": "string",
-              "description": "Filter expression"
+              "type": "boolean"
             }
           },
           {
             "in": "query",
-            "name": "inline",
-            "description": "Set if references shall be inlined",
+            "name": "skip",
+            "description": "The number of resources to skip",
             "required": false,
             "schema": {
-              "type": "boolean"
+              "type": "integer"
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of resources (optionally matching the query parameter)",
-            "content": {
-              "application/json": {
+          },
+          {
+            "in": "query",
+            "name": "top",
+            "description": "The number of resources to show",
+            "required": false,
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "xregistry_schema_registry.json#/definitions/schema"
-                  }
-                }
-              }
-            }
-          }
+              "type": "integer"
         }
       },
-      "put": {
-        "operationId": "putResources",
-        "requestBody": {
-          "description": "A request to create or update the discovery group's collection of groups with the given group",
-          "content": {
-            "application/json": {
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
               "schema": {
-                "type": "object",
-                "additionalProperties": {
-                  "$ref": "xregistry_schema_registry.json#/definitions/schema"
+              "type": "array",
+              "items": {
+                "type": "string"
                 }
               }
             }
-          }
-        },
+        ],
         "responses": {
           "200": {
             "description": "Updated list of resources",
@@ -323,26 +320,18 @@
             "description": "Conflict - epoch not greater"
           }
         }
-      },
-      "delete": {
-        "operationId": "deleteResources",
-        "responses": {
-          "200": {
-            "description": "Ok"
-          },
-          "400": {
-            "description": "Bad Request - constraint failure"
-          },
-          "409": {
-            "description": "Conflict - epoch not greater"
-          }
-        }
-      }
+      }      
     },
     "/schemagroups/{groupId}/schemas/{resourceId}": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -426,6 +415,71 @@
           },
           "404": {
             "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be upserted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/resource-description"
+          },
+          {
+            "$ref": "#/components/parameters/resource-docs"
+          },
+          {
+            "$ref": "#/components/parameters/resource-origin"
+          },
+          {
+            "$ref": "#/components/parameters/resource-tags"
+          }
+        ],
+        "summary": "Create or update a resource",
+        "description": "Create a resource. ",
+        "operationId": "putResource",
+        "requestBody": {
+          "description": "The resource to be created/updated",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
           }
         }
       },
@@ -546,7 +600,7 @@
             "in": "query",
             "name": "epoch",
             "description": "The epoch of the resource to be deleted",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "description": "A number representing the version number of the resource.",
@@ -570,7 +624,101 @@
     "/schemagroups/{groupId}/schemas/{resourceId}/versions/{versionId}": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "allowEmptyValue": true,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResourceVersionsAll",
+        "description": "Get an optionally filtered collection of resources",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "skip",
+            "description": "The number of resources to skip",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "top",
+            "description": "The number of resources to show",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resource versions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_resources.json#/definitions/resource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{groupType}/{groupId}/{resourceType}/{resourceId}/versions/{versionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -583,6 +731,7 @@
           "name": "meta",
           "description": "Interact with the metadata",
           "required": false,
+          "allowEmptyValue": true,
           "schema": {
             "type": "boolean"
           }
@@ -649,11 +798,72 @@
           }
         }
       },
+      "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be updated",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "operationId": "updateResourceVersion",
+        "description": "Updates the metadata for the schema version",
+        "requestBody": {
+          "description": "The schema version document",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The schema version metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict"
+          }
+        }
+      },
       "delete": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
         "operationId": "deleteResourceVersion",
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "Ok"
           },
           "400": {
             "description": "Bad Request - constraint failure"
@@ -674,6 +884,24 @@
       }
     },
     "parameters": {
+      "groupType": {
+        "in": "path",
+        "name": "groupType",
+        "description": "The groupType (plural)",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resourceType": {
+        "in": "path",
+        "name": "id",
+        "description": "The resourceType (plural)",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
       "id": {
         "in": "path",
         "name": "id",
@@ -730,7 +958,7 @@
         "in": "header",
         "name": "resource-id",
         "required": false,
-        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "description": "A unique identifier for this resource. This value MUST be globally unique",
         "schema": {
           "type": "string",
           "format": "uri-reference"
@@ -750,7 +978,7 @@
         "in": "header",
         "name": "resource-self",
         "required": false,
-        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "description": "A unique URI for the resource.",
         "schema": {
           "type": "string",
           "format": "uri"

--- a/registry/schemas/xregistry_openapi_schema.json
+++ b/registry/schemas/xregistry_openapi_schema.json
@@ -1,0 +1,960 @@
+{
+  "openapi": "3.0.6",
+  "info": {
+    "title": "xRegistry API",
+    "description": "xRegistry API",
+    "version": "0.5-wip"
+  },
+  "servers": [],
+  "security": [
+    {
+      "api_key": []
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "getAll",
+        "description": "Gets the root document",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The root document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_schema_registry.json"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "uploadDoc",
+        "description": "Uploads a registry document and upserts its contents into the registry",
+        "requestBody": {
+          "description": "A request to create or update the discovery endpoint's collection of endpoints with the given endpoints",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_schema_registry.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The resulting document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_schema_registry.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/schemagroups": {
+      "get": {
+        "operationId": "getResourceGroupAll",
+        "description": "Gets all entries of the resource group",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "description": "Query expression",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter expression"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource groups that match the query or all available resource groups if no query was specified",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_schema_registry.json#/definitions/schemaGroup"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No groups found"
+          }
+        }
+      },
+      "post": {
+        "operationId": "postResourceGroup",
+        "requestBody": {
+          "description": "Create a new resource group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_schema_registry.json#/definitions/schemaGroup"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The resulting resource group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_schema_registry.json#/definitions/schemaGroup"
+                }
+              }
+            },
+            "headers": {
+              "Location": {
+                "description": "The location of the created resource",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/schemagroups/{groupId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        }
+      ],
+      "get": {
+        "operationId": "getResourceGroup",
+        "responses": {
+          "200": {
+            "description": "The resource group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_schema_registry.json#/definitions/schemaGroup"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "operationId": "putResourceGroup",
+        "description": "creates or updates the resource group",
+        "requestBody": {
+          "description": "A request to create or update the discovery group's collection of groups with the given group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_schema_registry.json#/definitions/schemaGroup"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_schema_registry.json#/definitions/schemaGroup"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResourceGroup",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Ok"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/schemagroups/{groupId}/schemas": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        }
+      ],
+      "get": {
+        "operationId": "getResourcesAll",
+        "description": "Get an optionally filtered collection of resources",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "description": "Query expression",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter expression"
+            }
+          },
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resources (optionally matching the query parameter)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_schema_registry.json#/definitions/schema"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "putResources",
+        "requestBody": {
+          "description": "A request to create or update the discovery group's collection of groups with the given group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "xregistry_schema_registry.json#/definitions/schema"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated list of resources",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                     "$ref": "xregistry_schema_registry.json#/definitions/schema"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResources",
+        "responses": {
+          "200": {
+            "description": "Ok"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/schemagroups/{groupId}/schemas/{resourceId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResource",
+        "responses": {
+          "200": {
+            "description": "The corresponding resource",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              },
+              "Content-Location": {
+                "description": "permalink location of the returned version",
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "summary": "Post new resource version",
+        "description": "Register resource version If resource of specified name does not exist in specified group, resource and resource version is created at version 1. If resource of specified name exists already in specified group, resource is created at latest version + 1. If resource with identical content already exists, existing resource's ID is returned. \n",
+        "operationId": "postResource",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/resource-description"
+          },
+          {
+            "$ref": "#/components/parameters/resource-docs"
+          },
+          {
+            "$ref": "#/components/parameters/resource-origin"
+          },
+          {
+            "$ref": "#/components/parameters/resource-tags"
+          },
+          {
+            "in": "header",
+            "description": "format",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "A request to add a new resource to the version collection",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created resource",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete resource",
+        "description": "Delete resource",
+        "operationId": "deleteResource",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/schemagroups/{groupId}/schemas/{resourceId}/versions/{versionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "$ref": "#/components/parameters/versionId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResourceVersion",
+        "description": "Gets the document stored for the schema version",
+        "responses": {
+          "200": {
+            "description": "The schema version document",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResourceVersion",
+        "responses": {
+          "204": {
+            "description": "No content"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "code",
+        "in": "query"
+      }
+    },
+    "parameters": {
+      "id": {
+        "in": "path",
+        "name": "id",
+        "description": "The id of the endpoint",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "groupId": {
+        "in": "path",
+        "name": "groupId",
+        "description": "The id of the group",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "resourceId": {
+        "in": "path",
+        "name": "resourceId",
+        "description": "The id of the schema",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "versionId": {
+        "in": "path",
+        "name": "versionId",
+        "description": "The id of the schema",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "resource-type": {
+        "in": "header",
+        "name": "resource-type",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-id": {
+        "in": "header",
+        "name": "resource-id",
+        "required": false,
+        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-version": {
+        "in": "header",
+        "name": "resource-version",
+        "required": false,
+        "description": "A number representing the version number of the resource.",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "resource-self": {
+        "in": "header",
+        "name": "resource-self",
+        "required": false,
+        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-description": {
+        "in": "header",
+        "name": "resource-description",
+        "required": false,
+        "description": "A summary of the purpose of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-name": {
+        "in": "header",
+        "name": "resource-name",
+        "required": false,
+        "description": "The name of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-docs": {
+        "in": "header",
+        "required": false,
+        "name": "resource-docs",
+        "description": "Absolute URL that provides a link to additional documentation about the resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-origin": {
+        "in": "header",
+        "required": false,
+        "name": "resource-origin",
+        "description": "A URI reference to the original source of this resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-tags": {
+        "in": "header",
+        "name": "resource-tags",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/resource-tag"
+          }
+        }
+      },
+      "resource-createdby": {
+        "in": "header",
+        "name": "resource-createdby",
+        "required": false,
+        "description": "Identity of who created this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-createdon": {
+        "in": "header",
+        "name": "resource-createdon",
+        "required": false,
+        "description": "Time when this entity was created",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "resource-modifiedby": {
+        "in": "header",
+        "name": "resource-modifiedby",
+        "required": false,
+        "description": "Identity of who last modified this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-modifiedon": {
+        "in": "header",
+        "name": "resource-modifiedon",
+        "required": false,
+        "description": "Time when this entity was last modified",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "headers": {
+      "resource-type": {
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-id": {
+        "required": false,
+        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-version": {
+        "required": false,
+        "description": "A number representing the version number of the resource.",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "resource-self": {
+        "required": false,
+        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-description": {
+        "required": false,
+        "description": "A summary of the purpose of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-name": {
+        "required": false,
+        "description": "The name of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-docs": {
+        "description": "Absolute URL that provides a link to additional documentation about the resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-origin": {
+        "description": "A URI reference to the original source of this resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-tags": {
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/resource-tag"
+          }
+        }
+      },
+      "resource-createdby": {
+        "required": false,
+        "description": "Identity of who created this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-createdon": {
+        "required": false,
+        "description": "Time when this entity was created",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "resource-modifiedby": {
+        "required": false,
+        "description": "Identity of who last modified this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-modifiedon": {
+        "required": false,
+        "description": "Time when this entity was last modified",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "schemas": {
+      "resource-tag": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/registry/schemas/xregistry_openapi_schema.json
+++ b/registry/schemas/xregistry_openapi_schema.json
@@ -83,9 +83,7 @@
     },
     "/schemagroups": {
       "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        }
+        
       ],
       "get": {
         "operationId": "getResourceGroupAll",
@@ -135,11 +133,8 @@
         }
       }
     },
-    "/{groupType}/{groupId}": {
+    "/schemagroups/{groupId}": {
       "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        },
         {
           "$ref": "#/components/parameters/groupId"
         }
@@ -244,13 +239,7 @@
     "/schemagroups/{groupId}/schemas": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         }
       ],
       "get": {
@@ -325,13 +314,7 @@
     "/schemagroups/{groupId}/schemas/{resourceId}": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -624,101 +607,7 @@
     "/schemagroups/{groupId}/schemas/{resourceId}/versions/{versionId}": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
-        },
-        {
-          "$ref": "#/components/parameters/resourceId"
-        },
-        {
-          "in": "query",
-          "name": "meta",
-          "description": "Interact with the metadata",
-          "required": false,
-          "allowEmptyValue": true,
-          "schema": {
-            "type": "boolean"
-          }
-        }
-      ],
-      "get": {
-        "operationId": "getResourceVersionsAll",
-        "description": "Get an optionally filtered collection of resources",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "inline",
-            "description": "Set if references shall be inlined",
-            "required": false,
-            "allowEmptyValue": true,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "query",
-            "name": "skip",
-            "description": "The number of resources to skip",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "top",
-            "description": "The number of resources to show",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "filter",
-            "description": "Filter criterion(s)",
-            "explode": true,
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of resource versions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "xregistry_resources.json#/definitions/resource"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/{groupType}/{groupId}/{resourceType}/{resourceId}/versions/{versionId}": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
-          "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -786,6 +675,11 @@
                 "schema": {
                   "type": "string",
                   "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
                 }
               }
             }

--- a/registry/schemas/xregistry_openapi_template.json
+++ b/registry/schemas/xregistry_openapi_template.json
@@ -83,9 +83,7 @@
     },
     "/{%-groupNamePlural-%}": {
       "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        }
+        
       ],
       "get": {
         "operationId": "getResourceGroupAll",
@@ -135,11 +133,8 @@
         }
       }
     },
-    "/{groupType}/{groupId}": {
+    "/{%-groupNamePlural-%}/{groupId}": {
       "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        },
         {
           "$ref": "#/components/parameters/groupId"
         }
@@ -244,13 +239,7 @@
     "/{%-groupNamePlural-%}/{groupId}/{%-resourceNamePlural-%}": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         }
       ],
       "get": {
@@ -325,13 +314,7 @@
     "/{%-groupNamePlural-%}/{groupId}/{%-resourceNamePlural-%}/{resourceId}": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -624,101 +607,7 @@
     "/{%-groupNamePlural-%}/{groupId}/{%-resourceNamePlural-%}/{resourceId}/versions/{versionId}": {
       "parameters": [
         {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
           "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
-        },
-        {
-          "$ref": "#/components/parameters/resourceId"
-        },
-        {
-          "in": "query",
-          "name": "meta",
-          "description": "Interact with the metadata",
-          "required": false,
-          "allowEmptyValue": true,
-          "schema": {
-            "type": "boolean"
-          }
-        }
-      ],
-      "get": {
-        "operationId": "getResourceVersionsAll",
-        "description": "Get an optionally filtered collection of resources",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "inline",
-            "description": "Set if references shall be inlined",
-            "required": false,
-            "allowEmptyValue": true,
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "query",
-            "name": "skip",
-            "description": "The number of resources to skip",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "top",
-            "description": "The number of resources to show",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "filter",
-            "description": "Filter criterion(s)",
-            "explode": true,
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of resource versions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "xregistry_resources.json#/definitions/resource"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/{groupType}/{groupId}/{resourceType}/{resourceId}/versions/{versionId}": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/groupType"
-        },
-        {
-          "$ref": "#/components/parameters/groupId"
-        },
-        {
-          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -786,6 +675,11 @@
                 "schema": {
                   "type": "string",
                   "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
                 }
               }
             }

--- a/registry/schemas/xregistry_openapi_template.json
+++ b/registry/schemas/xregistry_openapi_template.json
@@ -1,0 +1,960 @@
+{
+  "openapi": "3.0.6",
+  "info": {
+    "title": "xRegistry API",
+    "description": "xRegistry API",
+    "version": "0.5-wip"
+  },
+  "servers": [],
+  "security": [
+    {
+      "api_key": []
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "getAll",
+        "description": "Gets the root document",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The root document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "{%-documentTypeReference-%}"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "uploadDoc",
+        "description": "Uploads a registry document and upserts its contents into the registry",
+        "requestBody": {
+          "description": "A request to create or update the discovery endpoint's collection of endpoints with the given endpoints",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "{%-documentTypeReference-%}"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The resulting document",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "{%-documentTypeReference-%}"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{%-groupNamePlural-%}": {
+      "get": {
+        "operationId": "getResourceGroupAll",
+        "description": "Gets all entries of the resource group",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "description": "Query expression",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter expression"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource groups that match the query or all available resource groups if no query was specified",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "{%-groupTypeReference-%}"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No groups found"
+          }
+        }
+      },
+      "post": {
+        "operationId": "postResourceGroup",
+        "requestBody": {
+          "description": "Create a new resource group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "{%-groupTypeReference-%}"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The resulting resource group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "{%-groupTypeReference-%}"
+                }
+              }
+            },
+            "headers": {
+              "Location": {
+                "description": "The location of the created resource",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/{%-groupNamePlural-%}/{groupId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        }
+      ],
+      "get": {
+        "operationId": "getResourceGroup",
+        "responses": {
+          "200": {
+            "description": "The resource group",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "{%-groupTypeReference-%}"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "operationId": "putResourceGroup",
+        "description": "creates or updates the resource group",
+        "requestBody": {
+          "description": "A request to create or update the discovery group's collection of groups with the given group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "{%-groupTypeReference-%}"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "{%-groupTypeReference-%}"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResourceGroup",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Ok"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/{%-groupNamePlural-%}/{groupId}/{%-resourceNamePlural-%}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        }
+      ],
+      "get": {
+        "operationId": "getResourcesAll",
+        "description": "Get an optionally filtered collection of resources",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "query",
+            "description": "Query expression",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter expression"
+            }
+          },
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resources (optionally matching the query parameter)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "{%-resourceTypeReference-%}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "putResources",
+        "requestBody": {
+          "description": "A request to create or update the discovery group's collection of groups with the given group",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "{%-resourceTypeReference-%}"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated list of resources",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                     "$ref": "{%-resourceTypeReference-%}"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResources",
+        "responses": {
+          "200": {
+            "description": "Ok"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    },
+    "/{%-groupNamePlural-%}/{groupId}/{%-resourceNamePlural-%}/{resourceId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResource",
+        "responses": {
+          "200": {
+            "description": "The corresponding resource",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              },
+              "Content-Location": {
+                "description": "permalink location of the returned version",
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "post": {
+        "summary": "Post new resource version",
+        "description": "Register resource version If resource of specified name does not exist in specified group, resource and resource version is created at version 1. If resource of specified name exists already in specified group, resource is created at latest version + 1. If resource with identical content already exists, existing resource's ID is returned. \n",
+        "operationId": "postResource",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/resource-description"
+          },
+          {
+            "$ref": "#/components/parameters/resource-docs"
+          },
+          {
+            "$ref": "#/components/parameters/resource-origin"
+          },
+          {
+            "$ref": "#/components/parameters/resource-tags"
+          },
+          {
+            "in": "header",
+            "description": "format",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "A request to add a new resource to the version collection",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "The created resource",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete resource",
+        "description": "Delete resource",
+        "operationId": "deleteResource",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/{%-groupNamePlural-%}/{groupId}/{%-resourceNamePlural-%}/{resourceId}/versions/{versionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "$ref": "#/components/parameters/versionId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResourceVersion",
+        "description": "Gets the document stored for the schema version",
+        "responses": {
+          "200": {
+            "description": "The schema version document",
+            "headers": {
+              "resource-id": {
+                "$ref": "#/components/headers/resource-id"
+              },
+              "resource-version": {
+                "$ref": "#/components/headers/resource-version"
+              },
+              "resource-name": {
+                "$ref": "#/components/headers/resource-name"
+              },
+              "resource-self": {
+                "$ref": "#/components/headers/resource-self"
+              },
+              "resource-description": {
+                "$ref": "#/components/headers/resource-description"
+              },
+              "resource-docs": {
+                "$ref": "#/components/headers/resource-docs"
+              },
+              "resource-origin": {
+                "$ref": "#/components/headers/resource-origin"
+              },
+              "resource-tags": {
+                "$ref": "#/components/headers/resource-tags"
+              },
+              "resource-createdby": {
+                "$ref": "#/components/headers/resource-createdby"
+              },
+              "resource-createdon": {
+                "$ref": "#/components/headers/resource-createdon"
+              },
+              "resource-modifiedby": {
+                "$ref": "#/components/headers/resource-modifiedby"
+              },
+              "resource-modifiedon": {
+                "$ref": "#/components/headers/resource-modifiedon"
+              }
+            },
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteResourceVersion",
+        "responses": {
+          "204": {
+            "description": "No content"
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "code",
+        "in": "query"
+      }
+    },
+    "parameters": {
+      "id": {
+        "in": "path",
+        "name": "id",
+        "description": "The id of the endpoint",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "groupId": {
+        "in": "path",
+        "name": "groupId",
+        "description": "The id of the group",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "resourceId": {
+        "in": "path",
+        "name": "resourceId",
+        "description": "The id of the schema",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "versionId": {
+        "in": "path",
+        "name": "versionId",
+        "description": "The id of the schema",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "description": "A unique identifier",
+          "format": "uri-reference"
+        }
+      },
+      "resource-type": {
+        "in": "header",
+        "name": "resource-type",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-id": {
+        "in": "header",
+        "name": "resource-id",
+        "required": false,
+        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-version": {
+        "in": "header",
+        "name": "resource-version",
+        "required": false,
+        "description": "A number representing the version number of the resource.",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "resource-self": {
+        "in": "header",
+        "name": "resource-self",
+        "required": false,
+        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-description": {
+        "in": "header",
+        "name": "resource-description",
+        "required": false,
+        "description": "A summary of the purpose of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-name": {
+        "in": "header",
+        "name": "resource-name",
+        "required": false,
+        "description": "The name of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-docs": {
+        "in": "header",
+        "required": false,
+        "name": "resource-docs",
+        "description": "Absolute URL that provides a link to additional documentation about the resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-origin": {
+        "in": "header",
+        "required": false,
+        "name": "resource-origin",
+        "description": "A URI reference to the original source of this resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-tags": {
+        "in": "header",
+        "name": "resource-tags",
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/resource-tag"
+          }
+        }
+      },
+      "resource-createdby": {
+        "in": "header",
+        "name": "resource-createdby",
+        "required": false,
+        "description": "Identity of who created this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-createdon": {
+        "in": "header",
+        "name": "resource-createdon",
+        "required": false,
+        "description": "Time when this entity was created",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "resource-modifiedby": {
+        "in": "header",
+        "name": "resource-modifiedby",
+        "required": false,
+        "description": "Identity of who last modified this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-modifiedon": {
+        "in": "header",
+        "name": "resource-modifiedon",
+        "required": false,
+        "description": "Time when this entity was last modified",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "headers": {
+      "resource-type": {
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-id": {
+        "required": false,
+        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-version": {
+        "required": false,
+        "description": "A number representing the version number of the resource.",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "resource-self": {
+        "required": false,
+        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-description": {
+        "required": false,
+        "description": "A summary of the purpose of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-name": {
+        "required": false,
+        "description": "The name of the resource.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-docs": {
+        "description": "Absolute URL that provides a link to additional documentation about the resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "resource-origin": {
+        "description": "A URI reference to the original source of this resource.",
+        "schema": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "resource-tags": {
+        "required": false,
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/resource-tag"
+          }
+        }
+      },
+      "resource-createdby": {
+        "required": false,
+        "description": "Identity of who created this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-createdon": {
+        "required": false,
+        "description": "Time when this entity was created",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "resource-modifiedby": {
+        "required": false,
+        "description": "Identity of who last modified this entity",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resource-modifiedon": {
+        "required": false,
+        "description": "Time when this entity was last modified",
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "schemas": {
+      "resource-tag": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/registry/schemas/xregistry_openapi_template.json
+++ b/registry/schemas/xregistry_openapi_template.json
@@ -14,7 +14,7 @@
   "paths": {
     "/": {
       "get": {
-        "operationId": "getAll",
+        "operationId": "getRootDocument",
         "description": "Gets the root document",
         "parameters": [
           {
@@ -22,8 +22,22 @@
             "name": "inline",
             "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
               "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -41,7 +55,7 @@
         }
       },
       "post": {
-        "operationId": "uploadDoc",
+        "operationId": "upsertDocument",
         "description": "Uploads a registry document and upserts its contents into the registry",
         "requestBody": {
           "description": "A request to create or update the discovery endpoint's collection of endpoints with the given endpoints",
@@ -68,6 +82,11 @@
       }
     },
     "/{%-groupNamePlural-%}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        }
+      ],
       "get": {
         "operationId": "getResourceGroupAll",
         "description": "Gets all entries of the resource group",
@@ -77,18 +96,22 @@
             "name": "inline",
             "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
               "type": "boolean"
             }
           },
           {
             "in": "query",
-            "name": "query",
-            "description": "Query expression",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
             "required": false,
             "schema": {
-              "type": "string",
-              "description": "Filter expression"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -110,49 +133,13 @@
             "description": "No groups found"
           }
         }
-      },
-      "post": {
-        "operationId": "postResourceGroup",
-        "requestBody": {
-          "description": "Create a new resource group",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "{%-groupTypeReference-%}"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "The resulting resource group",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "{%-groupTypeReference-%}"
-                }
-              }
-            },
-            "headers": {
-              "Location": {
-                "description": "The location of the created resource",
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request - constraint failure"
-          },
-          "409": {
-            "description": "Conflict - epoch not greater"
-          }
-        }
       }
     },
-    "/{%-groupNamePlural-%}/{groupId}": {
+    "/{groupType}/{groupId}": {
       "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
         {
           "$ref": "#/components/parameters/groupId"
         }
@@ -179,6 +166,19 @@
         }
       },
       "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be updated",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
         "operationId": "putResourceGroup",
         "description": "creates or updates the resource group",
         "requestBody": {
@@ -220,7 +220,7 @@
             "in": "query",
             "name": "epoch",
             "description": "The epoch of the resource group to be deleted",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "description": "A number representing the version number of the resource.",
@@ -244,7 +244,13 @@
     "/{%-groupNamePlural-%}/{groupId}/{%-resourceNamePlural-%}": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         }
       ],
       "get": {
@@ -253,55 +259,46 @@
         "parameters": [
           {
             "in": "query",
-            "name": "query",
-            "description": "Query expression",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
             "required": false,
+            "allowEmptyValue": true,
             "schema": {
-              "type": "string",
-              "description": "Filter expression"
+              "type": "boolean"
             }
           },
           {
             "in": "query",
-            "name": "inline",
-            "description": "Set if references shall be inlined",
+            "name": "skip",
+            "description": "The number of resources to skip",
             "required": false,
             "schema": {
-              "type": "boolean"
+              "type": "integer"
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A list of resources (optionally matching the query parameter)",
-            "content": {
-              "application/json": {
+          },
+          {
+            "in": "query",
+            "name": "top",
+            "description": "The number of resources to show",
+            "required": false,
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "{%-resourceTypeReference-%}"
-                  }
-                }
-              }
-            }
-          }
+              "type": "integer"
         }
       },
-      "put": {
-        "operationId": "putResources",
-        "requestBody": {
-          "description": "A request to create or update the discovery group's collection of groups with the given group",
-          "content": {
-            "application/json": {
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
               "schema": {
-                "type": "object",
-                "additionalProperties": {
-                  "$ref": "{%-resourceTypeReference-%}"
+              "type": "array",
+              "items": {
+                "type": "string"
                 }
               }
             }
-          }
-        },
+        ],
         "responses": {
           "200": {
             "description": "Updated list of resources",
@@ -323,26 +320,18 @@
             "description": "Conflict - epoch not greater"
           }
         }
-      },
-      "delete": {
-        "operationId": "deleteResources",
-        "responses": {
-          "200": {
-            "description": "Ok"
-          },
-          "400": {
-            "description": "Bad Request - constraint failure"
-          },
-          "409": {
-            "description": "Conflict - epoch not greater"
-          }
-        }
-      }
+      }      
     },
     "/{%-groupNamePlural-%}/{groupId}/{%-resourceNamePlural-%}/{resourceId}": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -426,6 +415,71 @@
           },
           "404": {
             "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be upserted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/resource-description"
+          },
+          {
+            "$ref": "#/components/parameters/resource-docs"
+          },
+          {
+            "$ref": "#/components/parameters/resource-origin"
+          },
+          {
+            "$ref": "#/components/parameters/resource-tags"
+          }
+        ],
+        "summary": "Create or update a resource",
+        "description": "Create a resource. ",
+        "operationId": "putResource",
+        "requestBody": {
+          "description": "The resource to be created/updated",
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "409": {
+            "description": "Conflict - epoch not greater"
           }
         }
       },
@@ -546,7 +600,7 @@
             "in": "query",
             "name": "epoch",
             "description": "The epoch of the resource to be deleted",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "integer",
               "description": "A number representing the version number of the resource.",
@@ -570,7 +624,101 @@
     "/{%-groupNamePlural-%}/{groupId}/{%-resourceNamePlural-%}/{resourceId}/versions/{versionId}": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
           "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
+        },
+        {
+          "$ref": "#/components/parameters/resourceId"
+        },
+        {
+          "in": "query",
+          "name": "meta",
+          "description": "Interact with the metadata",
+          "required": false,
+          "allowEmptyValue": true,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getResourceVersionsAll",
+        "description": "Get an optionally filtered collection of resources",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "inline",
+            "description": "Set if references shall be inlined",
+            "required": false,
+            "allowEmptyValue": true,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "skip",
+            "description": "The number of resources to skip",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "top",
+            "description": "The number of resources to show",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "Filter criterion(s)",
+            "explode": true,
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of resource versions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "xregistry_resources.json#/definitions/resource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{groupType}/{groupId}/{resourceType}/{resourceId}/versions/{versionId}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/groupType"
+        },
+        {
+          "$ref": "#/components/parameters/groupId"
+        },
+        {
+          "$ref": "#/components/parameters/resourceType"
         },
         {
           "$ref": "#/components/parameters/resourceId"
@@ -583,6 +731,7 @@
           "name": "meta",
           "description": "Interact with the metadata",
           "required": false,
+          "allowEmptyValue": true,
           "schema": {
             "type": "boolean"
           }
@@ -649,11 +798,72 @@
           }
         }
       },
+      "put": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be updated",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
+        "operationId": "updateResourceVersion",
+        "description": "Updates the metadata for the schema version",
+        "requestBody": {
+          "description": "The schema version document",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "xregistry_resources.json#/definitions/resource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The schema version metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "xregistry_resources.json#/definitions/resource"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - constraint failure"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict"
+          }
+        }
+      },
       "delete": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "epoch",
+            "description": "The epoch of the resource group to be deleted",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "A number representing the version number of the resource.",
+              "format": "int64"
+            }
+          }
+        ],
         "operationId": "deleteResourceVersion",
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "Ok"
           },
           "400": {
             "description": "Bad Request - constraint failure"
@@ -674,6 +884,24 @@
       }
     },
     "parameters": {
+      "groupType": {
+        "in": "path",
+        "name": "groupType",
+        "description": "The groupType (plural)",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "resourceType": {
+        "in": "path",
+        "name": "id",
+        "description": "The resourceType (plural)",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
       "id": {
         "in": "path",
         "name": "id",
@@ -730,7 +958,7 @@
         "in": "header",
         "name": "resource-id",
         "required": false,
-        "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+        "description": "A unique identifier for this resource. This value MUST be globally unique",
         "schema": {
           "type": "string",
           "format": "uri-reference"
@@ -750,7 +978,7 @@
         "in": "header",
         "name": "resource-self",
         "required": false,
-        "description": "A unique URI for the resource. The URI MUST be a combination of the  base URI of the list of this resource type for the current Discovery  Service appended with the `id` of this resource.\n",
+        "description": "A unique URI for the resource.",
         "schema": {
           "type": "string",
           "format": "uri"

--- a/registry/schemas/xregistry_openapi_template_endpoint_registry_sed_args.txt
+++ b/registry/schemas/xregistry_openapi_template_endpoint_registry_sed_args.txt
@@ -1,0 +1,6 @@
+/groupNamePlural/s/{%-groupNamePlural-%}/endpoints/g
+/resourceNamePlural/s/{%-resourceNamePlural-%}/definitions/g
+/resourceType/s/{%-resourceTypeReference-%}/xregistry_messagedefinition_definition.json#\/definitions\/definition/g
+/resourceVersionType/s/{%-resourceVersionTypeReference-%}/xregistry_resources.json#\/definitions\/resource/g
+/groupType/s/{%-groupTypeReference-%}/xregistry_endpoint_registry.json#\/definitions\/endpoint/g
+/documentType/s/{%-documentTypeReference-%}/xregistry_endpoint_registry.json/g

--- a/registry/schemas/xregistry_openapi_template_messagedefinition_registry_sed_args.txt
+++ b/registry/schemas/xregistry_openapi_template_messagedefinition_registry_sed_args.txt
@@ -1,0 +1,6 @@
+/groupNamePlural/s/{%-groupNamePlural-%}/definitiongroups/g
+/resourceNamePlural/s/{%-resourceNamePlural-%}/definitions/g
+/resourceType/s/{%-resourceTypeReference-%}/xregistry_messagedefinition_definition.json#\/definitions\/definition/g
+/resourceVersionType/s/{%-resourceVersionTypeReference-%}/xregistry_resources.json#\/definitions\/resource/g
+/groupType/s/{%-groupTypeReference-%}/xregistry_messagedefinition_registry.json#\/definitions\/definitionGroup/g
+/documentType/s/{%-documentTypeReference-%}/xregistry_messagedefinition_registry.json/g

--- a/registry/schemas/xregistry_openapi_template_schema_registry_sed_args.txt
+++ b/registry/schemas/xregistry_openapi_template_schema_registry_sed_args.txt
@@ -1,0 +1,6 @@
+/groupNamePlural/s/{%-groupNamePlural-%}/schemagroups/g
+/resourceNamePlural/s/{%-resourceNamePlural-%}/schemas/g
+/resourceType/s/{%-resourceTypeReference-%}/xregistry_schema_registry.json#\/definitions\/schema/g
+/resourceVersionType/s/{%-resourceVersionTypeReference-%}/xregistry_schema_registry.json#\/definitions\/schemaVersion/g
+/groupType/s/{%-groupTypeReference-%}/xregistry_schema_registry.json#\/definitions\/schemaGroup/g
+/documentType/s/{%-documentTypeReference-%}/xregistry_schema_registry.json/g

--- a/registry/schemas/xregistry_resources.json
+++ b/registry/schemas/xregistry_resources.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "document",
+  "properties": {
+    "_ref": {      "$ref": "#/definitions/document"
+    }
+  },
+  "definitions": {
+    "document": {
+      "type": "object",
+      "title": "document",
+      "properties": {
+        "specversion": {
+          "type": "string"
+        }
+      },      
+      "additionalProperties": true
+    },
+    "reference": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "resource": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "A unique identifier for this Endpoint. This value MUST be globally unique",
+          "format": "uri-reference"
+        },
+        "groupId": {
+          "type": "string",
+          "description": "Optional reference to a definitionGroup that this resource is subordinate to",
+          "format": "uri-reference"
+        },
+        "version": {
+          "type": "integer",
+          "description": "A number representing the version number of the resource.",
+          "format": "int64"
+        },
+        "self": {
+          "type": "string",
+          "description": "A unique URI for the resource. The URI MUST be a combination of the base URI of the list of this resource type for the current Discovery Service appended with the `id` of this resource.",
+          "format": "uri-reference"
+        },
+        "description": {
+          "type": "string",
+          "description": "A summary of the purpose of the resource."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        "docs": {
+          "type": "string",
+          "description": "Absolute URL that provides a link to additional documentation about the resource.",
+          "format": "uri"
+        },
+        "origin": {
+          "type": "string",
+          "description": "A URI reference to the original source of this resource.",
+          "format": "uri-reference"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tag"
+          }
+        },
+        "createdBy": {
+          "description": "Identity of who created this entity",
+          "type": "string"
+        },
+        "createdOn": {
+          "description": "Time when this entity was created",
+          "type": "string",
+          "format": "date-time"
+        },
+        "modifiedBy": {
+          "description": "Identity of who last modified this entity",
+          "type": "string"
+        },
+        "modifiedOn": {
+          "description": "Time when this entity was last modified",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "tag": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/registry/schemas/xregistry_schema_registry.json
+++ b/registry/schemas/xregistry_schema_registry.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "properties": {
+    "schemaGroups": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/schemaGroup"
+      }
+    }
+  },
+  "required": [
+    "schemaGroups"
+  ],
+  "definitions": {
+    "schemaGroup": {
+      "type": "object",
+      "title": "schemaGroup",
+      "properties": {
+        "format": {
+          "type": "string",
+          "description": "Specifies the format of all schemas in this definitionGroup in the format {schema-type}/{version}",
+          "example": [
+            "jsonschema/draft-07",
+            "avro",
+            "xsd",
+            "protobuf"
+          ]
+        },
+        "schemas": {
+          "type": "object",
+          "description": "A collection of schemas",
+          "additionalProperties": {
+            "$ref": "#/definitions/schema"
+          }
+        },
+        "schemaGroups": {
+          "type": "object",
+          "description": "A collection of schemaGroups",
+          "additionalProperties": {
+            "$ref": "#/definitions/schemaGroup"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "xregistry_resources.json#/definitions/resource"
+        }
+      ]
+    },
+    "schema": {
+      "type": "object",
+      "title": "schema",
+      "description": "a schema is a collection of schema version documents that describe semantically the same data item",
+      "properties": {
+        "versions": {
+          "type": "object",
+          "description": "A collection of schema versions",
+          "additionalProperties": {
+            "$ref": "#/definitions/schemaVersion"
+          }
+        },
+        "format": {
+          "type": "string",
+          "description": "The format of the schema in the format {schema-type}/{version}"
+        }
+      },
+      "required": [
+        "versions",
+        "format"
+      ],
+      "allOf": [
+        {
+          "$ref": "xregistry_resources.json#/definitions/resource"
+        }
+      ]
+    },
+    "schemaVersion": {
+      "type": "object",
+      "title" : "schemaVersion",
+      "description": "a schema version (a document)",
+      "properties": {
+        "schemaUrl": {
+          "type": "string",
+          "description": "A URL to the schema document.",
+          "format": "uri"
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "type": "object",
+              "description": "An in-line definition of the schema of the message's data."
+            },
+            {
+              "type": "string",
+              "description": "An in-line definition of the schema of the message's data."
+            }
+          ]
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "schemaUrl"
+          ]
+        },
+        {
+          "required": [
+            "schema"
+          ]
+        }
+      ],
+      "allOf": [
+        {
+          "$ref": "xregistry_resources.json#/definitions/resource"
+        }
+      ]
+    }
+  }
+}

--- a/registry/spec.md
+++ b/registry/spec.md
@@ -1814,6 +1814,7 @@ scenarios:
               "type" : "schemaversion",
               "id" : "1.0",
               "schema" : "syntax = \"proto3\"; message Metrics { float metric = 1; }"
+            }
           }
         }
       }

--- a/registry/spec.md
+++ b/registry/spec.md
@@ -1752,7 +1752,7 @@ scenarios:
         "protocol": "MQTT/5.0",
         "strict": false,
         "endpoints": [
-          "mqtt://mqtt.example.com:1883",
+          "mqtt://mqtt.example.com:1883"
         ],
         "options" : {
           "topic": "{deviceid}/telemetry"

--- a/registry/spec.md
+++ b/registry/spec.md
@@ -1799,6 +1799,7 @@ scenarios:
           "schemaurl" : "#/schemaGroups/com.example.telemetry/schema/com.example.telemetrydata/versions/1.0"
         }
       }
+    }
   },
   "schemaGroups" : {
     "com.example.telemetry" : {

--- a/registry/spec.md
+++ b/registry/spec.md
@@ -1,4 +1,4 @@
-# Registry Service - Version 0.3-wip
+# Registry Service - Version 0.5-wip
 
 ## Abstract
 
@@ -12,20 +12,23 @@ automation and tooling.
 - [Notations and Terminology](#notations-and-terminology)
   - [Notational Conventions](#notational-conventions)
   - [Terminology](#terminology)
-- [Attributes and Extensions](#attributes-and-extensions)
-- [Registry APIs](#registry-apis)
-  - [Retrieving the Registry Model](#retrieving-the-registry-model)
-  - [Retrieving the Registry](#retrieving-the-registry)
-  - [Managing Groups](#managing-groups)
-  - [Managing Resources](#managing-resources)
-  - [Managing versions of a Resource](#managing-versions-of-a-resource)
-- [Endpoint Registry](#endpoint-registry)
-  - [Endpoints](#endpoints)
-  - [DefinitionGroups](#definitiongroups)
-  - [Definition](#definitions)
-- [Schema Registry](#schema-registry)
-  - [SchemaGroups](#schemagroups)
-  - [Schemas](#schemas)
+- [Registry Formats and APIs](#registry-formats-and-apis)
+  - [Attributes and Extensions](#attributes-and-extensions)
+  - [Registry APIs](#registry-apis)
+    - [Retrieving the Registry Model](#retrieving-the-registry-model)
+    - [Retrieving the Registry](#retrieving-the-registry)
+    - [Managing Groups](#managing-groups)
+    - [Managing Resources](#managing-resources)
+    - [Managing versions of a Resource](#managing-versions-of-a-resource)
+- [CloudEvents Registry](#cloudevents-registry)
+  - [Schema Registry](#schema-registry)
+    - [Schema Groups](#group-schemagroups)
+    - [Schemas](#resource-schemas)
+  - [Message Definitions Registry](#message-definitions-registry)
+    - [Message Definition Groups](#message-definition-groups)
+    - [Message Definitions](#message-definitions)
+  - [Endpoint Registry](#endpoint-registry)
+    - [Endpoints](#endpoints-endpoints)
 
 ## Overview
 
@@ -38,9 +41,20 @@ provide a common interaction pattern for these types of services with the goal
 of providing an interoperable framework that will enable common tooling and
 automation to be created.
 
-This specification itself is meant to be a framework from which additional
-specifications will be defined that expose model specific resources and
-metadata.
+The first section of this specification, ["Registry Formats and
+APIs"](#registry-formats-and-apis), is meant to be a framework from which
+additional specifications can be defined that expose model specific resources
+and metadata.
+
+The second section of this specification ["CloudEvents
+Registry"](#cloudevents-registry) defines a set of concrete resource types and
+metadata for the purpose of describing messaging and eventing endpoints, message
+and event metadata definitions, and the payload schemas they use. The name
+"CloudEvents Registry" reflects the specification coming from the CNCF
+CloudEvents project, but the specification is intended to be generic enough to
+be used with any messaging and eventing format and protocol and the registry
+section does thus define metadata formats for the native message formats of
+several other messaging and eventing protocols.
 
 ## Notations and Terminology
 
@@ -83,13 +97,33 @@ include model specific Groups, Resources and extension attributes.
 A Resource is the main entity that is stored within a Registry Service. It
 MAY be versioned and grouped as needed by the Registry's model.
 
-## Attributes and Extensions
+## Registry Formats and APIs
 
-The follow attributes are used by one or more entities defined by this
+This section defines common Registry metadata elements and APIs. It is an
+explicit goal for this specification that metadata can be created and managed in
+files in a file system, for instance in a Git repository, and also managed in a
+Registry service that implement the API described here.
+
+For instance, during development of a module, the metadata about the events
+raised by the modules will best be managed in a file that resides alongside the
+module's source code. When the module is ready to be deployed into a concrete
+system, the metadata about the events will be registered in a Registry service
+along with the endpoint where those events can be subscribed to or consumed
+from, and which allows discovery of the endpoint and all related metadata by
+other systems at runtime.
+
+Therefore, the hierarchical structure of the Registry model is defined in such a
+way that is can be represented in a single file, including but not limited to
+JSON or YAML, or via the resource graph of a REST API.
+
+### Attributes and Extensions
+
+The following attributes are used by one or more entities defined by this
 specification. They are defined here once rather than repeating them
 throughout the specification.
 
-List of attributes:
+Attributes:
+
 - `"id": "STRING"`
 - `"name": "STRING"`
 - `"description": "STRING"`
@@ -106,6 +140,7 @@ List of attributes:
 Implementations of this specification MAY define additional (extension)
 attributes, and they MAY appear at any level of the model. However they MUST
 adhere to the following rules:
+
 - it is STRONGLY RECOMMENDED that they be named in such a way as to avoid
   potential conflicts with future Registry Service attributes. For example,
   use of a model specific prefix.
@@ -117,7 +152,8 @@ In situations where an attribute is serialized in a case-sensitive situation,
 then the case specified by this specification, or the defining extension
 specification, MUST be adhere to.
 
-### `id`
+#### `id`
+
 - Type: String   # SHOULD this be a URI-Reference?
 - Description: An immutable unique identifier of the entity.
 - Constraints:
@@ -133,7 +169,8 @@ specification, MUST be adhere to.
 - Examples:
   - A UUID
 
-### `name`
+#### `name`
+
 - Type: String
 - Description: A human readable name of the entity.
   Note that implementations MAY choose to enforce constraints on this value.
@@ -145,7 +182,8 @@ specification, MUST be adhere to.
 - Examples:
   - `My Endpoints`
 
-### `description`
+#### `description`
+
 - Type: String
 - Description: A human readable summary of the purpose of the entity.
 - Constraints:
@@ -154,7 +192,8 @@ specification, MUST be adhere to.
 - Examples:
   - `A queue of the sensor generated messages`
 
-### `tags`
+#### `tags`
+
 - Type: Map of name/value string pairs
 - Description: A mechanism in which additional metadata about the entity can
   be stored without changing the schema of the entity.
@@ -167,7 +206,8 @@ specification, MUST be adhere to.
 - Examples:
   - `{ "owner": "John", "verified": "" }`
 
-### `version`
+#### `version`
+
 - Type: Unsigned Integer       # SHOULD this be a String?
 - Description: A numeric value representing a specific instance of an entity.
   Note that versions of an entity can be modified without changing the
@@ -180,8 +220,9 @@ specification, MUST be adhere to.
 - Examples:
   - `1`, `2`, `3`
 
-### `epoch`
-- Type: Unisgned Integer
+#### `epoch`
+
+- Type: Unsigned Integer
 - Description: A numeric value used to determine whether an entity has been
   modified. Each time the associated entity is updated, this value MUST be
   set to a new value that is greater than the current one.
@@ -197,7 +238,8 @@ specification, MUST be adhere to.
 - Examples:
   - `1`, `2`, `3`
 
-### `self`
+#### `self`
+
 - Type: URL
 - Description: A unique URL for the entity. The URL MUST be a combination of
   the base URL for the list of resources of this type of entity appended with
@@ -207,7 +249,8 @@ specification, MUST be adhere to.
 - Examples:
   - `https://example.com/registry/endpoints/123`
 
-### `createdBy`
+#### `createdBy`
+
 - Type: String
 - Description: A reference to the user or component that was responsible for
   the creation of this entity. This specification makes no requirement on
@@ -219,7 +262,8 @@ specification, MUST be adhere to.
   - `John Smith`
   - `john.smith@example.com`
 
-### `createdOn`
+#### `createdOn`
+
 - Type: Timestamp
 - Description: The date/time of when the entity was created.
 - Constraints:
@@ -227,7 +271,8 @@ specification, MUST be adhere to.
 - Examples:
   - `2030-12-19T06:00:00Z"
 
-### `modifiedBy`
+#### `modifiedBy`
+
 - Type: String
 - Description: A reference to the user or component that was responsible for
   the the latest update of this entity. This specification makes no requirement
@@ -239,7 +284,8 @@ specification, MUST be adhere to.
   - `John Smith`
   - `john.smith@example.com`
 
-### `modifiedOn`
+#### `modifiedOn`
+
 - Type: Timestamp
 - Description: The date/time of when the entity was last updated.
 - Constraints:
@@ -247,7 +293,8 @@ specification, MUST be adhere to.
 - Examples:
   - `2030-12-19T06:00:00Z"
 
-### `docs`
+#### `docs`
+
 - Type: URI-Reference
 - Description: A URI-Reference to additional documentation about this entity.
   This specification does not place any constraints on the data returned from
@@ -259,12 +306,11 @@ specification, MUST be adhere to.
 - Examples:
   - `https://example.com/docs/myQueue`
 
-
-## Registry APIs
+### Registry APIs
 
 This specification defines the following API patterns:
 
-```
+``` meta
 /?model                             # Manage the registry model
 /                                   # Show all Groups
 /GROUPs                             # Manage a Group Type
@@ -290,17 +336,19 @@ prefix MUST be used consistently for all APIs in the same Registry Service.
 
 The following sections define the APIs in more detail.
 
-### Retrieving the Registry Model
+#### Retrieving the Registry Model
 
 This returns the metadata describing the model of the Registry Service.
 
 The request MUST be of the form:
-```
+
+``` meta
 GET /?model
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -323,6 +371,7 @@ Content-Length: nnnn
 ```
 
 The following describes the attributes of Registry model:
+
 - `groups`
   - REQUIRED if there are any Groups defined for the Registry
   - The set of Groups supported by the Registry
@@ -357,11 +406,14 @@ The following describes the attributes of Registry model:
 **Example:**
 
 Request:
-```
+
+``` meta
 GET /?model
 ```
+
 Response:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -369,19 +421,20 @@ Content-Length: nnnn
 { TODO }
 ```
 
-
-### Retrieving the Registry
+#### Retrieving the Registry
 
 This returns the Groups in the Registry along with metadata about the
 Registry itself.
 
 The request MUST be of the form:
-```
+
+``` meta
 GET /
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -404,11 +457,14 @@ Content-Length: nnnn
 **Example:**
 
 Request:
-```
+
+``` meta
 GET /
 ```
+
 Response:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -424,19 +480,21 @@ Content-Length: nnnn
 }
 ```
 
-#### Retrieving all Registry Contents
+##### Retrieving all Registry Contents
 
 This returns the Groups and all nested data in the Registry along with
 metadata about the Registry itself. This is designed for cases where the
 entire Registry's contents are to be represented as a single document.
 
 The request MUST be of the form:
-```
+
+``` meta
 GET /?inline
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -499,11 +557,14 @@ TODO: define the error / add filtering / pagination
 **Example:**
 
 Request:
-```
+
+``` meta
 GET /?inline
 ```
+
 Response:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -511,15 +572,15 @@ Content-Length: nnnn
 { TODO }
 ```
 
+#### Managing Groups
 
-### Managing Groups
-
-#### Retrieving all Groups
+##### Retrieving all Groups
 
 This returns all entities that are in a Group.
 
 The request MUST be of the form:
-```
+
+``` meta
 GET /GROUPs[?inline]
 ```
 
@@ -527,7 +588,8 @@ The OPTIONAL `inline` query parameter indicates the nested Resources are to
 be included in the response.
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -561,11 +623,14 @@ can leverage pagination of the response data.
 **Example:**
 
 Request:
-```
+
+``` meta
 GET /endpoints
 ```
+
 Response:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -593,12 +658,13 @@ Link: <http://example.com/endpoints&page=2>;rel=next;count=100
 
 TODO: add filtering and define error
 
-#### Creating a Group
+##### Creating a Group
 
 This will add a new Group to the Registry.
 
 The request MUST be of the form:
-```
+
+``` meta
 POST /GROUPs
 
 {
@@ -608,7 +674,8 @@ POST /GROUPs
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 201 Created
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -628,13 +695,16 @@ Location: URL             # .../GROUPs/ID
 **Example:**
 
 Request:
-```
+
+``` meta
 POST /endpoints
 
 { TODO }
 ```
+
 Response:
-```
+
+``` meta
 HTTP/1.1 201 Created
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -643,12 +713,13 @@ Location: https://example.com/endpoints/ID
 { TODO }
 ```
 
-#### Retrieving a Group
+##### Retrieving a Group
 
 This will return a single Group.
 
 The request MUST be of the form:
-```
+
+``` meta
 GET /GROUPs/ID[?inline]
 ```
 
@@ -656,7 +727,8 @@ The OPTIONAL `inline` query parameter indicates the nested Resources are to
 be included in the response.
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -681,11 +753,14 @@ Content-Length: nnnn
 **Example:**
 
 Request:
-```
+
+``` meta
 GET /endpoints/123
 ```
+
 Response:
-```
+
+``` meta
 HTTP/1.1 ...
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -700,12 +775,13 @@ Content-Length: nnnn
 }
 ```
 
-#### Updating a Group
+##### Updating a Group
 
 This will update the attributes of a Group.
 
 The request MUST be of the form:
-```
+
+``` meta
 PUT /GROUPs/ID[?epoch=EPOCH]
 
 {
@@ -719,7 +795,8 @@ PUT /GROUPs/ID[?epoch=EPOCH]
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -738,7 +815,8 @@ Content-Length: nnnn
 **Example:**
 
 Request:
-```
+
+``` meta
 PUT /endpoints/123
 
 {
@@ -747,8 +825,10 @@ PUT /endpoints/123
   "epoch": 1
 }
 ```
+
 Response:
-```
+
+``` meta
 HTTP/1.1 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -763,19 +843,21 @@ Content-Length: nnnn
 }
 ```
 
-#### Deleting Groups
+##### Deleting Groups
 
 To delete a single Group the following API can be used.
 
 The request MUST be of the form:
-```
+
+``` meta
 DELETE /GROUPs/ID[?epoch=EPOCH]
 ```
 
 If `epoch` is present then it MUST match the current value.
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK                  # 202 or 204 are ok
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -791,7 +873,8 @@ Content-Length: nnnn
 To delete multiple Groups the following API can be used.
 
 The request MUST be of the form:
-```
+
+``` meta
 DELETE /GROUPs
 
 [
@@ -803,7 +886,8 @@ DELETE /GROUPs
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK                  # 202 or 204 are ok
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -816,15 +900,15 @@ and none of the Groups are deleted.
 
 A `DELETE /GROUPs` without a body MUST delete all Groups.
 
+#### Managing Resources
 
-### Managing Resources
-
-#### Retrieving all Resources
+##### Retrieving all Resources
 
 This will retrieve the Resources from a Group.
 
 The request MUST be of the form:
-```
+
+``` meta
 GET /GROUPs/ID/RESOURCEs[?inline]
 ```
 
@@ -832,7 +916,8 @@ The OPTIONAL `inline` query parameter indicates the nested Resources are to
 be included in the response.
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -842,7 +927,6 @@ Link: <URL>;rel=next;count=INT  # If pagination is needed
   "ID": {
     "id": "STRING",
     "name": "STRING",
-    "type": "STRING", ?
     "version": INT,
     "epoch": UINT,
     "self": "URL",                   # URL to specific version
@@ -857,11 +941,14 @@ Link: <URL>;rel=next;count=INT  # If pagination is needed
 **Example:**
 
 Request:
-```
+
+``` meta
 GET /endpoints/123/definitions
 ```
+
 Response:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -871,7 +958,7 @@ Link: <http://example.com/endpoints/123/definitions&page=2>;rel=next;count=100
   "456": {
     "id": "456",
     "name": "Blob Created",
-    "type": "CloudEvents/1.0",
+    "format": "CloudEvents/1.0",
     "version": 3,
     "epoch": 1,
     "self": "https://example.com/endpoints/123/definitions/456/version/3"
@@ -879,12 +966,13 @@ Link: <http://example.com/endpoints/123/definitions&page=2>;rel=next;count=100
 }
 ```
 
-#### Creating Resources
+##### Creating Resources
 
 This will create a new Resources in a particular Group.
 
 The request MUST be of the form:
-```
+
+``` meta
 POST /GROUPs/ID/RESOURCEs
 Registry-name: STRING ?          # If absent, default to the ID?
 Registry-type: STRING ?
@@ -894,7 +982,8 @@ Registry-RESOURCEURI: URI ?      # If present body MUST be empty (singular)
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 201 Created
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -914,23 +1003,26 @@ Content-Location: URL            # Same as Registry-self value
 **Example:**
 
 Request:
-```
+
+``` meta
 TODO
 ```
 
-#### Retrieving a Resource
+##### Retrieving a Resource
 
 This will retrieve the latest version of a Resource. This can be considered an
 alias for `/GROUPs/ID/RESOURCEs/RESOURCEID/versions/VERSION` where
 `VERSION` is the latest version value.
 
 The request MUST be of the form:
-```
+
+``` meta
 GET /GROUPs/ID/RESOURCEs/ID
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK  or 307 Tempary Redirect    # 307 if RESOURCEURI is present
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -951,11 +1043,12 @@ Location: URL                    # If 307. Same a Registry-RESOURCEURI
 **Example:**
 
 Request:
-```
+
+``` meta
 TODO
 ```
 
-#### Retrieving a Resource's Metadata
+##### Retrieving a Resource's Metadata
 
 This will retrieve the metadata for the latest version of a Resource. This can
 be considered an alias for
@@ -963,12 +1056,14 @@ be considered an alias for
 latest version value.
 
 The request MUST be of the form:
-```
+
+``` meta
 GET /GROUPs/ID/RESOURCEs/ID?meta
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -976,7 +1071,6 @@ Content-Length: nnnn
 {
   "id": "STRING",
   "name": "STRING",
-  "type": "STRING", ?
   "version": INT,
   "epoch": UINT,
   "self": "URL",
@@ -987,11 +1081,12 @@ Content-Length: nnnn
 **Example:**
 
 Request:
-```
+
+``` meta
 TODO
 ```
 
-#### Updating a Resource
+##### Updating a Resource
 
 This will update the latest version of a Resource. Missing Registry HTTP
 headers MUST NOT be interpreted as deleting the attribute. However, a Registry
@@ -999,7 +1094,8 @@ HTTP headers with an empty string for its value MUST be interpreted as a
 request to delete the attribute.
 
 The request MUST be of the form:
-```
+
+``` meta
 PUT /GROUPs/ID/RESOURCEs/ID[?epoch=EPOCH]
 Registry-id: STRING ?            # If present it MUST match URL
 Registry-name: STRING ?
@@ -1013,7 +1109,8 @@ Registry-RESOURCEURI: URI ?      # If present body MUST be empty (singular)
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1040,30 +1137,33 @@ have the same value then an error MUST be generated.
 **Example:**
 
 Request:
-```
+
+``` meta
 TODO
 ```
+
 Response:
-```
+
+``` meta
 TODO
 ```
 
 TODO: make a note that empty string and attribute missing are the same thing.
 Which error is to be returned?
 
-#### Updating a Resource's metadata
+##### Updating a Resource's metadata
 
 This will update the metadata of the latest version of a Resource without
 creating a new version.
 
 The request MUST be of the form:
-```
+
+``` meta
 PUT /GROUPs/ID/RESOURCEs/ID?meta[&epoch=EPOCH]
 
 {
   "id": "STRING",
   "name": "STRING",
-  "type": "STRING", ?
   "version": INT, ?            # If present it MUST match current value
   "epoch": UINT, ?             # If present it MUST match current value & URL
   "self": "URL", ?             # If present it MUST be ignored
@@ -1072,7 +1172,8 @@ PUT /GROUPs/ID/RESOURCEs/ID?meta[&epoch=EPOCH]
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1080,7 +1181,6 @@ Content-Length: nnnn
 {
   "id": "STRING",
   "name": "STRING",
-  "type": "STRING", ?
   "version": INT,
   "epoch": UINT,               # MUST be incremented
   "self": "URL",
@@ -1091,27 +1191,32 @@ Content-Length: nnnn
 **Example:**
 
 Request:
-```
-TODO
-```
-Response:
-```
+
+``` meta
 TODO
 ```
 
-#### Deleting Resources
+Response:
+
+``` meta
+TODO
+```
+
+##### Deleting Resources
 
 To delete a single Resource the following API can be used.
 
 The request MUST be of the form:
-```
+
+``` meta
 DELETE /GROUPs/ID/RESOURCEs/ID[?epoch=EPOCH]
 ```
 
 If `epoch` is present then it MUST match the current value.
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK                  # 202 or 204 are ok
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1130,14 +1235,16 @@ Content-Location: URL              # Does this make sense if it's been deleted?
 **Example:**
 
 Request:
-```
+
+``` meta
 TODO
 ```
 
 To delete multiple Resources the following API can be used.
 
 The request MUST be of the form:
-```
+
+``` meta
 DELETE /GROUPs/ID/RESOURCEs
 
 [
@@ -1149,7 +1256,8 @@ DELETE /GROUPs/ID/RESOURCEs
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK                  # 202 or 204 are ok
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1163,15 +1271,15 @@ and none of the Resources are deleted.
 A `DELETE /GROUPs/ID/RESOURCEs` without a body MUST delete all Resources in the
 Group.
 
+#### Managing versions of a Resource
 
-### Managing versions of a Resource
-
-#### Retrieving all versions of a Resource
+##### Retrieving all versions of a Resource
 
 This will retrieve all versions of a Resource.
 
 The request MUST be of the form:
-```
+
+``` meta
 GET /GROUPs/ID/RESOURCEs/ID/versions[?inline]
 ```
 
@@ -1179,7 +1287,8 @@ The OPTIONAL `inline` query parameter indicates the nested Resources are to
 be included in the response.
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1189,7 +1298,6 @@ Link: <URL>;rel=next;count=INT  # If pagination is needed
   VERSION: {
     "id": "STRING",
     "name": "STRING",
-    "type": "STRING", ?
     "version": INT,
     "epoch": UINT,
     "self": "URL",
@@ -1203,18 +1311,20 @@ Link: <URL>;rel=next;count=INT  # If pagination is needed
 **Example:**
 
 Request:
-```
+
+``` meta
 TODO
 ```
 
-#### Creating a new version of a Resource
+##### Creating a new version of a Resource
 
 This will create a new version of a Resource. Any metadata not present will be
 inherited from latest version. To delete any metadata include its HTTP Header
 with an empty value.
 
 The request MUST be of the form:
-```
+
+``` meta
 POST /GROUPs/ID/RESOURCEs/ID[?epoch=EPOCH]
 Registry-id: STRING ?            # If present it MUST match URL
 Registry-name: STRING ?
@@ -1228,7 +1338,8 @@ Registry-RESOURCEURI: URI ?      # If present body MUST be empty (singular)
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 201 Created
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1248,25 +1359,30 @@ Location: .../GROUPs/ID/RESOURCEs/ID   # or self?
 **Example:**
 
 Request:
-```
-TODO
-```
-Response:
-```
+
+``` meta
 TODO
 ```
 
-#### Retrieving a version of a Resource
+Response:
+
+``` meta
+TODO
+```
+
+##### Retrieving a version of a Resource
 
 This will retrieve a partiuclar version of a Resource.
 
 The request MUST be of the form:
-```
+
+``` meta
 GET /GROUPs/ID/RESOURCEs/ID/versions/VERSION
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK  or 307 Tempary Redirect    # 307 if RESOURCEURI is present
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1286,21 +1402,24 @@ Location: URL                    # If 307. Same a Registry-RESOURCEURI
 **Example:**
 
 Request:
-```
+
+``` meta
 TODO
 ```
 
-#### Retrieving a version of a Resource's metadata
+##### Retrieving a version of a Resource's metadata
 
 This will retrieve the metadata for a particular version of a Resource.
 
 The request MUST be of the form:
-```
+
+``` meta
 GET /GROUPs/ID/RESOURCEs/ID/versions/VERSION?meta
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1308,7 +1427,6 @@ Content-Length: nnnn
 {
   "id": "STRING",
   "name": "STRING",
-  "type": "STRING", ?
   "version": INT,
   "epoch": UINT,
   "self": "URL",
@@ -1319,11 +1437,12 @@ Content-Length: nnnn
 **Example:**
 
 Request:
-```
+
+``` meta
 TODO
 ```
 
-#### Updating a version of a Resource
+##### Updating a version of a Resource
 
 This will update a particular version of a Resource. Missing Registry HTTP
 headers MUST NOT be interpreted as deleting the attribute. However, a Registry
@@ -1331,7 +1450,8 @@ HTTP headers with an empty string for its value MUST be interpreted as a
 request to delete the attribute.
 
 The request MUST be of the form:
-```
+
+``` meta
 PUT /GROUPs/ID/RESOURCEs/ID/versions/VERSION[?epoch=EPOCH]
 Registry-id: STRING ?            # If present it MUST match URL
 Registry-name: STRING ?
@@ -1345,7 +1465,8 @@ Registry-RESOURCEURI: URI ?      # If present body MUST be empty (singular)
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1372,23 +1493,24 @@ have the same value then an error MUST be generated.
 **Example:**
 
 Request:
-```
+
+``` meta
 TODO
 ```
 
-#### Updating a version of a Resource's metadata
+##### Updating a version of a Resource's metadata
 
 This will update the metadata of a particular version of a Resource without
 creating a new version.
 
 The request MUST be of the form:
-```
+
+``` meta
 PUT /GROUPs/ID/RESOURCEs/ID/versions/VERSION?meta[&epoch=EPOCH]
 
 {
   "id": "STRING",
   "name": "STRING",
-  "type": "STRING", ?
   "version": INT, ?            # If present it MUST match current value
   "epoch": UINT, ?             # If present it MUST match current value & URL
   "self": "URL", ?             # If present it MUST be ignored
@@ -1397,7 +1519,8 @@ PUT /GROUPs/ID/RESOURCEs/ID/versions/VERSION?meta[&epoch=EPOCH]
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1405,7 +1528,6 @@ Content-Length: nnnn
 {
   "id": "STRING",
   "name": "STRING",
-  "type": "STRING", ?
   "version": INT,
   "epoch": UINT,               # MUST be incremented
   "self": "URL",
@@ -1416,27 +1538,32 @@ Content-Length: nnnn
 **Example:**
 
 Request:
-```
-TODO
-```
-Response:
-```
+
+``` meta
 TODO
 ```
 
-#### Deleting versions of a Resource
+Response:
+
+``` meta
+TODO
+```
+
+##### Deleting versions of a Resource
 
 To delete a single version of a Resource the following API can be used.
 
 The request MUST be of the form:
-```
+
+``` meta
 DELETE /GROUPs/ID/RESOURCEs/ID/versions/VERSION[?epoch=EPOCH]
 ```
 
 If `epoch` is present then it MUST match the current value.
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK                  # 202 or 204 are ok
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1455,18 +1582,22 @@ Content-Location: URL              # Does this make sense if it's been deleted?
 **Example:**
 
 Request:
-```
+
+``` meta
 TODO
 ```
+
 Response:
-```
+
+``` meta
 TODO
 ```
 
 To delete multiple versions of a Resource the following API can be used.
 
 The request MUST be of the form:
-```
+
+``` meta
 DELETE /GROUPs/ID/RESOURCEs/ID/versions
 
 [
@@ -1479,7 +1610,8 @@ DELETE /GROUPs/ID/RESOURCEs/ID/versions
 ```
 
 A successful response MUST be of the form:
-```
+
+``` meta
 HTTP/1.1 200 OK                  # 202 or 204 are ok
 Content-Type: application/json; charset=utf-8
 Content-Length: nnnn
@@ -1498,13 +1630,1251 @@ An attempt to delete all versions MUST generate an error.
 A `DELETE /GROUPs/ID/RESOURCEs/ID/versions` without a body MUST delete all
 versions (except the latest) of the Resource.
 
+## CloudEvents Registry
 
-## Endpoint Registry
+The CloudEvents Registry is a universal catalog and discovery metadata format
+as well as a metadata service API for messaging and eventing schemas, metaschemas,
+and messaging and eventing endpoints.
 
-This section defines the custom attributes that an Endpoint Registry supports.
+The CloudEvents registry model contains three separate registries that can be
+implemented separately or in combination.
 
-The Registry model defined by an Endpoint Registry is:
+- The [Schema Registry](#schema-registry) section describes the metadata
+  description of payload schemas for events and messages. The schema registry is
+  universally applicable to any scenario where collaborating parties share
+  structured data that is defined by formal schemas. For instance, when storing
+  Protobuf encoded structured data in a cloud file store, you might place a
+  schema registry in file form in the parent directory, which formally organizes
+  and documents all versions of all Protobuf schemas that are used in the
+  directory.
+- The [Message Definitions Registry](#message-definitions-registry) section
+  describes the metadata description of events and messages. The payload schemas
+  for events and messages can be embedded in the definition, reference an
+  external schema document, or can be referenced into the schema registry. The
+  message definitions registry is universally applicable to any asynchronous
+  messaging and eventing scenario. You might define a group of definitions that
+  describe precisely which messages, with which metadata, are permitted to flow
+  into a channel and can thus be expected by consumers of that channel and then
+  associate that definition group with a topic or queue in your eventing or
+  messaging infrastructure. That association might be a metadata attribute on
+  the topic or queue in the messaging infrastructure that embeds the metadata or
+  points to it.
+- The [Endpoint Registry](#endpoint-registry) section defines the metadata
+  description of network endpoints that accept or emit events and messages. The
+  endpoint registry is a formal description of associations of message
+  definitions and network endpoints, which can be used to discover endpoints
+  that consume or emit particular messages or events via a central registry. The
+  message definitions can be embedded into the endpoint metadata or as
+  a reference into the message definitions registry.
+
+The metadata model is structured such that network endpoint information and
+message metadata and payload schemas can be described compactly in a single
+metadata object (and therefore as a single document) in the simplest case or can
+be spread out and managed across separate registry products in a sophisticated
+large-enterprise scenario.
+
+The following is an exemplary, compact definition of an MQTT 5.0 consumer
+endpoint with a single, embedded message definition using an embedded Protobuf 3
+schema for its payload.
+
+``` JSON
+{
+  "$schema": "https://cloudevents.io/schemas/registry",
+  "specversion": "0.4-wip",
+  "id": "urn:uuid:3978344f-8596-4c3a-a978-8fc9a6a469f7",
+  "endpoints" : 
+  {
+    "com.example.telemetry" : {
+      "id" : "com.example.telemetry",
+      "usage": "consumer",
+      "config": {
+        "protocol": "MQTT/5.0",
+        "strict": false,
+        "endpoints": [
+            "mqtt://mqtt.example.com:1883",
+        ],
+        "options" : {
+            "topic": "{deviceid}/telemetry"
+        }
+      },
+      "format" : "CloudEvents/1.0",
+      "definitions": {
+        "com.example.telemetry" : {
+          "id": "com.example.telemetry",
+          "description": "device telemetry event",
+          "format": "CloudEvents/1.0",
+          "metadata": {
+            "attributes": {
+              "id": {
+                "type": "string",
+                "required": true
+              },
+              "type": {
+                "type": "string",
+                "value": "com.example.telemetry",
+                "required": true
+              },
+              "time": {
+                "type": "datetime",
+                "required": true
+              },
+              "source": {
+                "type": "uritemplate",
+                "value": "{deploymentid}/{deviceid}",
+                "required": true
+              }
+            }
+          },
+          "schemaformat": "Protobuf/3.0",
+          "schema" : "syntax = \"proto3\"; message Metrics { float metric = 1; } }"
+        }
+      }
+    }
+  }
+}
 ```
+
+The same metadata can be expressed by spreading the metadata across the message
+definition and schema registries, which makes the definitions reusable for other
+scenarios:
+
+``` JSON
+{
+  "$schema": "https://cloudevents.io/schemas/registry",
+  "specversion": "0.4-wip",
+  "id": "urn:uuid:3978344f-8596-4c3a-a978-8fc9a6a469f7",
+  "endpoints" : 
+  {
+    "com.example.telemetry" : {
+      "id" : "com.example.telemetry",
+      "usage": "consumer",
+      "config": {
+        "protocol": "MQTT/5.0",
+        "strict": false,
+        "endpoints": [
+          "mqtt://mqtt.example.com:1883",
+        ],
+        "options" : {
+          "topic": "{deviceid}/telemetry"
+        }
+      },
+      "format" : "CloudEvents/1.0",
+      "definitionGroups" :[
+        "#/definitionGroups/com.example.telemetryEvents"
+      ]
+    }
+  },
+  "definitionGroups" : {
+    "com.example.telemetryEvents" : {
+      "type" : "definitionGroup",
+      "id" : "com.example.telemetryEvents",
+      "definitions": {
+        "com.example.telemetry" : {
+          "id": "com.example.telemetry",
+          "description": "device telemetry event",
+          "format": "CloudEvents/1.0",
+          "metadata": {
+            "attributes": {
+              "id": {
+                "type": "string",
+                "required": true
+              },
+              "type": {
+                "type": "string",
+                "value": "com.example.telemetry",
+                "required": true
+              },
+              "time": {
+                "type": "datetime",
+                "required": true
+              },
+              "source": {
+                "type": "uritemplate",
+                "value": "{deploymentid}/{deviceid}",
+                "required": true
+              }
+            }
+          },
+          "schemaformat": "Protobuf/3.0",
+          "schemaurl" : "#/schemaGroups/com.example.telemetry/schema/com.example.telemetrydata/versions/1.0"
+        }
+      }
+  },
+  "schemaGroups" : {
+    "com.example.telemetry" : {
+      "type" : "schemagroup",
+      "id" : "com.example.telemetry",
+      "schemas": {
+        "com.example.telemetrydata" : {
+          "id": "com.example.telemetrydata",
+          "description": "device telemetry event data",
+          "format": "Protobuf/3.0",
+          "versions" : {
+            "1.0" : {
+              "type" : "schemaversion",
+              "id" : "1.0",
+              "schema" : "syntax = \"proto3\"; message Metrics { float metric = 1; }"
+          }
+      }
+    }
+  }
+}
+```
+
+If we assume the message definitions and schemas to reside at an API endpoint,
+an endpoint definition might just reference the associated message definition
+group with a deep link to the respective object in the service:
+
+``` JSONC
+{
+  "$schema": "https://cloudevents.io/schemas/registry",
+  "specversion": "0.4-wip",
+  "id": "urn:uuid:3978344f-8596-4c3a-a978-8fc9a6a469f7",
+  "endpoints" : 
+  {
+    "com.example.telemetry" : {
+      "id" : "com.example.telemetry",
+      "usage": "consumer",
+      "config": {
+        // ... details ...
+      },
+      "format" : "CloudEvents/1.0",
+      "definitionGroups" :[
+          "https://site.example.com/registry/definitiongroups/com.example.telemetryEvents"
+      ]
+    }
+  }
+}
+```
+
+If the message definitions and schemas are stored in a file-based registry,
+including files shared via public version control repositories, the reference
+link will first reference the file and then the object within the file, using
+[JSON Pointer][JSON Pointer] syntax:
+
+``` JSONC
+{
+  "$schema": "https://cloudevents.io/schemas/registry",
+  "specversion": "0.4-wip",
+  "id": "urn:uuid:3978344f-8596-4c3a-a978-8fc9a6a469f7",
+  "endpoints" : 
+  {
+    "com.example.telemetry" : {
+      "id" : "com.example.telemetry",
+      "usage": "consumer",
+      "config": {
+        // ... details ......
+      },
+      "format" : "CloudEvents/1.0",
+      "definitionGroups" :[
+        "https://rawdata.repos.example.com/myorg/myproject/main/example.telemetryEvents.cereg#/definitionGroups/com.example.telemetryEvents"
+      ]
+    }
+  }
+}
+```
+
+All other references to other objects in the registry can be expressed in the
+same way.
+
+While the CloudEvents Registry is primarily motivated by enabling development of
+CloudEvents-based event flows, the registry is not limited to CloudEvents. It
+can be used to describe any asynchronous messaging or eventing endpoint and its
+messages, including endpoints that do not use CloudEvents at all. The [Message
+Formats](#message-formats) section therefore not only describes the attribute
+meta-schema for CloudEvents, but also meta-schemas for the native message
+envelopes of MQTT, AMQP, and other messaging protocols.
+
+The registry is designed to be extensible to support any structured data
+encoding and related schemas for message or event payloads. The [Schema
+Formats](#schema-formats) section describes the meta-schema for JSON Schema, XML
+Schema, Apache Avro schema, and Protobuf schema.
+
+### File format
+
+A CloudEvents Registry can be implemented using the Registry API or with plain
+text files.
+
+When using the file-based model, files with the extension `.cereg` use JSON
+encoding. Files with the extension `.cereg.yaml` or `.cereg.yml` use YAML
+encoding. The formal JSON schema for the file format is defined in the
+[CloudEvents Registry Document Schema](#cloudevents-registry-document-schema),
+which implements the Registry format and the CloudEvents Registry format.
+
+The media-type for the file format is `application/cloudevents-registry+json` for the
+JSON encoding and `application/cloudevents-registry+yaml` for the YAML encoding.
+
+The JSON schema identifier is `https://cloudevents.io/schemas/registry` and the
+`specversion` property indicates the version of this specification that the
+elements of the file conform to.
+
+A CloudEvents Registry file MUST contain a single JSON object or YAML document.
+The object declares the roots of the three sub-registries, which are either
+embedded or referenced. Any of the three sub-registries MAY be omitted.
+
+``` meta
+{
+   "$schema": "https://cloudevents.io/schemas/registry",
+   "specversion": "0.4-wip",
+   "endpoints": { ... } | "endpointsUrl": "URL",
+   "definitionGroups": { ... } | "definitionGroupsUrl": "URL"
+   "schemaGroups" : { ... } | "schemagroupsUrl": "URL",
+}
+```
+
+While the file structure leads with endpoints followed by definition groups and
+then schema groups by convention, the order of the sub-registries is not significant.
+
+### Schema Registry
+
+The schema registry is a metadata store for organizing data schemas of any kind.
+
+The Registry API extension model of the Schema Registry is:
+
+``` JSON
+{
+  "groups": [
+    {
+      "singular": "schemaGroup",
+      "plural": "schemaGroups",
+      "schema": "TBD",
+      "resources": [
+        {
+          "singular": "schema",
+          "plural": "schemas",
+          "versions": -1
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Group: schemaGroups
+
+The group (GROUP) name for the Schema Registry is `schemaGroups`. The group does
+not have any specific extension attributes.
+
+A schema group is a collection of schemas that are related to each other in some
+application-defined way. A schema group does not impose an restrictions on the
+contained schenmas, meaning that a schema group can contain schemas of different
+formats. Every schema MUST reside inside a schema group.
+
+Example:
+
+``` meta
+{
+  "schemaGroups": {
+    "com.example.schemas": {
+      "id": "com.example.schemas",
+      "schemas": {
+        ...
+      }
+    }
+  }
+}
+```
+
+#### Resource: schemas
+
+The resources (RESOURCE) collection inside of schema groups is named `schemas`.
+The type of the resource is `schema`. Any single `schema` is a container for
+one or more `versions`, which hold the concrete schema documents or schema
+document references.
+
+Any new schema version that is added to a schema definition MUST be backwards
+compatible with all previous versions of the schema, meaning that a consumer
+using the new schema MUST be able to understand data encoded using a prior
+version of the schema. If a new version introduces a breaking change, it MUST be
+regisetered as a new schema with a new name.
+
+When you retrieve a schema without qualifying the version, you will get the
+latest version of the schema, see [retrieving a
+resource](#retrieving-a-resource). The latest version is the lexically greatest
+version number, whereby all version ids MUST be left-padded with spaces to the
+same length before being compared.
+
+The following extension is defined for the `schema` object in addition to the
+basic [attributes](#attributes-and-extensions):
+
+##### `format` (Schema format)
+
+- Type: String  
+- Description: Identifies the schema format. In absence of formal media-type
+  definitions for several important schema formats, we define a convention here
+  to reference schema formats by name and version as `{NAME}/{VERSION}`. This
+  specification defines a set of common [schema format names](#schema-formats)
+  that MUST be used for the given formats, but applications MAY define
+  extensions for other formats on their own.
+- Constraints:
+  - REQUIRED
+  - MUST be a non-empty string
+  - MUST follow the naming convention `{NAME}/{VERSION}`, whereby `{NAME}` is
+    the name of the schema format and `{VERSION}` is the version of the schema
+    format in the format defined by the schema format itself.
+- Examples:
+  - `JsonSchema/draft-07`
+  - `Protobuf/3`
+  - `XSD/1.1`
+  - `Avro/1.9`  
+
+#### Resource Version: schemaversion
+
+The `VERSION` object of the `schema` resource is of type `schemaversion`. The
+[`format`](#format-schema-format) extension attribute of `schema` MAY be repeated in `schemaversion` for
+clarity, but MUST be identical. `schemaversion` has the following extension
+attributes.
+
+##### `schema`
+
+- Type: String | Object
+- Description: Embedded schema string or object. The format and encoding of the
+  schema is defined by the `format` attribute.
+- Constraints:
+  - Mutually exlusive with `schemaurl`. One of the two MUST be present.
+
+##### `schemaurl`
+
+- Type: URI
+- Description: Reference to a schema document external to the registry.
+- Constraints:
+  - Mutually exlusive with `schemaurl`. One of the two MUST be present.
+  - Cross-references to a schema document within the same registry MUST NOT be
+    used.
+
+The following example shows three embedded `Protobuf/3` schema versions for a
+schema named `com.example.telemetrydata`:
+
+``` JSON
+{
+  "schemaGroups" : {
+    "com.example.telemetry" : {
+      "type" : "schemagroup",
+      "id" : "com.example.telemetry",
+      "schemas": {
+        "com.example.telemetrydata" : {
+          "id": "com.example.telemetrydata",
+          "description": "device telemetry event data",
+          "format": "Protobuf/3",
+          "versions" : {
+            "1.0" : {
+              "type" : "schemaversion",
+              "id" : "1.0",
+              "schema" : "syntax = \"proto3\"; message Metrics { float metric = 1; } }"
+            },
+            "2.0" : {
+              "type" : "schemaversion",
+              "id" : "2.0",
+              "schema" : "syntax = \"proto3\"; message Metrics { float metric = 1; string unit = 2; } }"
+            },
+            "3.0" : {
+              "type" : "schemaversion",
+              "id" : "3.0",
+              "schema" : "syntax = \"proto3\"; message Metrics { float metric = 1; string unit = 2; string description = 3; } }"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Schema Formats
+
+This section defines a set of common schema formats that MUST be used for the
+given formats, but applications MAY define extensions for other formats on their
+own.
+
+##### JSON Schema
+
+The [`format`](#format-schema-format) identifier for JSON Schema is
+`JsonSchema`.
+
+When the `format` attribute is set to `JsonSchema`, the `schema` attribute of
+the `schemaversion` is a JSON object representing a JSON Schema document
+conformant with the declared version.
+
+A URI-reference, like [`schemaurl`](#schemaurl-message-schema-url) that points
+to a JSON Schema document MAY use a JSON pointer expression to deep link into
+the schema document to reference a particular type definition. Otherwise the
+top-level object definition of the schema is used.
+
+The version of the JSON Schema format is the version of the JSON
+Schema specification that is used to define the schema. The version of the JSON
+Schema specification is defined in the `$schema` attribute of the schema
+document.
+
+The identifiers for the following JSON Schema versions
+
+- Draft 07: `http://json-schema.org/draft-07/schema`
+- Draft 2019-09: `https://json-schema.org/draft/2019-09/schema`
+- Draft 2020-12: `https://json-schema.org/draft/2020-12/schema`
+
+are defined as follows:
+
+- `JsonSchema/draft-07`
+- `JsonSchema/draft/2019-09`
+- `JsonSchema/draft/2020-12`
+
+which follows the exact convention as defined for JSON schema and expecting an
+eventually released version 1.0 of the JSON Schema specification using a plain
+version number.
+
+##### XML Schema
+
+The [`format`](#format-schema-format) identifier for XML Schema is `XSD`. The
+version of the XML Schema format is the version of the W3C XML Schema specification
+that is used to define the schema.
+
+When the `format` attribute is set to `XSD`, the `schema` attribute of
+`schemaversion` is a string containing an XML Schema document conformant with
+the declared version.
+
+A URI-reference, like [`schemaurl`](#schemaurl-message-schema-url) that points
+to a XSD Schema document MAY use an XPath expression to deep link into the
+schema document to reference a particular type definition. Otherwise the root
+element definition of the schema is used.
+
+The identifiers for the following XML Schema versions
+
+- 1.0: `https://www.w3.org/TR/xmlschema-1/`
+- 1.1: `https://www.w3.org/TR/xmlschema11-1/`
+
+are defined as follows:
+
+- `XSD/1.0`
+- `XSD/1.1`
+
+##### Apache Avro Schema
+
+The [`format`](#format-schema-format) identifier for Apache Avro Schema is
+`Avro`. The version of the Apache Avro Schema format is the version of the Apache
+Avro Schema release that is used to define the schema.
+
+When the `format` attribute is set to `Avro`, the `schema` attribute of the
+`schemaversion` is a JSON object representing an Avro schema document conformant
+with the declared version.
+
+Examples:
+
+- `Avro/1.8.2` is the identifier for the Apache Avro release 1.8.2.
+- `Avro/1.11.0` is the identifier for the Apache Avro release 1.11.0
+
+A URI-reference, like [`schemaurl`](#schemaurl-message-schema-url) that points
+to an Avro Schema document MUST reference an Avro record declaration contained
+in the schema document using a URI fragment suffix `[:]{record-name}`. The ':'
+character is used as a separator when the URI already contains a fragment.
+
+Examples:
+
+- If the Avro schema document is referenced using the URI
+`https://example.com/avro/telemetry.avsc`, the URI fragment `#TelemetryEvent`
+references the record declaration of the `TelemetryEvent` record.
+- If the Avro schema document is a local schema registry reference like
+`#/schemaGroups/com.example.telemetry/schemas/com.example.telemetrydata`, in the
+which the reference is already in the form of a URI fragment, the suffix is
+appended separated with a colon, for instance
+`.../com.example.telemetrydata:TelemetryEvent`.
+
+##### Protobuf Schema
+
+The [`format`](#format-schema-format) identifier for Protobuf Schema is
+`Protobuf`. The version of the Protobuf Schema format is the version of the
+Protobuf syntax that is used to define the schema.
+
+When the `format` attribute is set to `Protobuf`, the `schema` attribute of the
+`schemaversion` is a string containing a Protobuf schema document conformant with
+the declared version.
+
+- `Protobuf/3` is the identifier for the Protobuf syntax version 3.
+- `Protobuf/2` is the identifier for the Protobuf syntax version 2.
+
+A URI-reference, like [`schemaurl`](#schemaurl-message-schema-url) that points
+to an Protobuf Schema document MUST reference an Protobuf `message` declaration
+contained in the schema document using a URI fragment suffix `[:]{message-name}`.
+The ':' character is used as a separator when the URI already contains a
+fragment.
+
+Examples:
+
+- If the Protobuf schema document is referenced using the URI `https://example.com/protobuf/telemetry.proto`, the URI fragment `#TelemetryEvent` references the message declaration of the `TelemetryEvent` message.
+- If the Protobuf schema document is a local schema registry reference like
+  `#/schemaGroups/com.example.telemetry/schemas/com.example.telemetrydata`, in
+  the which the reference is already in the form of a URI fragment, the suffix
+  is appended separated with a colon, for instance
+  `.../com.example.telemetrydata:TelemetryEvent`.
+
+### Message Definitions Registry
+
+The Message Definitions Registry (or "Message Catalog") is a registry of
+metadata definitions for messages and events. The entries in the registry
+describe constraints for the metadata of messages and events, for instance the
+concrete values and patterns for the `type`, `source`, and `subject` attributes
+of a CloudEvent.
+
+All message definitions (events are a from of messages and are therefore always
+implied to be included from here on forward) are defined inside definition groups.
+
+A definition group is a collection of message definitions that are related to
+each other in some application-specific way. For instance, a definition group
+can be used to group all events raised by a particular application module or by
+a particular role of an application protocol exchange pattern.
+
+The Registry API extension model of the Message Definitions Registry is
+
+``` JSON
+{
+  "groups": [
+    {
+      "singular": "definitionGroup",
+      "plural": "definitionGroups",
+      "schema": "TBD",
+      "resources": [
+        {
+          "singular": "definition",
+          "plural": "definitions",
+          "versions": 0,
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Message Definition Groups
+
+The Group (GROUP) name is `definitionGroups`. The type of a group is `definitionGroup`.
+
+The following attributes are defined for the `definitionGroup` object in addition to the
+basic [attributes](#attributes-and-extensions):
+
+##### `format` (Message format)
+
+- Type: String  
+- Description: Identifies the message metadata format. Message metadata formats
+  are referenced by name and version as `{NAME}/{VERSION}`. This specification
+  defines a set of common [message format names](#message-formats) that MUST be
+  used for the given formats, but applications MAY define extensions for other
+  formats on their own. All definitions inside a group MUST use this same
+  format.
+- Constraints:
+  - REQUIRED
+  - MUST be a non-empty string
+  - MUST follow the naming convention `{NAME}/{VERSION}`, whereby `{NAME}` is
+    the name of the message format and `{VERSION}` is the version of the schema
+    format in the format defined by the schema format itself.
+- Examples:
+  - `CloudEvents/1.0`
+  - `MQTT/3.1.1`
+  - `AMQP/1.0`
+  - `Kafka/0.11`  
+
+#### Message Definitions
+
+The resource (RESOURCE) collection name inside `definitionGroup` is
+`definitions`. The resource name is `definition`.
+
+Different from schemas, message definitions do not contain a
+version history. If the metadata of two messages differs, they are considered
+different definitions.
+
+The following extension is defined for the `definition` object in addition to the
+basic [attributes](#attributes-and-extensions):
+
+##### `format` (Message format, definition)
+
+Same as the [`format`](#format-message-format) attribute of the
+`definitionGroup` object.
+
+Since definitions MAY be cross-referenced ("borrowed") across definition group
+boundaries, this attribute is also REQUIRED and MUST be the same as the `format`
+attribute of the `definitionGroup` object into which the definition is embedded
+or referenced.
+
+Illustrating example:
+
+``` JSONC
+
+"definitionGroups" : {
+  "com.example.abc" : {
+    "type" : "definitionGroup",
+    "id": "com.example.abc",
+    "format" : "CloudEvents/1.0",
+    "definitions" : {
+      "com.example.abc.event1" : {
+        "type" : "definition",
+        "id": "com.example.abc.event1",
+        "format" : "CloudEvents/1.0",
+         // ... details ...
+        }
+      },
+      "com.example.abc.event2" : {
+        "type" : "definition",
+        "id": "com.example.abc.event1",
+        "format" : "CloudEvents/1.0",
+        // ... details ...
+      }
+  },
+  "com.example.def" : {
+    "id": "com.example.def",
+    "format" : "CloudEvents/1.0",
+    "definitions" : {
+      "com.example.abc.event1" : {
+        "uri": "#/definitionGroups/com.example.abc/definitions/com.example.abc.event1",
+        // ... more ...
+      }
+    }
+  }
+}
+```
+
+##### `metadata` (Message metadata)
+
+- Type: Object
+- Description: Describes the metadata constraints for messages of this type. The
+  content of the metadata property is defined by the message format, but all
+  formats use a common schema for the constraints defined for their metadata
+  headers, properties or attributes.
+- Constraints:
+  - REQUIRED
+- Examples:
+  - See [Message Formats](#message-formats)
+
+##### `schemaformat`
+
+- Type: String
+- Description: Identifies the schema format applicable to the message payload,
+  equivalent to the schema ['format'](#format-schema-format) attribute.
+- Constraints:
+  - OPTIONAL
+  - If present, MUST be a non-empty string
+  - If present, MUST follow the naming convention `{NAME}/{VERSION}`, whereby
+    `{NAME}` is the name of the schema format and `{VERSION}` is the version of
+    the schema format in the format defined by the schema format itself.
+- Examples:
+  - 'JSONSchema/draft-07'
+  - 'Avro/1.9.0'
+  - 'Protobuf/3'
+
+##### `schema` (Message schema)
+
+- Type: String | Object as defined by the schema format
+- Description: Contains the inline schema for the message payload. The schema format
+  is identified by the `schemaformat` attribute. Equivalent to the schemaversion
+  ['schema'](#schema) attribute
+- Constraints:
+  - OPTIONAL.
+  - Mutually exclusive with the `schemaurl` attribute.
+  - If present, `schemaformat` MUST be present.
+- Examples:
+  - See [Schema Formats](#schema-formats)
+
+##### `schemaurl` (Message schema URL)
+
+- Type: URI-reference
+- Description: Contains a relative or absolute URI that points to the schema
+  object to use for the message payload. The schema format is identified by the
+  `schemaformat` attribute. See [Schema Formats](#schema-formats) for details on
+  how to reference specific schema objects for the message payload. It is not
+  sufficient for the URI-reference to point to a schema document; it MUST
+  resolve to a concrete schema object.
+- Constraints:
+  - OPTIONAL.
+  - Mutually exclusive with the `schema` attribute.
+  - If present, `schemaformat` MUST be present.
+
+#### Message Formats
+
+This section defines the message formats that are directly supported by this
+specification. Message formats lean on a protocol-neutral metadata definition
+like CloudEvents or on the message model definition of a specific protocol like
+AMQP or MQTT or Kafka. A message format defines constraints for the fixed and
+variable headers/properties/attributes of the event format or protocol message
+model.
+
+> Message format definitions might be specific to a particular client instance
+> and used to configure that client. Therefore, the message format definitions
+> allow for specifying very narrow constraints like the exact value of an Apache
+> Kafka record `key`.
+
+##### Common properties
+
+The following properties are common to all definitions of message
+headers/properties/attributes constraints:
+
+###### `required` (REQUIRED)
+
+- Type: Boolean
+- Description: Indicates whether the property is REQUIRED to be present in a
+  message of this type.
+- Constraints:
+  - OPTIONAL. Defaults to `false`.
+  - If present, MUST be a boolean value.
+
+###### `description` (Description)
+
+- Type: String
+- Description: A human-readable description of the property.
+- Constraints:
+  - OPTIONAL.
+  - If present, MUST be a non-empty string.
+
+###### `value` (Value)
+
+- Type: Any
+- Description: The value of the property. With a few exceptions, see below, this
+  is the value that MUST be literally present in the message for the message to
+  be considered conformant with this metaschema.
+- Constraints:
+  - OPTIONAL.
+  - If present, MUST be a valid value for the property.
+
+If the `type` property has the value `uritemplate`, `value` MAY contain
+placeholders. As defined in [RFC6570][RFC6570] (Level 1), the placeholders MUST
+be enclosed in curly braces (`{` and `}`) and MUST be a valid `symbol`.
+Placeholders that are used multiple times in the same message definition are
+assumed to represent identical values.
+
+When validating a message property against this value, the placeholders act as
+wildcards. For example, the value `{foo}/bar` would match the value `abc/bar` or
+`xyz/bar`.
+
+When creating a message based on a metaschema with such a value, the
+placeholders MUST be replaced with valid values. For example, the value
+`{foo}/bar` would be replaced with `abc/bar` or `xyz/bar` when creating a
+message.
+
+If the `type` property has the value `timestamp` and the `value` property is
+set to a value of `01-01-0000T00:00:00Z`, the value MUST be replaced with the
+current timestamp when creating a message.
+
+###### `type` (Type)
+
+- Type: String
+- Description: The type of the property. This is used to constrain the value of
+  the property.
+- Constraints:
+  - OPTIONAL. Defaults to "string".
+  - The valid types are those defined in the [CloudEvents][CloudEvents Types]
+    core specification, with some additions:
+    - `var`: Any type of value, including `null`.
+    - `boolean`: CloudEvents "Boolean" type.
+    - `string`: CloudEvents "String" type.
+    - `symbol`: A `string` that is restricted to alphanumerical characters and
+      underscores.
+    - `binary`: CloudEvents "Binary" type.
+    - `timestamp`: CloudEvents "Timestamp" type (RFC3339 DateTime)
+    - `duration`: RFC3339 Duration
+    - `uritemplate`: [RFC6570][RFC6570] Level 1 URI Template
+    - `uri`: CloudEvents "URI" type (RFC3986 URI)
+    - `urireference`: CloudEvents "URI-reference" type (RFC3986 URI-reference)
+    - `number`: IEEE754 Double
+    - `integer`: CloudEvents "Integer" type (RFC 7159, Section 6)
+
+###### `specurl` (Specification URL)
+
+- Type: URI-reference
+- Description: Contains a relative or absolute URI that points to the
+  human-readable specification of the property.
+- Constraints:
+  - OPTIONAL
+
+###### CloudEvents/1.0
+
+For the "CloudEvents/1.0" format, the [`metadata`](#metadata-message-metadata)
+object contains a property `attributes`, which is an object whose properties
+correspond to the CloudEvents context attributes.
+
+As with the [CloudEvents specification][CloudEvents], the attributes form a flat list and
+extension attributes are allowed. Attribute names are restricted to lower-case
+alphanumerical characters without separators.
+
+The base attributes are defined as follows:
+
+| Attribute | Type |
+| ---- | ---- |
+| `type` | `string` |
+| `source` | `uritemplate` |
+| `subject` | `string` |
+| `id` | `string` |
+| `time` | `timestamp` |
+| `dataschema` | `uritemplate` |
+| `datacontenttype` | `string` |
+
+The following rules apply to the attribute declarations:
+
+- All attribute declarations are OPTIONAL. Requirements for absent
+  definitions are implied by the CloudEvents specification.
+- The `specversion` attribute is implied by the message format and is NOT
+  REQUIRED. If present, it MUST be declared with a `string` type and set to the
+  value "1.0".
+- The `type`, `id`, and `source` attributes implicitly have the `required` flag
+  set to `true` and MUST NOT be declared as `required: false`.
+- The `id` attribute's `value` SHOULD NOT be defined.
+- The `time` attribute's `value` defaults to `01-01-0000T00:00:00Z` ("current
+  time") and SHOULD NOT be declared with a different value.
+- The `datacontenttype` attribute's `value` is inferred from the
+  [`schemaformat`](#schemaformat) attribute of the message definition if absent.
+- The `dataschema` attribute's `value` is inferred from the
+  [`schemaurl`](#schemaurl-message-schema-url) attribute or
+  [`schema`](#schema-message-schema) attribute of the message definition if
+  absent.
+- The `type` of the property definition defaults to the CloudEvents type
+  definition for the attribute, if any. The `type` of an attribute MAY be
+  modified. For instance, the `source` type `urireference` MAY be changed to
+  `uritemplate` or the `subject` type `string` MAY be constrained to a
+  `urireference` or `integer`. If no CloudEvents type definition exists, the
+  type defaults to `string`.
+
+The values of all `string` and `uritemplate`-typed attributes MAY contain
+placeholders using the [RFC6570][RFC6570] Level 1 URI Template syntax. When the
+same placeholder is used in multiple properties, the value of the placeholder is
+assumed to be identical.
+
+The following example declares a CloudEvent with a JSON payload. The attribute
+`id` is REQUIRED in the declared event per the CloudEvents specification in
+spite of such a declaration being absent here, the `type` of the `type`
+attribute is `string` and the attribute is `required` even though the
+declarations are absent. The `time` attribute is made `required` contrary to the
+CloudEvents base specification. The implied `datacontenttype` is
+`application/json` and the implied `dataschema` is
+`https://example.com/schemas/com.example.myevent.json`:
+
+``` JSON
+{
+  "format": "CloudEvents/1.0",
+  "metadata": {
+    "attributes": {
+      "type": {
+        "value": "com.example.myevent"
+      },
+      "source": {
+        "value": "https://{tenant}/{module}/myevent",
+        "type": "uritemplate"
+      },
+      "subject": {
+        "type": "urireference"
+      },
+      "time": {
+        "required": true
+      },
+    }
+  },
+  "schemaformat": "JsonSchema/draft-07",
+  "schemaurl": "https://example.com/schemas/com.example.myevent.json",
+}
+```
+
+For clarity of the definition, you MAY always declare all implied attribute
+properties explicitly, but they MUST conform with the rules above.
+
+#### "HTTP/1.1", "HTTP/2", "HTTP/3"
+
+The "HTTP" format is used to define messages that are sent over an HTTP
+connection. The format is based on the [HTTP Message Format][HTTP Message
+ Format] and is common across all version of HTTP.
+
+The [`metadata`](#metadata-message-metadata) object MAY contain several
+properties:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `headers` | Array | The HTTP headers. See below. |
+| `query` | Map | The HTTP query parameters. |
+| `path` | `uritemplate` | The HTTP path. |
+| `method` | `string` | The http method |
+| `status` | `string` | The http status code |
+
+HTTP allows for multiple headers with the same name. The `headers` property is
+therefore an array of objects with `name` and `value` properties. The `name`
+property is a string that MUST be a valid HTTP header name.
+
+The `query` property is a map of string keys to string values.
+
+The `path` property is a URI template.
+
+The `method` property is a string that MUST be a valid HTTP method.
+
+The `status` property is a string that MUST be a valid HTTP response
+code. The `status` and `method` properties are mutually exclusive and
+MUST NOT be present at the same time.
+
+The values of all `string` and `uritemplate`-typed properties and headers and
+query elements MAY contain placeholders using the [RFC6570][RFC6570] Level 1 URI
+Template syntax. When the same placeholder is used in multiple properties, the
+value of the placeholder is assumed to be identical.
+
+The following example defines a message that is sent over HTTP/1.1:
+
+``` JSON
+{
+  "format": "HTTP/1.1",
+  "metadata": {
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/json"
+      }
+    ],
+    "query": {
+      "foo": "bar"
+    },
+    "path": "/foo/{bar}",
+    "method": "POST"
+  },
+  "schemaformat": "JsonSchema/draft-07",
+  "schemaurl": "https://example.com/schemas/com.example.myevent.json",
+}
+```
+
+#### "AMQP/1.0"
+
+The "AMQP/1.0" format is used to define messages that are sent over an [AMQP][AMQP 1.0]
+connection. The format is based on the default [AMQP 1.0 Message Format][AMQP
+1.0 Message Format].
+
+The [`metadata`](#metadata-message-metadata) object MAY contain several
+properties, each of which corresponds to a section of the AMQP 1.0 Message:
+
+| Property | Type | Description |
+| ---- | --- | ---- |
+| `properties` | Map | The AMQP 1.0 [Message Properties][AMQP 1.0 Message Properties] section. |
+| `application-properties` | Map | The AMQP 1.0 [Application Properties][AMQP 1.0 Application Properties] section. |
+| `message-annotations` | Map | The AMQP 1.0 [Message Annotations][AMQP 1.0 Message Annotations] section. |
+| `delivery-annotations` | Map | The AMQP 1.0 [Delivery Annotations][AMQP 1.0 Delivery Annotations] section. |
+| `header` | Map | The AMQP 1.0 [Message Header][AMQP 1.0 Message Header] section. |
+| `footer` | Map | The AMQP 1.0 [Message Footer][AMQP 1.0 Message Footer] section. |
+
+As in AMQP, all sections and properties are OPTIONAL.
+
+The values of all `string`, `symbol`, `uri`, and `uritemplate`-typed properties
+MAY contain placeholders using the [RFC6570][RFC6570] Level 1 URI Template
+syntax. When the same placeholder is used in multiple properties, the value of
+the placeholder is assumed to be identical.
+
+Example for an AMQP 1.0 message type that declares a fixed `subject` (analogous
+to CloudEvents' `type`), a custom property, and a `content-type` of
+`application/json` without declaring a schema reference in the message
+definition:
+
+``` JSON
+{
+  "format" : "AMQP/1.0",
+  "metadata": {
+    "properties": {
+      "message-id": {
+        "required" : true
+      },
+      "to": {
+        "value": "https://{host}/{queue}"
+      },
+      "subject": {
+        "value": "MyMessageType"
+        "required" : true
+      },
+      "content-type": {
+        "value": "application/json"
+      },
+      "content-encoding": {
+        "value": "utf-8"
+      }
+    },
+    "application-properties": {
+      "my-application-property": {
+        "value": "my-application-property-value"
+      }
+    }
+  }
+}
+```
+
+##### `properties` (AMQP 1.0 Message Properties)
+
+The `properties` property is an object that contains the properties of the
+AMQP 1.0 [Message Properties][AMQP 1.0 Message Properties] section. The
+following properties are defined, with type constraints:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `message-id` | `string` | uniquely identifies a message within the message system |
+| `user-id` | `binary` | identity of the user responsible for producing the message |
+| `to` | `uritemplate` | address of the node to send the message to |
+| `subject` | `string` | message subject |
+| `reply-to` | `uritemplate` | address of the node to which the receiver of this message ought to send replies |
+| `correlation-id` | `string` | client-specific id that can be used to mark or identify messages between clients |
+| `content-type` | `symbol` | MIME content type for the message |
+| `content-encoding` | `symbol` | MIME content encoding for the message |
+| `absolute-expiry-time` | `timestamp` | time when this message is considered expired |
+| `group-id` | `string` | group this message belongs to |
+| `group-sequence` | `integer` | position of this message within its group |
+| `reply-to-group-id` | `uritemplate` | group-id to which the receiver of this message ought to send replies to |
+
+##### `application-properties` (AMQP 1.0 Application Properties)
+
+The `application-properties` property is an object that contains the custom
+properties of the AMQP 1.0 [Application Properties][AMQP 1.0 Application Properties] section.
+
+The names of the properties MUST be of type `symbol` and MUST be unique.
+The values of the properties MAY be of any permitted type.
+
+##### `message-annotations` (AMQP 1.0 Message Annotations)
+
+The `message-annotations` property is an object that contains the custom
+properties of the AMQP 1.0 [Message Annotations][AMQP 1.0 Message Annotations] section.
+
+The names of the properties MUST be of type `symbol` and MUST be unique.
+The values of the properties MAY be of any permitted type.
+
+##### `delivery-annotations` (AMQP 1.0 Delivery Annotations)
+
+The `delivery-annotations` property is an object that contains the custom
+properties of the AMQP 1.0 [Delivery Annotations][AMQP 1.0 Delivery Annotations] section.
+
+The names of the properties MUST be of type `symbol` and MUST be unique.
+The values of the properties MAY be of any permitted type.
+
+###### `header` (AMQP 1.0 Message Header)
+
+The `header` property is an object that contains the properties of the
+AMQP 1.0 [Message Header][AMQP 1.0 Message Header] section. The
+following properties are defined, with type constraints:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `durable` | `boolean` | specify durability requirements |
+| `priority` | `integer` | relative message priority |
+| `ttl` | `integer` | message time-to-live in milliseconds |
+| `first-acquirer` | `boolean` | indicates whether the message has not been acquired previously |
+| `delivery-count` | `integer` | number of prior unsuccessful delivery attempts |
+
+##### `footer` (AMQP 1.0 Message Footer)
+
+The `footer` property is an object that contains the custom properties of the
+AMQP 1.0 [Message Footer][AMQP 1.0 Message Footer] section.
+
+The names of the properties MUST be of type `symbol` and MUST be unique.
+The values of the properties MAY be of any permitted type.
+
+#### "MQTT/3.1.1" and "MQTT/5.0"
+
+The "MQTT/3.1.1" and "MQTT/5.0" formats are used to define messages that are
+sent over [MQTT 3.1.1][MQTT 3.1.1] or [MQTT 5.0][MQTT 5.0] connections. The
+format describes the [MQTT PUBLISH packet][MQTT 5.0] content.
+
+The [`metadata`](#metadata-message-metadata) object contains the elements of the
+MQTT PUBLISH packet directly, with the `user-properties` element corresponding
+to the application properties collection of other protocols.
+
+The following properties are defined. The MQTT 3.1.1 and MQTT 5.0 columns
+indicate whether the property is supported for the respective MQTT version.
+
+| Property | Type | MQTT 3.1.1 | MQTT 5.0 | Description |
+| --- | --- | --- | --- | --- |
+| `qos` | `integer` | yes | yes | Quality of Service level |
+| `retain` | `boolean` | yes | yes | Retain flag |
+| `topic-name` | `string` | yes | yes | Topic name |
+| `payload-format` | `integer` | no | yes | Payload format indicator |
+| `message-expiry-interval` | `integer` | no | yes | Message expiry interval |
+| `response-topic` | `uritemplate` | no | yes | Response topic |
+| `correlation-data` | `binary` | no | yes | Correlation data |
+| `content-type` | `symbol` | no | yes | MIME content type of the payload |
+| `user-properties` | Array | no | yes | User properties |
+
+Like HTTP, the MQTT allows for multiple user properties with the same name,
+so the `user-properties` property is an array of objects, each of which
+contains a single property name and value.
+
+The values of all `string`, `symbol`, and `uritemplate`-typed properties and
+user-properties MAY contain placeholders using the [RFC6570][RFC6570] Level 1
+URI Template syntax. When the same placeholder is used in multiple properties,
+the value of the placeholder is assumed to be identical.
+
+The following example shows a message with the "MQTT/5.0" format, asking for
+QoS 1 delivery, with a topic name of "mytopic", and a user property of
+"my-application-property" with a value of "my-application-property-value":
+
+``` JSON
+{
+  "format" : "MQTT/5.0",
+  "metadata": {
+    "qos": {
+      "value": 1
+    },
+    "retain": {
+      "value": false
+    },
+    "topic-name": {
+      "value": "mytopic"
+    },
+    "user-properties": [
+      { "my-application-property": {
+            "value": "my-application-property-value"
+          }
+      }
+    ]
+  }
+}
+```
+
+#### "Kafka/0.11" format
+
+The "Kafka" format is used to define messages that are sent over [Apache
+Kafka][Apache Kafka] connections. The version number reflects the last version
+in which the record structure was changed in the Apache Kafka project, not the
+current version. If the version number is omitted, the latest version is
+assumed.
+
+The [`metadata`](#metadata-message-metadata) object contains the common elements
+of the Kafka [producer][Apache Kafka producer] and [consumer][Apache Kafka
+consumer] records, with the `headers` element corresponding to the application
+properties collection of other protocols.
+
+The following properties are defined:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `topic` | `string` | The topic the record will be appended to |
+| `partition` | `integer` | The partition to which the record ought be sent |
+| `key` | `binary` | The key that will be included in the record |
+| `headers` | Map | A map of headers to set on the record |
+| `timestamp` | `integer` | The timestamp of the record; if 0 (default), the producer will assign the timestamp |
+
+The values of all `string`, `symbol`, `uritemplate`-typed properties
+and headers MAY contain placeholders using the [RFC6570][RFC6570] Level 1 URI
+Template syntax. When the same placeholder is used in multiple properties, the
+value of the placeholder is assumed to be identical.
+
+Example:
+
+``` JSON
+{
+  "format" : "Kafka/0.11",
+  "metadata" : {
+    "topic" : {
+      "value" : "mytopic"
+    },
+    "key" : {
+      "value" : "thisdevice"
+    }
+  }
+}
+
+```
+
+### Endpoint Registry
+
+The Endpoint Registry is a registry of metadata definitions for abstract and
+concrete network endpoint to which messages can be produced, from which messages
+can be consumed, or which makes messages available for subscription and
+delivery to a consumer-designated endpoint.
+
+As discussed in [CloudEvents Registry overview](#cloudevents-registry),
+endpoints are supersets of [message definition groups](#message-definition-groups)
+and MAY contain inlined definitions. Therefore, the RESORCE level in the
+meta-model for the Endpoint Registry are likewise `definitions`:
+
+``` JSON
 {
   "groups": [
     {
@@ -1519,50 +2889,82 @@ The Registry model defined by an Endpoint Registry is:
           "mutable": true
         }
       ]
-    },
-    {
-      "singular": "defintionGroup",
-      "plural": "definitionGroups",
-      "schema": "TBD",
-      "resources": [
-        {
-          "singular": "definition",
-          "plural": "definitions",
-          "versions": 0,
-          "mutable": true
-        }
-      ]
     }
   ]
 }
 ```
 
+#### Endpoints: endpoints
 
-### Endpoints
+A Group (GROUP) name is `endpoints`. The type of a group is `endpoint`.
 
-A Group (GROUP) name of `endpoints` is defined with the following
-extension attributes:
+The following attributes are defined for the `endpoint` type:
 
-```
-"origin": "URI", ?
-"deprecated": { ... }, ?
-"channel", "STRING", ?
+##### `usage`
 
-"usage": "subscriber|consumer|producer",
-"config": {
-  "protocol": "STRING",
-  "endpoints": "URL" | [ "URL", ... ],
-  "options": { ... }, ?
-  "strict": true|false ?
-}, ?
+- Type: String (Enum: `subscriber`, `consumer`, `producer`)
+- Description: The `usage` attribute is a string that indicates the intended
+  usage of the endpoint by communicating parties.
+  
+  Each of these parties will have a different perspective on an endpoint. For
+  instance, a `producer` endpoint is seen as a "target" by the originator of
+  messages, and as a "source" by the party that accepts the messages. The
+  nomenclature used for the `usage` field is primarily oriented around the
+  common scenario of network endpoints being provided by some sort of
+  intermediary like a message broker. The term `producer` primarily describes
+  the relationship of a client with that intermediary.
+  
+  In a direct-delivery scenario where the originator of messages connects
+  directly to the target (e.g. a "WebHook" call), the target endpoint implements
+  the accepting end of the `producer` relationship.
 
-"format": "STRING", ?
-"definitionGroups": [ DEFINITIONGROUP-URI-Reference, ... ] ?
-```
+  Some of these perspectives are mentioned below for illustration, but not
+  formally defined or reflected in the metadata model. Perspectives depend on
+  the context in which the endpoint metadata is used and this metadata model is
+  intentionally leaving perspectives open to users.
+  
+  The following values are defined for `usage`
 
-??? maybe `definitionGroups` ought to be a URL in case the list is large?
+  - `subscriber`: The endpoint offers managing subscriptions for delivery of
+    messages to another endpoint, using the [CloudEvents Subscriptions
+    API][CloudEvents Subscriptions API].
+
+    Some perspectives that might exist on a subscriber endpoint:
+    - Application from which messages originate
+    - Application which accepts messages from the delivery agent
+    - Application which manages subscriptions for delivery of messages to the
+      target application. This might be a message broker subscription manager.
+  
+  - `consumer`:  The endpoint offers messages being consumed from it.
+
+    Some perspectives that might exist on a consumer endpoint:
+    - Message store or source which makes messages available for consumption;
+      this might be a message broker topic or a queue.
+    - Proxy or other intermediary which solicits messages from the source and
+      forwards them to the target endpoint.
+    - Application which consumes messages
+  
+  - `producer`: The endpoint offers messages being produces (sent) to it.
+
+    Some perspectives might exist on a producer endpoint:
+    - Application from which messages originate
+    - Reverse proxy or other intermediary which accepts messages from the
+      originator and forwards them to the target endpoint.
+    - Application which accepts messages. This might be a message broker topic
+      or a queue. This might be an HTTP endpoint that directly accepts and
+      handles messages.
+
+  Any endpoint can be seen from different role perspectives:
+  
+  There might also be further perspectives such as pipeline stages for
+  pre-/post-processing, etc.
+
+- Constraints:
+  - REQUIRED.
+  - MUST be one of "subscriber", "consumer", or "producer".
 
 #### `origin`
+
 - Type: URI
 - Description: A URI reference to the original source of this Endpoint. This
   can be used to locate the true authority owner of the Endpoint in cases of
@@ -1577,6 +2979,7 @@ extension attributes:
   - `https://example2.com/myregistry/endpoints/9876`
 
 #### `deprecated`
+
 - Type: Object containing the following properties:
   - effective<br>
     An OPTIONAL property indicating the time when the Endpoint entered, or will
@@ -1625,14 +3028,24 @@ extension attributes:
     ```
 
 #### `channel`
+
 - Type: String
 - Description: A string that can be used to correlate Endpoints. Any Endpoints
-  within an instance of an Endpoint Regsitry that share the same non-empty
+  within an instance of an Endpoint Registry that share the same non-empty
   `channel` value MUST have some relationship. This specification does not
   define that relationship or the specific values used in this property.
   However, it is expected that the `usage` value in combination with this
   `channel` property will provide some information to help determine the
   relationship.
+
+  For instance, a message broker queue "queue1" might be represented with a
+  `producer` endpoint and a `consumer` endpoint, both with the same `channel`
+  attribute value of "queue1".
+
+  An event processing pipeline might have a sequence of stages, each with a
+  `producer` endpoint and a `consumer` endpoint, all with the same `channel`
+  attribute value of "pipeline1", or some further qualification like
+  "pipeline1-stage1", etc.
 
   When this property has no value it MUST either be serialized as an empty
   string or excluded from the serialization entirely.
@@ -1642,240 +3055,363 @@ extension attributes:
 - Examples:
   - `queue1`
 
-#### `usage`
-- Type: String
-- Description: The interaction model supported by this Endpoint. This
-  specification defines a set of possible values (see the
-  [Usage Values](#usage-values) section for more information, however,
-  implementations MAY define new values as extensions. It is RECOMMENDED
-  that extension values be defined with some organizational unique string
-  to reduce the chances of collisions with possible future spec-defined values.
-- Constraints:
-  - REQUIRED
-  - MUST be a non-empty string
-- Examples:
-  - `consumer`
+##### `definitions` (Endpoint)
 
-#### `config`
-- Type: Object
-- Description: Metadata that provides additional information concerning the
-  interactions with this Endpoint. This metadata MUST be related to the
-  `usage` value specified.
+Endpoints are supersets of [message definition groups](#message-definition-groups)
+and MAY contain inlined definitions. See [Message Definitions](#message-definitions).
 
-  When this property has no value it MUST either be serialized as an empty
-  object or excluded from the serialization entirely.
-- Constraints:
-  - OPTIONAL
-- Examples:
-  - `{ "protocol": "kafka", "endpoints": "example.com/mykafka" }`
+Example:
 
-##### `config.protocol`
-- Type: xxx
-- Description: xxx
-- Constraints:
-  - xxx
-- Examples:
-  - xxx
-
-##### `config.endpoints`
-- Type: xxx
-- Description: xxx
-- Constraints:
-  - xxx
-- Examples:
-  - xxx
-
-##### `config.options`
-- Type: xxx
-- Description: xxx
-- Constraints:
-  - xxx
-- Examples:
-  - xxx
-
-##### `config.strict`
-- Type: xxx
-- Description: xxx
-- Constraints:
-  - xxx
-- Examples:
-  - xxx
-
-#### `format`
-- Type: String
-- Description: Specifies the set of rules that govern how the messages for this
-  Endpoint MUST be formatted. This value can be used to definitively identify
-  the type of messages without checking the individual attributes defined by
-  the associated message definitions.
-
-  If present and is not an empty string, then all Definition Groups and
-  Definitions associated with this Endpoint MUST have a `format` value that
-  matches this property's value.
-
-  See the [Message Formats](#message-formats) section for more information.
-
-  When this property has no value it MUST either be serialized as an empty
-  string or excluded from the serialization entirely.
-- Constraints:
-  - OPTIONAL
-- Examples:
-  - `cloudevents/1.0`
-  - `amqp/1.0`
-
-#### `definitionGroups`
-- Type: Array of DEFINITIONGROUP-URI-References
-- Description: A set of Definition Groups supported by this Endpoint. Each
-  Group Reference MAY be to a Group defined outside of the current Endpoint
-  Regsitry instance.
-
-  When this property has no value it MUST either be serialized as an empty
-  array or excluded from the serialization entirely.
-- Constraints:
-  - OPTIONAL
-  - if present, the same Group, as identified by its `id`, MUST NOT appear
-    more than once within this property. It might be difficult to detect
-    cases where a nested Group reference would result in a recursive situation.
-    In those cases it would be an error state and this Endpoint Registry
-    is not compliant. As a means to recover from this state, a client MAY
-    choose to break the recursive nature of the references by removing the
-    first occurrence of a reference that refers to a previous seen parent
-    reference.
-- Examples:
-  - ```
-    [ "https://example.com/myendpoints/definitionGroups/987",
-       "/definitionGroups/MyGroup" ]
-    ```
-
-
-#### Usage Values
-
-The Endpoint `usage` value indicates how clients of the Endpoint are meant
-to interact with it. There are 3 values defined by this specification:
-- `subscriber`: in order for clients to receives messages from this Endpoint
-  a subscribe request MUST be sent to one of the Endpoint's `config.endpoints`
-  URLs. The Endpoints messages MUST be sent using a "push" delivery mechanism
-  to a location specified within the subscribe request.
-- `consumer`: clients can receive messages from this Endpoint by issuing a
-  "pull" type of request to one of the Endpoint's `config.endpoints` URLs.
-- `producer`: clients can send messages to this Endpoint by ussing a "push"
-   type of request to one of the Endpoint's `config.endpoints` URLs.
-
-Implementations MAY defined additional `usage` values, but it is RECOMMENDED
-that they are defined with some organizational unique string to reduce the
- chances of collisions with possible future spec-defined values.
-
-For each possible `usage` value, the Endpoint's `config.protocol` value
-indicates the mechanism by which the messages will be transferred to/from the
-Endpoint.
-
-
-#### Message Formats
-
-TBD
-
-```
-cloudevents/1.0
-amqp
-kafka
-```
-
-### DefinitionGroups
-
-A Group (GROUP) name of `definitionGoups` is defined with the following
-extension attributes:
-
-```
-  "self": "URI",
-  "origin": "URI", ?
-  "definitionGroups": [ GROUP-URI-Reference, ... ], ?  # Nested groups
-}
-```
-
-
-### Definitions
-
-A Resource (RESOURCE) name of `definitions` and a Resource Entity are
-defined.
-
-The Resource entity is defined as:
-
-```
+``` JSON
 {
-  "id": "STRING",                        # URI-Reference?
-  "name": "STRING",
-  "description": "STRING", ?
-  "tags": { "STRING": "STRING" * }, ?
-  "version": "STRING", ?
-
-  "createdBy": "STRING", ?
-  "createdOn": "TIME", ?
-  "modifiedBy": "STRING", ?
-  "modifiedOn": "TIME", ?
-  "docs": "URL", ?                           # end of common attributes
-
-  "self": "URI",
-  "origin": "URI", ?
-  "ownerGroup": "GROUP-URI-Reference",
-  "format": "STRING", ?                      # type ?
-  "metadata": {
-    "attributes": {
-      "ATTRIBUTE_NAME": {
-        "required": true|false,
-        "description": "STRING", ?
-        "value": JSON_OBJECT,
-        "type": "string|object|...", ?
-        "specURL": "URL" ?
-      }
-    } *
-  }, ?
-  "schemaformat": "STRING", ?
-  "schema": { ... }, ?
-  "schemaURL": "URL" ?
-}
+  "protocol": "HTTP/1.1",
+  "options": {
+    "method": "POST"
+    },
+  "definitions" : {
+    "myevent": {
+      "format": "CloudEvents/1.0",
+      "metadata": {
+        "attributes": {
+          "type" : {
+            "value" : "myevent"
+          }
+}}}}}
 ```
 
-## Schema Registry
+##### `definitionGroups` (Endpoint)
 
-This section defines the custom attributes that a Schema Registry supports.
+The `definitionGroups` attribute is an array of URI-references to message
+definition groups. The `definitionGroups` attribute is used to reference
+message definition groups that are not inlined in the endpoint definition.
 
-The Registry model defined by a Schema Registry is:
-```
+Example:
+
+``` JSON
 {
-  "groups": [
-    {
-      "singular": "schemagroup",
-      "plural": "schemagroups",
-      "schema": "TBD",
-      "resources": [
-        {
-          "singular": "schema",
-          "plural": "schemas",
-          "versions": -1,
-        }
-      ]
-    }
+  "protocol": "HTTP/1.1",
+  "options": {
+    "method": "POST"
+    },
+  "definitionGroups" : [
+    "https://example.com/registry/definitiongroups/mygroup"
   ]
 }
 ```
 
+##### `config`
 
-### SchemaGroups
+- Type: Map
+- Description: Configuration details of the endpoint. An endpoint
+  MAY be defined without detail configuration. In this case, the endpoint is
+  considered to be "abstract".
+  > Note: Authentication and authorization details are intentionally **not**
+  > included in the endpoint metadata. The supported authentication and
+  > authorization mechanisms are either part of the protocol, negotiated at
+  > runtime (e.g. SASL), made available through the specific endpoint's
+  > documentation, or separate metadata specific to security policies.
+- Constraints:
+  - OPTIONAL
 
-A Group (GROUP) name of `schemagroups` is defined with the following extension
-attributes:
+##### `config.protocol`
 
+- Type: String
+- Description: The transport or application protocol used by the endpoint. This
+  specification defines a set of common protocol names that MUST be used for
+  respective protocol endpoints, but implementations MAY define and use
+  additional protocol names.
+
+  Predefined protocols are referred tp by name and version as
+  `{NAME}/{VERSION}`. If the version is not specified, the default version of
+  the protocol is assumed. The version number format is determined by the
+  protocol specification's usage of versions.
+
+  The predefined protocol names are:
+  - "HTTP/1.1", "HTTP/2", "HTTP/3" - Use the *lowest* HTTP version
+    that the endpoints supports; that is commonly "HTTP/1.1". The default
+    version is "HTTP/1.1" and MAY be shortened to "HTTP".
+  - "AMQP/1.0" - Use the [AMQP 1.0][AMQP 1.0] protocol. MAY be shortened to
+    "AMQP". AMQP draft versions before 1.0 (e.g. 0.9) are *not* AMQP.
+  - "MQTT/3.1.1", "MQTT/5.0" - Use the MQTT [3.1.1][MQTT 3.1.1] or [5.0][MQTT
+    5.0] protocol. The shorthand "MQTT" maps to "MQTT/5.0".
+  - "NATS/1.0.0" - Use the [NATS][NATS] protocol. MAY be shortened to "NATS",
+  - which assumes usage of the latest NATS clients.
+  - "KAFKA/3.5" - Use the [Apache Kafka][Apache Kafka] protocol. MAY be
+    shortened to "KAFKA", which assumes usage of the latest Apache Kafka
+    clients.
+  
+  An example for an extension protocol identifier might be "BunnyMQ/0.9.1".
+
+- Constraints:
+  - REQUIRED
+  - MUST be a non-empty string.
+
+##### `config.endpoints`
+
+- Type: Array of URI
+- Description: The network addresses that are for communication with the
+  endpoint. The endpoints are ordered by preference, with the first endpoint
+  being the preferred endpoint. Some protocol implementations might not support
+  multiple endpoints, in which case all but the first endpoint might be ignored.
+  Whether the URI just identifies a network host or links directly to a resource
+  managed by the network host is protocol specific.
+- Constraints:
+  - OPTIONAL
+  - Each entry MUST be a valid, absolute URI (URL)
+- Examples:
+  - `["tcp://example.com", "wss://example.com"]`
+  - `["https://example.com"]`
+
+##### `config.options`
+
+- Type: Map
+- Description: Additional configuration options for the endpoint. The
+  configuration options are protocol specific and described in the
+  [protocol options](#protocol-options) section below.
+- Constraints:
+  - OPTIONAL
+  - When present, MUST be a map of non-empty strings to non-empty strings.
+  - If `config.protocol` is a well-known protocol, the options MUST be
+    compliant with the [protocol's options](#protocol-options).
+
+##### `config.strict`
+
+- Type: Boolean
+- Description: If `true`, the endpoint metadata represents a public, live
+  endpoint that is available for communication and a strict validator MAY test
+  the liveness of the endpoint.
+- Constraints:
+  - OPTIONAL.
+  - Default value is `false`.
+
+##### Protocol Options
+
+The following protocol options (`config.options`) are defined for the respective
+protocols. All of these are OPTIONAL.
+
+###### HTTP options
+
+The [endpoint URIs](#configendpoints) for "HTTP" endpoints MUST be valid HTTP
+URIs using the "http" or "https" scheme.
+
+The following options are defined for HTTP:
+
+- `method`: The HTTP method to use for the endpoint. The default value is
+  `POST`. The value MUST be a valid HTTP method name.
+- `headers`: An array of HTTP headers to use for the endpoint. HTTP allows for
+  duplicate headers. The objects in the array have the following attributes:
+  - `name`: The name of the HTTP header. The value MUST be a non-empty string.
+  - `value`: The value of the HTTP header. The value MUST be a non-empty string.
+- `query`: A map of HTTP query parameters to use for the endpoint. The value
+  MUST be a map of non-empty strings to non-empty strings.
+
+The values of all `query` and `headers` MAY contain placeholders using the
+[RFC6570][RFC6570] Level 1 URI Template syntax. When the same placeholder is
+used in multiple properties, the value of the placeholder is assumed to be
+identical.
+
+Example:
+
+```JSON
+{
+  "protocol": "HTTP/1.1",
+  "options": {
+    "method": "POST",
+    "headers": [
+      {
+        "name": "Content-Type",
+        "value": "application/json"
+      }
+    ],
+    "query": {
+      "operation": "send"
+    }
+  }
+}
 ```
-None
+
+##### AMQP options
+
+The [endpoint URIs](#configendpoints) for "AMQP" endpoints MUST be valid AMQP
+URIs using the "amqp" or "amqps" scheme. If the path portion of the URI is
+present, it MUST be a valid AMQP node name.
+
+The following options are defined for AMQP endpoints.
+
+- `node`: The name of the AMQP node (a queue or topic or some addressable entity) to
+  use for the endpoint. If present, the value overrides the path portion of the Endpoint URI.
+- `durable`: If `true`, the AMQP `durable` flag is set on transfers. The default
+  value is `false`. This option only applies to `usage:producer` endpoints.
+- `link-properties`: A map of AMQP link properties to use for the endpoint. The
+  value MUST be a map of non-empty strings to non-empty strings.
+- `connection-properties`: A map of AMQP connection properties to use for the
+  endpoint. The value MUST be a map of non-empty strings to non-empty strings.
+- `distribution-mode`: Either `move` or `copy`. The default value is `move`. The
+  distribution mode is AMQP's way of expressing whether a receiver operates on
+  copies of messages (it's a topic subscriber) or whether it moves messages from
+  the queue (it's a queue consumer). This option only applies to
+  `usage:consumer` endpoints.
+
+The values of all `link-properties` and `connection-properties` MAY contain
+placeholders using the [RFC6570][RFC6570] Level 1 URI Template syntax. When the
+same placeholder is used in multiple properties, the value of the placeholder is
+assumed to be identical.
+
+Example:
+
+```JSON
+{
+  "usage" : "producer",
+  "protocol": "AMQP/1.0",
+  "options": {
+    "node": "myqueue",
+    "durable": true,
+    "link-properties": {
+      "my-link-property": "my-link-property-value"
+    },
+    "connection-properties": {
+      "my-connection-property": "my-connection-property-value"
+    },
+    "distribution-mode": "move"
+  }
+}
 ```
 
+##### MQTT options
 
-### Schemas
+The [endpoint URIs](#configendpoints) for "MQTT" endpoints MUST be valid MQTT
+URIs using the (informal) "mqtt" or "mqtts" scheme. If the path portion of the
+URI is present, it MUST be a valid MQTT topic name. The informal schemes "tcp"
+(plain TCP/1883), "ssl" (TLS TCP/8883), and "wss" (Websockets/443) MAY also be
+used, but MUST NOT have a path.
 
-A Resource (RESOURCE) name of `schemas` is defined with the following `meta`
-extension attributes:
+The following options are defined for MQTT endpoints.
 
+- `topic`: The MQTT topic to use for the endpoint. If present, the value
+  overrides the path portion of the Endpoint URI. The value MAY contain
+  placeholders using the [RFC6570][RFC6570] Level 1 URI Template syntax
+- `qos`: The MQTT Quality of Service (QoS) level to use for the endpoint. The
+  value MUST be an integer between 0 and 2. The default value is 0. The value is
+  overidden by the `qos` property of the [MQTT message format](#mqtt311-and-mqtt50).
+- `retain`: If `true`, the MQTT `retain` flag is set on transfers. The default
+  value is `false`. The value is overidden by the `retain` property of the [MQTT
+  message format](#mqtt311-and-mqtt50). This option only applies to
+  `usage:producer` endpoints.
+- `clean-session`: If `true`, the MQTT `clean-session` flag is set on
+  connections. The default value is `true`.
+- `will-topic`: The MQTT `will-topic` to use for the endpoint. The value MUST be
+  a non-empty string. The value MAY contain placeholders using the
+  [RFC6570][RFC6570] Level 1 URI Template syntax
+- `will-message`: This is URI and/or JSON Pointer that refers to the MQTT
+  `will-message` to use for the endpoint. The value MUST be a non-empty string.
+  It MUST point to a valid [´definition´](#message-definitions) that MUST either
+  use the ["CloudEvents/1.0"](#cloudevents10) or ["MQTT/3.1.1." or
+  "MQTT/5.0"](#mqtt311-and-mqtt50) [`format`](#format-message-format).
+
+Example:
+
+```JSON
+{
+  "usage" : "producer",
+  "protocol": "MQTT/5.0",
+  "options": {
+    "topic": "mytopic",
+    "qos": 1,
+    "retain": false,
+    "clean-session": false,
+    "will-topic": "mytopic",
+    "will-message": "#/definitionGroup/mygroup/definitions/my-will-message"
+  }
+}
 ```
-"authority": "URI" ?
+
+##### KAFKA options
+
+The [endpoint URIs](#configendpoints) for "Kafka" endpoints MUST be valid Kafka
+bootstrap server addresses. The scheme follows Kafka configuration usage, e.g.
+`SSL://{host}:{port}` or `PLAINTEXT://{host}:{port}`.
+
+The following options are defined for Kafka endpoints.
+
+- `topic`: The Kafka topic to use for the endpoint. The value MUST be a non-empty
+  string if present. The value MAY contain placeholders using the
+  [RFC6570][RFC6570] Level 1 URI Template syntax
+- `acks`: The Kafka `acks` setting to use for the endpoint. The value MUST be an
+  integer between -1 and 1. The default value is 1. This option only applies to
+  `usage:producer` endpoints.
+- `key`: The fixed Kafka key to use for this endpoint. The value MUST be a
+  non-empty string if present. This option only applies to `usage:producer`
+  endpoints. The value MAY contain placeholders using the
+  [RFC6570][RFC6570] Level 1 URI Template syntax
+- `partition`: The fixed Kafka partition to use for this endpoint. The value
+  MUST be an integer if present. This option only applies to `usage:producer`
+  endpoints.
+- `consumer-group`: The Kafka consumer group to use for this endpoint. The value
+  MUST be a non-empty string if present. This option only applies to
+  `usage:consumer` endpoints. The value MAY contain placeholders using the
+  [RFC6570][RFC6570] Level 1 URI Template syntax
+
+Example:
+
+```JSON
+{
+  "usage" : "producer",
+  "protocol": "Kafka/2.0",
+  "options": {
+    "topic": "mytopic",
+    "acks": 1,
+    "key": "mykey",
+  }
+}
 ```
 
+##### NATS options
+
+The [endpoint URIs](#configendpoints) for "NATS" endpoints MUST be valid NATS
+URIs. The scheme MUST be "nats" or "tls" or "ws" and the URI MUST include a port
+number, e.g. `nats://{host}:{port}` or `tls://{host}:{port}`.
+
+The following options are defined for NATS endpoints.
+
+- `subject`: The NATS subject to use. The value MAY contain placeholders using
+  the [RFC6570][RFC6570] Level 1 URI Template syntax
+
+Example:
+
+```JSON
+{
+  "usage" : "producer",
+  "protocol": "NATS/1.0.0",
+  "options": {
+    "subject": "mysubject"
+  }
+}
+```
+
+## References
+
+### CloudEvents Registry Document Schema
+
+See [CloudEvents Registry Document Schema](./schemas/xregistry_messaging_catalog.json).
+
+[JSON Pointer]: https://www.rfc-editor.org/rfc/rfc6901
+[CloudEvents Types]: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type-system
+[AMQP 1.0]: https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-overview-v1.0-os.html
+[AMQP 1.0 Message Format]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#section-message-format
+[AMQP 1.0 Message Properties]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-properties
+[AMQP 1.0 Application Properties]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties
+[AMQP 1.0 Message Annotations]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-message-annotations
+[AMQP 1.0 Delivery Annotations]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-delivery-annotations
+[AMQP 1.0 Message Header]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-header
+[AMQP 1.0 Message Footer]: http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-footer
+[MQTT 5.0]: https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html
+[MQTT 3.1.1]: https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html
+[CloudEvents]: https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md
+[CloudEvents Subscriptions API]: https://github.com/cloudevents/spec/blob/main/subscriptions/spec.md
+[NATS]: https://docs.nats.io/reference/reference-protocols/nats-protocol
+[Apache Kafka]: https://kafka.apache.org/protocol
+[Apache Kafka producer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/producer/ProducerRecord.html
+[Apache Kafka consumer]: https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/ConsumerRecord.html
+[HTTP Message Format]: https://www.rfc-editor.org/rfc/rfc9110#section-6
+[RFC6570]: https://www.rfc-editor.org/rfc/rfc6570
 [rfc3339]: https://tools.ietf.org/html/rfc3339

--- a/registry/spec.md
+++ b/registry/spec.md
@@ -2201,7 +2201,10 @@ fragment.
 
 Examples:
 
-- If the Protobuf schema document is referenced using the URI `https://example.com/protobuf/telemetry.proto`, the URI fragment `#TelemetryEvent` references the message declaration of the `TelemetryEvent` message.
+- If the Protobuf schema document is referenced using the URI 
+  `https://example.com/protobuf/telemetry.proto`, the URI fragment 
+  `#TelemetryEvent` references the message declaration of the `TelemetryEvent` 
+  message.
 - If the Protobuf schema document is a local schema registry reference like
   `#/schemaGroups/com.example.telemetry/schemas/com.example.telemetrydata`, in
   the which the reference is already in the form of a URI fragment, the suffix

--- a/registry/spec.md
+++ b/registry/spec.md
@@ -1680,7 +1680,7 @@ schema for its payload.
 ``` JSON
 {
   "$schema": "https://cloudevents.io/schemas/registry",
-  "specversion": "0.4-wip",
+  "specversion": "0.5-wip",
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fc9a6a469f7",
   "endpoints" : 
   {
@@ -1815,6 +1815,7 @@ scenarios:
               "id" : "1.0",
               "schema" : "syntax = \"proto3\"; message Metrics { float metric = 1; }"
           }
+        }
       }
     }
   }
@@ -1918,7 +1919,7 @@ embedded or referenced. Any of the three sub-registries MAY be omitted.
    "specversion": "0.4-wip",
    "endpoints": { ... } | "endpointsUrl": "URL",
    "definitionGroups": { ... } | "definitionGroupsUrl": "URL"
-   "schemaGroups" : { ... } | "schemagroupsUrl": "URL",
+   "schemaGroups" : { ... } | "schemaGroupsUrl": "URL",
 }
 ```
 
@@ -1956,8 +1957,8 @@ The group (GROUP) name for the Schema Registry is `schemaGroups`. The group does
 not have any specific extension attributes.
 
 A schema group is a collection of schemas that are related to each other in some
-application-defined way. A schema group does not impose an restrictions on the
-contained schenmas, meaning that a schema group can contain schemas of different
+application-defined way. A schema group does not impose any restrictions on the
+contained schemas, meaning that a schema group can contain schemas of different
 formats. Every schema MUST reside inside a schema group.
 
 Example:
@@ -1986,7 +1987,7 @@ Any new schema version that is added to a schema definition MUST be backwards
 compatible with all previous versions of the schema, meaning that a consumer
 using the new schema MUST be able to understand data encoded using a prior
 version of the schema. If a new version introduces a breaking change, it MUST be
-regisetered as a new schema with a new name.
+registered as a new schema with a new name.
 
 When you retrieve a schema without qualifying the version, you will get the
 latest version of the schema, see [retrieving a
@@ -2031,14 +2032,14 @@ attributes.
 - Description: Embedded schema string or object. The format and encoding of the
   schema is defined by the `format` attribute.
 - Constraints:
-  - Mutually exlusive with `schemaurl`. One of the two MUST be present.
+  - Mutually exclusive with `schemaurl`. One of the two MUST be present.
 
 ##### `schemaurl`
 
 - Type: URI
 - Description: Reference to a schema document external to the registry.
 - Constraints:
-  - Mutually exlusive with `schemaurl`. One of the two MUST be present.
+  - Mutually exclusive with `schemaurl`. One of the two MUST be present.
   - Cross-references to a schema document within the same registry MUST NOT be
     used.
 
@@ -3121,7 +3122,7 @@ Example:
   respective protocol endpoints, but implementations MAY define and use
   additional protocol names.
 
-  Predefined protocols are referred tp by name and version as
+  Predefined protocols are referred to by name and version as
   `{NAME}/{VERSION}`. If the version is not specified, the default version of
   the protocol is assumed. The version number format is determined by the
   protocol specification's usage of versions.

--- a/registry/spec.md
+++ b/registry/spec.md
@@ -1691,7 +1691,7 @@ schema for its payload.
         "protocol": "MQTT/5.0",
         "strict": false,
         "endpoints": [
-            "mqtt://mqtt.example.com:1883",
+            "mqtt://mqtt.example.com:1883"
         ],
         "options" : {
             "topic": "{deviceid}/telemetry"


### PR DESCRIPTION

- Schema Registry section complete 
- Message Definitions section complete
- Endpoint Registry started

Covers CloudEvents, AMQP, MQTT (3.1.1/5.0) as transports
Covers JSON, XSD, Avro, Proto as schema formats

Plan to extend out to the remaining transports we supprt with CE after completing the initial draft.