### PR TITLE
Move batch restrictions from HTTP to the main spec

### DIFF
--- a/cloudevents/bindings/http-protocol-binding.md
+++ b/cloudevents/bindings/http-protocol-binding.md
@@ -423,10 +423,6 @@ all event attributes, and `data`, are represented.
 The batch of events is then rendered in accordance with the event format
 specification and the resulting data becomes the HTTP message body.
 
-The batch MAY be empty. All batched CloudEvents MUST have the same `specversion`
-attribute. Other attributes MAY differ, including the `datacontenttype`
-attribute.
-
 #### 3.3.3. Examples
 
 This example shows two batched CloudEvents, sent with a PUT request:

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -148,6 +148,15 @@ as one that is unaware of CloudEvents.
 A "batch-mode message" is one where multiple (zero or more) events are
 encoded in a single message body, according to a specific event format. Not
 all event formats or protocol bindings support batch-mode messages.
+The CloudEvents within a batch are largely independent from one another: there
+is no restriction that they have the same source, producer, content type etc.
+There are just two restrictions, however:
+
+- All CloudEvents within the same batch MUST have the same `specversion`
+  attribute value.
+- All CloudEvents within the same batch MUST be distinct, i.e. the
+  (`source`, `id`) attribute value pair for each CloudEvent in the batch MUST
+  be unique.
 
 #### Protocol
 

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -150,13 +150,8 @@ encoded in a single message body, according to a specific event format. Not
 all event formats or protocol bindings support batch-mode messages.
 The CloudEvents within a batch are largely independent from one another: there
 is no restriction that they have the same source, producer, content type etc.
-There are just two restrictions, however:
-
-- All CloudEvents within the same batch MUST have the same `specversion`
-  attribute value.
-- All CloudEvents within the same batch MUST be distinct, i.e. the
-  (`source`, `id`) attribute value pair for each CloudEvent in the batch MUST
-  be unique.
+The only restriction is that all CloudEvents within the same batch MUST have
+the same value for the `specversion` attribute.
 
 #### Protocol
 


### PR DESCRIPTION
The restriction in terms of uniqueness is new, and definitely open for debate. I had previously always just assumed it. If we choose not to require it, we should explicitly permit duplicates.
