### PR TITLE
Clarify CDATA handling in XML format

### DIFF
--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -67,6 +67,10 @@ CloudEvent or CloudEvent batch. Comments MUST be ignored during processing, exce
 for the child element of a `<data>` element containing [XML element data](#33-xml-element-data),
 where all nodes MUST be preserved.
 
+CDATA nodes and regular text nodes MUST be treated interchangably during processing,
+except for the child element `<data>` element containing [XML element data](#33-xml-element-data),
+where all nodes MUST be preserved.
+
 XML elements in namespaces other than `http://cloudevents.io/xmlformat/V1`, and
 XML attributes other than those described in this specification MAY appear within an XML
 representation of a CloudEvent or CloudEvent batch. These SHOULD be ignored during
@@ -155,7 +159,7 @@ Example:
 XML element data MUST be carried in an element with a defined type of `xs:any` with
 exactly one child XML element (with any mandatory namespace definitions).
 
-All XML nodes (including comments) within the child XML element MUST
+All XML nodes (including comments and CDATA nodes) within the child XML element MUST
 be preserved during processing.
 
 The `<data>` XML element MUST NOT contain any direct child text nodes with


### PR DESCRIPTION
(We should definitely have a big conformance suite for this format at some point...)

The repetition of the language around XML element data is deliberate, but slightly clunky. Other suggestions welcome.

Also happy to add an example with both CDATA and a text node if that would be useful, but it feels like it's probably better in a conformance test.

This is an alternative to #1143, and I believe would fix #1013.

Initial review requested from Jem, and we can go on from there.