### PR TITLE
Modeling the registry API...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ gen/
 gen/
 .DS_Store
 *.pyc
+/registry/typespec/node_modules

--- a/registry/typespec/main.tsp
+++ b/registry/typespec/main.tsp
@@ -1,0 +1,124 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/openapi3";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+
+@service({
+    title: "xregistry",
+    description: "First pass of the xregistry api",
+    version: "0.0.1",
+    termsOfService: "https://github.com/cloudevents/",
+    contact: {
+      name: "Mark Weitzel et al.",
+      url: "https://github.com/cloudevents/spec/blob/main/registry/spec.md"
+    }
+  })
+@server("https://xregistry.example/", "Actual server to be set during client setup")
+@route("/")
+namespace xregistry;
+
+@error
+@doc("Error response")
+model Error {
+    @doc("A server-defined code that uniquely identifies the error.")
+    code: string;
+    @doc("Top-level error object")
+    error: ErrorDetail;
+}
+
+@doc("Error details")
+model ErrorDetail {
+  @doc("A server-defined code that uniquely identifies the error.")
+  code: string;
+  @doc("A human-readable representation of the error.")
+  message: string;
+  @doc("An array of details about specific errors that led to this reported error.")
+  details?: ErrorDetail[];
+}
+
+model Patch<T> {
+  @header contentType: "application/merge-patch+json";
+  ...T;
+}
+
+model List<T> {
+  @doc("List of elements")
+  value: T[];
+  @doc("A link to the next page of results if present.")
+  nextLink?: url;
+}
+
+model RegistryTag {
+    key: string;
+    value: string;
+}
+
+model CommonMetadata {
+    singlular: string;
+    plural: string;
+    schema?: url;
+    resources?:[CommonMetadata]
+}
+
+model RegistryMetadata {
+    registryMetadata:{
+      name: string;
+      description: string;
+      tags: RegistryTag[];
+      groups:[CommonMetadata];
+    }
+}
+
+
+
+model RegistryResource {
+    @path
+    id: string;
+    name?: string;
+    description?: string;
+    tags?: RegistryTag[];
+    version?: int32;
+    epoch?: int64;
+    self?: url;
+    createdBy?: string;
+    createdOn?: zonedDateTime;
+    modifiedBy?: string;
+    modifiedOn?: zonedDateTime;
+    docs?: string;
+}
+
+// model a group of resources
+model Group {
+ @path 
+ id:string;
+ resources: RegistryResource[];
+}
+
+// Interfaces 
+interface RegistryItemsInterface<T, P = {}> {
+  @get list(...P): List<T> | Error;
+  @get read(...P, @path id: string): T | Error;
+  @put create(...P, @body body: T): T | Error;
+  @patch update(...P, @body body: Patch<T>): T | Error;
+  @delete delete(...P, @path id: string): void | Error;
+}
+
+@route("/groups")
+@tag("Groups")
+interface Groups extends RegistryItemsInterface<Group> {
+}
+
+//Define a "local" model here to make the interface more modular & resuable
+model GroupPathId { @path groupId: string }
+
+@route("groups/{groupId}/resources/")
+@tag("Resources")
+interface Resources extends RegistryItemsInterface<RegistryResource, GroupPathId> {
+}
+
+@route("/registryMetdata")
+interface RegistryMetadataInterface {
+  @get read(): RegistryMetadata | Error;
+}

--- a/registry/typespec/main.tsp
+++ b/registry/typespec/main.tsp
@@ -74,18 +74,41 @@ model RegistryMetadata {
 
 
 model RegistryResource {
+    @doc("A unique identifier of the entity.")
     @path
     id: string;
+
+    @doc("A human readable name of the entity. Note that implementations MAY choose to enforce constraints on this value. For example, they could mandate that id and name be the same value. How any such requirement is shared with all parties is out of scope of this specification.")
     name?: string;
+    
+    @doc("A human readable summary of the purpose of the entity.")
     description?: string;
+    
+    @doc("A mechanism in which additional metadata about the entity can be stored without changing the schema of the entity.")
     tags?: RegistryTag[];
+
+    @doc("A numeric value representing a specific instance of an entity. Note that versions of an entity can be modified without changing the version value. Often this value, or when a new version is created, is controlled by a user of the Registry.")
     version?: int32;
+
+    @doc("A numeric value used to determine whether an entity has been modified. Each time the associated entity is updated, this value MUST be set to a new value that is greater than the current one. Note that unlike version, this attribute is most often managed by the Registry itself. Additionally, if an entity is created that is based on another entity (e.g. a new version of an entity is created), then the new entity's `epoch` value can be reset (e.g. to zero) since the scope of its values is the entity.")
     epoch?: int64;
+
+    @doc("A unique URL for the entity. The URL MUST be a combination of the base URL for the list of resources of this type of entity appended with the id of the entity.")
     self?: url;
+
+    @doc("A reference to the user or component that was responsible for the creation of this entity. This specification makes no requirement on the semantics or syntax of this value.")
     createdBy?: string;
+
+    @doc("The date/time of when the entity was created.")
     createdOn?: zonedDateTime;
+
+    @doc("A reference to the user or component that was responsible for the the latest update of this entity. This specification makes no requirement on the semantics or syntax of this value")
     modifiedBy?: string;
+
+    @doc("The date/time of when the entity was last updated.")
     modifiedOn?: zonedDateTime;
+    
+    @doc("A URI-Reference to additional documentation about this entity. This specification does not place any constraints on the data returned from an HTTP GET to this value.")
     docs?: string;
 }
 

--- a/registry/typespec/package-lock.json
+++ b/registry/typespec/package-lock.json
@@ -1,0 +1,1046 @@
+{
+  "name": "xregistryapi",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "xregistryapi",
+      "version": "0.1.0",
+      "dependencies": {
+        "@typespec/compiler": "latest",
+        "@typespec/openapi3": "latest",
+        "@typespec/rest": "latest"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@typespec/compiler": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.41.0.tgz",
+      "integrity": "sha512-JmSclmneBmWiv2+ROFBhAl69uylIdLVnElB3Xr/hHPza9mcMRz7HR0Zi2tvjATsvPkIUgcoUM/pVXLhNjKeMLw==",
+      "dependencies": {
+        "@babel/code-frame": "~7.18.6",
+        "ajv": "~8.11.2",
+        "change-case": "~4.1.2",
+        "globby": "~13.1.1",
+        "js-yaml": "~4.1.0",
+        "mkdirp": "~1.0.4",
+        "mustache": "~4.2.0",
+        "node-fetch": "3.2.8",
+        "node-watch": "~0.7.1",
+        "picocolors": "~1.0.0",
+        "prettier": "~2.8.1",
+        "prompts": "~2.4.1",
+        "vscode-languageserver": "~8.0.2",
+        "vscode-languageserver-textdocument": "~1.0.1",
+        "yargs": "~17.6.2"
+      },
+      "bin": {
+        "tsp": "cmd/tsp.js",
+        "tsp-server": "cmd/tsp-server.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@typespec/http": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.41.0.tgz",
+      "integrity": "sha512-lKewobsQVlpEUWCH/jw3eodugCqR9VqSP3a7iM9IrhULjhNExLQ7GHR6GpKyxBLSMq8mqThrC0u0hLJNd0iRuQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "~0.41.0"
+      }
+    },
+    "node_modules/@typespec/openapi": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.41.0.tgz",
+      "integrity": "sha512-0zfmsorziqlaPHxM6ZckmLUlu7L4qY/BKO//uHA49UjSVWzMfq8O4szFYtQpaBjDMhsOV5AQRAF/elz6gMcqsg==",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "~0.41.0",
+        "@typespec/http": "~0.41.0",
+        "@typespec/rest": "~0.41.0"
+      }
+    },
+    "node_modules/@typespec/openapi3": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi3/-/openapi3-0.41.0.tgz",
+      "integrity": "sha512-rsE19Tzj1JeaBB48feuv+kD5yZHT+gVBvQ71PNQ39lfWsF1+5LIlktPfMXQ9fJycA/igyPoJMPahGebQBFKekA==",
+      "dependencies": {
+        "js-yaml": "~4.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "~0.41.0",
+        "@typespec/http": "~0.41.0",
+        "@typespec/openapi": "~0.41.0",
+        "@typespec/rest": "~0.41.0",
+        "@typespec/versioning": "~0.41.0"
+      }
+    },
+    "node_modules/@typespec/rest": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.41.0.tgz",
+      "integrity": "sha512-C3pAvXDzwe42H+4pdHXV5NiCFFZX8+igTLQR5aKZUixng9sN+Uz0PTv3QWGgHSBZvP+webTCswGDfHDLJotNxA==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "~0.41.0"
+      }
+    },
+    "node_modules/@typespec/versioning": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.41.0.tgz",
+      "integrity": "sha512-B1zHxzPVZ1ZUHE7ZDPhjjhe0tx6mk0UfPNV2sALrk5VVPFeXQSK4DJcB6vvvSpBoPOqtb81/wKENsYAM7Vfmog==",
+      "peer": true,
+      "dependencies": {
+        "@typespec/compiler": "~0.41.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
+      "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-watch": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+    },
+    "node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz",
+      "integrity": "sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.2"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+      "dependencies": {
+        "vscode-jsonrpc": "8.0.2",
+        "vscode-languageserver-types": "3.17.2"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+      "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/registry/typespec/package.json
+++ b/registry/typespec/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "xregistryapi",
+  "version": "0.1.0",
+  "type": "module",
+  "dependencies": {
+    "@typespec/compiler": "latest",
+    "@typespec/rest": "latest",
+    "@typespec/openapi3": "latest"
+  },
+  "private": true
+}

--- a/registry/typespec/tsp-output/@typespec/openapi3/openapi.yaml
+++ b/registry/typespec/tsp-output/@typespec/openapi3/openapi.yaml
@@ -1,0 +1,660 @@
+openapi: 3.0.0
+info:
+  title: xregistry
+  version: 0.0.1
+tags:
+  - name: Groups
+  - name: Resources
+paths:
+  /groups:
+    get:
+      tags:
+        - Groups
+      operationId: Groups_list
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/GroupReadItem'
+                    x-typespec-name: Group[]
+                    description: List of elements
+                  nextLink:
+                    type: string
+                    format: uri
+                    description: A link to the next page of results if present.
+                required:
+                  - value
+                x-typespec-name: List<Group>
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /groups/{groupId}/resources:
+    get:
+      tags:
+        - Resources
+      operationId: Resources_list
+      parameters:
+        - $ref: '#/components/parameters/GroupPathId'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  value:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/RegistryResourceReadItem'
+                    x-typespec-name: RegistryResource[]
+                    description: List of elements
+                  nextLink:
+                    type: string
+                    format: uri
+                    description: A link to the next page of results if present.
+                required:
+                  - value
+                x-typespec-name: List<RegistryResource>
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /groups/{groupId}/resources/{id}:
+    get:
+      tags:
+        - Resources
+      operationId: Resources_read
+      parameters:
+        - $ref: '#/components/parameters/GroupPathId'
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegistryResourceRead'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      tags:
+        - Resources
+      operationId: Resources_create
+      parameters:
+        - $ref: '#/components/parameters/GroupPathId'
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegistryResourceRead'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegistryResource'
+    patch:
+      tags:
+        - Resources
+      operationId: Resources_update
+      parameters:
+        - $ref: '#/components/parameters/GroupPathId'
+        - $ref: '#/components/parameters/RegistryResource.id'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegistryResourceRead'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                tags:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/RegistryTag'
+                  x-typespec-name: RegistryTag[]
+                version:
+                  type: integer
+                  format: int32
+                epoch:
+                  type: integer
+                  format: int64
+                self:
+                  type: string
+                  format: uri
+                createdBy:
+                  type: string
+                createdOn:
+                  type: string
+                  format: date-time
+                modifiedBy:
+                  type: string
+                modifiedOn:
+                  type: string
+                  format: date-time
+                docs:
+                  type: string
+              x-typespec-name: Patch<RegistryResource>
+    delete:
+      tags:
+        - Resources
+      operationId: Resources_delete
+      parameters:
+        - $ref: '#/components/parameters/GroupPathId'
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: >-
+            There is no content to send for this request, but the headers may be
+            useful. 
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /groups/{id}:
+    get:
+      tags:
+        - Groups
+      operationId: Groups_read
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupRead'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      tags:
+        - Groups
+      operationId: Groups_create
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupRead'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GroupCreateOrUpdate'
+    patch:
+      tags:
+        - Groups
+      operationId: Groups_update
+      parameters:
+        - $ref: '#/components/parameters/Group.id'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupRead'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/merge-patch+json:
+            schema:
+              type: object
+              properties:
+                resources:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/RegistryResourceUpdateItem'
+                  x-typespec-name: RegistryResource[]
+              x-typespec-name: Patch<Group>
+    delete:
+      tags:
+        - Groups
+      operationId: Groups_delete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: >-
+            There is no content to send for this request, but the headers may be
+            useful. 
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /registryMetdata:
+    get:
+      operationId: RegistryMetadataInterface_read
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegistryMetadata'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  parameters:
+    Group.id:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+    GroupPathId:
+      name: groupId
+      in: path
+      required: true
+      schema:
+        type: string
+    RegistryResource.id:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+  schemas:
+    CommonMetadata:
+      type: object
+      properties:
+        singlular:
+          type: string
+        plural:
+          type: string
+        schema:
+          type: string
+          format: uri
+        resources:
+          type: array
+          items: {}
+          x-typespec-name: '[CommonMetadata]'
+      required:
+        - singlular
+        - plural
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+          description: A server-defined code that uniquely identifies the error.
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ErrorDetail'
+          description: Top-level error object
+      description: Error response
+      required:
+        - code
+        - error
+    ErrorDetail:
+      type: object
+      properties:
+        code:
+          type: string
+          description: A server-defined code that uniquely identifies the error.
+        message:
+          type: string
+          description: A human-readable representation of the error.
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorDetail'
+          x-typespec-name: ErrorDetail[]
+          description: >-
+            An array of details about specific errors that led to this reported
+            error.
+      description: Error details
+      required:
+        - code
+        - message
+    GroupCreateOrUpdate:
+      type: object
+      properties:
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegistryResourceCreateOrUpdateItem'
+          x-typespec-name: RegistryResource[]
+      required:
+        - resources
+    GroupRead:
+      type: object
+      properties:
+        id:
+          type: string
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegistryResourceReadItem'
+          x-typespec-name: RegistryResource[]
+      required:
+        - id
+        - resources
+    GroupReadItem:
+      type: object
+      properties:
+        id:
+          type: string
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegistryResourceReadItem'
+          x-typespec-name: RegistryResource[]
+      required:
+        - id
+        - resources
+    RegistryMetadata:
+      type: object
+      properties:
+        registryMetadata:
+          type: object
+          properties:
+            name:
+              type: string
+            description:
+              type: string
+            tags:
+              type: array
+              items:
+                $ref: '#/components/schemas/RegistryTag'
+              x-typespec-name: RegistryTag[]
+            groups:
+              type: array
+              items: {}
+              x-typespec-name: '[CommonMetadata]'
+          required:
+            - name
+            - description
+            - tags
+            - groups
+          x-typespec-name: (anonymous model)
+      required:
+        - registryMetadata
+    RegistryResource:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegistryTag'
+          x-typespec-name: RegistryTag[]
+        version:
+          type: integer
+          format: int32
+        epoch:
+          type: integer
+          format: int64
+        self:
+          type: string
+          format: uri
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+          format: date-time
+        modifiedBy:
+          type: string
+        modifiedOn:
+          type: string
+          format: date-time
+        docs:
+          type: string
+    RegistryResourceCreateOrUpdateItem:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegistryTag'
+          x-typespec-name: RegistryTag[]
+        version:
+          type: integer
+          format: int32
+        epoch:
+          type: integer
+          format: int64
+        self:
+          type: string
+          format: uri
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+          format: date-time
+        modifiedBy:
+          type: string
+        modifiedOn:
+          type: string
+          format: date-time
+        docs:
+          type: string
+      required:
+        - id
+    RegistryResourceRead:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegistryTag'
+          x-typespec-name: RegistryTag[]
+        version:
+          type: integer
+          format: int32
+        epoch:
+          type: integer
+          format: int64
+        self:
+          type: string
+          format: uri
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+          format: date-time
+        modifiedBy:
+          type: string
+        modifiedOn:
+          type: string
+          format: date-time
+        docs:
+          type: string
+      required:
+        - id
+    RegistryResourceReadItem:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegistryTag'
+          x-typespec-name: RegistryTag[]
+        version:
+          type: integer
+          format: int32
+        epoch:
+          type: integer
+          format: int64
+        self:
+          type: string
+          format: uri
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+          format: date-time
+        modifiedBy:
+          type: string
+        modifiedOn:
+          type: string
+          format: date-time
+        docs:
+          type: string
+      required:
+        - id
+    RegistryResourceUpdateItem:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegistryTag'
+          x-typespec-name: RegistryTag[]
+        version:
+          type: integer
+          format: int32
+        epoch:
+          type: integer
+          format: int64
+        self:
+          type: string
+          format: uri
+        createdBy:
+          type: string
+        createdOn:
+          type: string
+          format: date-time
+        modifiedBy:
+          type: string
+        modifiedOn:
+          type: string
+          format: date-time
+        docs:
+          type: string
+      required:
+        - id
+    RegistryTag:
+      type: object
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+      required:
+        - key
+        - value
+servers:
+  - url: https://xregistry.example/
+    description: Actual server to be set during client setup
+    variables: {}

--- a/registry/typespec/tsp-output/@typespec/openapi3/openapi.yaml
+++ b/registry/typespec/tsp-output/@typespec/openapi3/openapi.yaml
@@ -107,6 +107,7 @@ paths:
         - name: id
           in: path
           required: true
+          description: A unique identifier of the entity.
           schema:
             type: string
       responses:
@@ -155,34 +156,79 @@ paths:
               properties:
                 name:
                   type: string
+                  description: >-
+                    A human readable name of the entity. Note that
+                    implementations MAY choose to enforce constraints on this
+                    value. For example, they could mandate that id and name be
+                    the same value. How any such requirement is shared with all
+                    parties is out of scope of this specification.
                 description:
                   type: string
+                  description: A human readable summary of the purpose of the entity.
                 tags:
                   type: array
                   items:
                     $ref: '#/components/schemas/RegistryTag'
                   x-typespec-name: RegistryTag[]
+                  description: >-
+                    A mechanism in which additional metadata about the entity
+                    can be stored without changing the schema of the entity.
                 version:
                   type: integer
                   format: int32
+                  description: >-
+                    A numeric value representing a specific instance of an
+                    entity. Note that versions of an entity can be modified
+                    without changing the version value. Often this value, or
+                    when a new version is created, is controlled by a user of
+                    the Registry.
                 epoch:
                   type: integer
                   format: int64
+                  description: >-
+                    A numeric value used to determine whether an entity has been
+                    modified. Each time the associated entity is updated, this
+                    value MUST be set to a new value that is greater than the
+                    current one. Note that unlike version, this attribute is
+                    most often managed by the Registry itself. Additionally, if
+                    an entity is created that is based on another entity (e.g. a
+                    new version of an entity is created), then the new entity's
+                    `epoch` value can be reset (e.g. to zero) since the scope of
+                    its values is the entity.
                 self:
                   type: string
                   format: uri
+                  description: >-
+                    A unique URL for the entity. The URL MUST be a combination
+                    of the base URL for the list of resources of this type of
+                    entity appended with the id of the entity.
                 createdBy:
                   type: string
+                  description: >-
+                    A reference to the user or component that was responsible
+                    for the creation of this entity. This specification makes no
+                    requirement on the semantics or syntax of this value.
                 createdOn:
                   type: string
                   format: date-time
+                  description: The date/time of when the entity was created.
                 modifiedBy:
                   type: string
+                  description: >-
+                    A reference to the user or component that was responsible
+                    for the the latest update of this entity. This specification
+                    makes no requirement on the semantics or syntax of this
+                    value
                 modifiedOn:
                   type: string
                   format: date-time
+                  description: The date/time of when the entity was last updated.
                 docs:
                   type: string
+                  description: >-
+                    A URI-Reference to additional documentation about this
+                    entity. This specification does not place any constraints on
+                    the data returned from an HTTP GET to this value.
               x-typespec-name: Patch<RegistryResource>
     delete:
       tags:
@@ -345,6 +391,7 @@ components:
       name: id
       in: path
       required: true
+      description: A unique identifier of the entity.
       schema:
         type: string
   schemas:
@@ -468,69 +515,152 @@ components:
       properties:
         name:
           type: string
+          description: >-
+            A human readable name of the entity. Note that implementations MAY
+            choose to enforce constraints on this value. For example, they could
+            mandate that id and name be the same value. How any such requirement
+            is shared with all parties is out of scope of this specification.
         description:
           type: string
+          description: A human readable summary of the purpose of the entity.
         tags:
           type: array
           items:
             $ref: '#/components/schemas/RegistryTag'
           x-typespec-name: RegistryTag[]
+          description: >-
+            A mechanism in which additional metadata about the entity can be
+            stored without changing the schema of the entity.
         version:
           type: integer
           format: int32
+          description: >-
+            A numeric value representing a specific instance of an entity. Note
+            that versions of an entity can be modified without changing the
+            version value. Often this value, or when a new version is created,
+            is controlled by a user of the Registry.
         epoch:
           type: integer
           format: int64
+          description: >-
+            A numeric value used to determine whether an entity has been
+            modified. Each time the associated entity is updated, this value
+            MUST be set to a new value that is greater than the current one.
+            Note that unlike version, this attribute is most often managed by
+            the Registry itself. Additionally, if an entity is created that is
+            based on another entity (e.g. a new version of an entity is
+            created), then the new entity's `epoch` value can be reset (e.g. to
+            zero) since the scope of its values is the entity.
         self:
           type: string
           format: uri
+          description: >-
+            A unique URL for the entity. The URL MUST be a combination of the
+            base URL for the list of resources of this type of entity appended
+            with the id of the entity.
         createdBy:
           type: string
+          description: >-
+            A reference to the user or component that was responsible for the
+            creation of this entity. This specification makes no requirement on
+            the semantics or syntax of this value.
         createdOn:
           type: string
           format: date-time
+          description: The date/time of when the entity was created.
         modifiedBy:
           type: string
+          description: >-
+            A reference to the user or component that was responsible for the
+            the latest update of this entity. This specification makes no
+            requirement on the semantics or syntax of this value
         modifiedOn:
           type: string
           format: date-time
+          description: The date/time of when the entity was last updated.
         docs:
           type: string
+          description: >-
+            A URI-Reference to additional documentation about this entity. This
+            specification does not place any constraints on the data returned
+            from an HTTP GET to this value.
     RegistryResourceCreateOrUpdateItem:
       type: object
       properties:
         id:
           type: string
+          description: A unique identifier of the entity.
         name:
           type: string
+          description: >-
+            A human readable name of the entity. Note that implementations MAY
+            choose to enforce constraints on this value. For example, they could
+            mandate that id and name be the same value. How any such requirement
+            is shared with all parties is out of scope of this specification.
         description:
           type: string
+          description: A human readable summary of the purpose of the entity.
         tags:
           type: array
           items:
             $ref: '#/components/schemas/RegistryTag'
           x-typespec-name: RegistryTag[]
+          description: >-
+            A mechanism in which additional metadata about the entity can be
+            stored without changing the schema of the entity.
         version:
           type: integer
           format: int32
+          description: >-
+            A numeric value representing a specific instance of an entity. Note
+            that versions of an entity can be modified without changing the
+            version value. Often this value, or when a new version is created,
+            is controlled by a user of the Registry.
         epoch:
           type: integer
           format: int64
+          description: >-
+            A numeric value used to determine whether an entity has been
+            modified. Each time the associated entity is updated, this value
+            MUST be set to a new value that is greater than the current one.
+            Note that unlike version, this attribute is most often managed by
+            the Registry itself. Additionally, if an entity is created that is
+            based on another entity (e.g. a new version of an entity is
+            created), then the new entity's `epoch` value can be reset (e.g. to
+            zero) since the scope of its values is the entity.
         self:
           type: string
           format: uri
+          description: >-
+            A unique URL for the entity. The URL MUST be a combination of the
+            base URL for the list of resources of this type of entity appended
+            with the id of the entity.
         createdBy:
           type: string
+          description: >-
+            A reference to the user or component that was responsible for the
+            creation of this entity. This specification makes no requirement on
+            the semantics or syntax of this value.
         createdOn:
           type: string
           format: date-time
+          description: The date/time of when the entity was created.
         modifiedBy:
           type: string
+          description: >-
+            A reference to the user or component that was responsible for the
+            the latest update of this entity. This specification makes no
+            requirement on the semantics or syntax of this value
         modifiedOn:
           type: string
           format: date-time
+          description: The date/time of when the entity was last updated.
         docs:
           type: string
+          description: >-
+            A URI-Reference to additional documentation about this entity. This
+            specification does not place any constraints on the data returned
+            from an HTTP GET to this value.
       required:
         - id
     RegistryResourceRead:
@@ -538,36 +668,78 @@ components:
       properties:
         id:
           type: string
+          description: A unique identifier of the entity.
         name:
           type: string
+          description: >-
+            A human readable name of the entity. Note that implementations MAY
+            choose to enforce constraints on this value. For example, they could
+            mandate that id and name be the same value. How any such requirement
+            is shared with all parties is out of scope of this specification.
         description:
           type: string
+          description: A human readable summary of the purpose of the entity.
         tags:
           type: array
           items:
             $ref: '#/components/schemas/RegistryTag'
           x-typespec-name: RegistryTag[]
+          description: >-
+            A mechanism in which additional metadata about the entity can be
+            stored without changing the schema of the entity.
         version:
           type: integer
           format: int32
+          description: >-
+            A numeric value representing a specific instance of an entity. Note
+            that versions of an entity can be modified without changing the
+            version value. Often this value, or when a new version is created,
+            is controlled by a user of the Registry.
         epoch:
           type: integer
           format: int64
+          description: >-
+            A numeric value used to determine whether an entity has been
+            modified. Each time the associated entity is updated, this value
+            MUST be set to a new value that is greater than the current one.
+            Note that unlike version, this attribute is most often managed by
+            the Registry itself. Additionally, if an entity is created that is
+            based on another entity (e.g. a new version of an entity is
+            created), then the new entity's `epoch` value can be reset (e.g. to
+            zero) since the scope of its values is the entity.
         self:
           type: string
           format: uri
+          description: >-
+            A unique URL for the entity. The URL MUST be a combination of the
+            base URL for the list of resources of this type of entity appended
+            with the id of the entity.
         createdBy:
           type: string
+          description: >-
+            A reference to the user or component that was responsible for the
+            creation of this entity. This specification makes no requirement on
+            the semantics or syntax of this value.
         createdOn:
           type: string
           format: date-time
+          description: The date/time of when the entity was created.
         modifiedBy:
           type: string
+          description: >-
+            A reference to the user or component that was responsible for the
+            the latest update of this entity. This specification makes no
+            requirement on the semantics or syntax of this value
         modifiedOn:
           type: string
           format: date-time
+          description: The date/time of when the entity was last updated.
         docs:
           type: string
+          description: >-
+            A URI-Reference to additional documentation about this entity. This
+            specification does not place any constraints on the data returned
+            from an HTTP GET to this value.
       required:
         - id
     RegistryResourceReadItem:
@@ -575,36 +747,78 @@ components:
       properties:
         id:
           type: string
+          description: A unique identifier of the entity.
         name:
           type: string
+          description: >-
+            A human readable name of the entity. Note that implementations MAY
+            choose to enforce constraints on this value. For example, they could
+            mandate that id and name be the same value. How any such requirement
+            is shared with all parties is out of scope of this specification.
         description:
           type: string
+          description: A human readable summary of the purpose of the entity.
         tags:
           type: array
           items:
             $ref: '#/components/schemas/RegistryTag'
           x-typespec-name: RegistryTag[]
+          description: >-
+            A mechanism in which additional metadata about the entity can be
+            stored without changing the schema of the entity.
         version:
           type: integer
           format: int32
+          description: >-
+            A numeric value representing a specific instance of an entity. Note
+            that versions of an entity can be modified without changing the
+            version value. Often this value, or when a new version is created,
+            is controlled by a user of the Registry.
         epoch:
           type: integer
           format: int64
+          description: >-
+            A numeric value used to determine whether an entity has been
+            modified. Each time the associated entity is updated, this value
+            MUST be set to a new value that is greater than the current one.
+            Note that unlike version, this attribute is most often managed by
+            the Registry itself. Additionally, if an entity is created that is
+            based on another entity (e.g. a new version of an entity is
+            created), then the new entity's `epoch` value can be reset (e.g. to
+            zero) since the scope of its values is the entity.
         self:
           type: string
           format: uri
+          description: >-
+            A unique URL for the entity. The URL MUST be a combination of the
+            base URL for the list of resources of this type of entity appended
+            with the id of the entity.
         createdBy:
           type: string
+          description: >-
+            A reference to the user or component that was responsible for the
+            creation of this entity. This specification makes no requirement on
+            the semantics or syntax of this value.
         createdOn:
           type: string
           format: date-time
+          description: The date/time of when the entity was created.
         modifiedBy:
           type: string
+          description: >-
+            A reference to the user or component that was responsible for the
+            the latest update of this entity. This specification makes no
+            requirement on the semantics or syntax of this value
         modifiedOn:
           type: string
           format: date-time
+          description: The date/time of when the entity was last updated.
         docs:
           type: string
+          description: >-
+            A URI-Reference to additional documentation about this entity. This
+            specification does not place any constraints on the data returned
+            from an HTTP GET to this value.
       required:
         - id
     RegistryResourceUpdateItem:
@@ -612,36 +826,78 @@ components:
       properties:
         id:
           type: string
+          description: A unique identifier of the entity.
         name:
           type: string
+          description: >-
+            A human readable name of the entity. Note that implementations MAY
+            choose to enforce constraints on this value. For example, they could
+            mandate that id and name be the same value. How any such requirement
+            is shared with all parties is out of scope of this specification.
         description:
           type: string
+          description: A human readable summary of the purpose of the entity.
         tags:
           type: array
           items:
             $ref: '#/components/schemas/RegistryTag'
           x-typespec-name: RegistryTag[]
+          description: >-
+            A mechanism in which additional metadata about the entity can be
+            stored without changing the schema of the entity.
         version:
           type: integer
           format: int32
+          description: >-
+            A numeric value representing a specific instance of an entity. Note
+            that versions of an entity can be modified without changing the
+            version value. Often this value, or when a new version is created,
+            is controlled by a user of the Registry.
         epoch:
           type: integer
           format: int64
+          description: >-
+            A numeric value used to determine whether an entity has been
+            modified. Each time the associated entity is updated, this value
+            MUST be set to a new value that is greater than the current one.
+            Note that unlike version, this attribute is most often managed by
+            the Registry itself. Additionally, if an entity is created that is
+            based on another entity (e.g. a new version of an entity is
+            created), then the new entity's `epoch` value can be reset (e.g. to
+            zero) since the scope of its values is the entity.
         self:
           type: string
           format: uri
+          description: >-
+            A unique URL for the entity. The URL MUST be a combination of the
+            base URL for the list of resources of this type of entity appended
+            with the id of the entity.
         createdBy:
           type: string
+          description: >-
+            A reference to the user or component that was responsible for the
+            creation of this entity. This specification makes no requirement on
+            the semantics or syntax of this value.
         createdOn:
           type: string
           format: date-time
+          description: The date/time of when the entity was created.
         modifiedBy:
           type: string
+          description: >-
+            A reference to the user or component that was responsible for the
+            the latest update of this entity. This specification makes no
+            requirement on the semantics or syntax of this value
         modifiedOn:
           type: string
           format: date-time
+          description: The date/time of when the entity was last updated.
         docs:
           type: string
+          description: >-
+            A URI-Reference to additional documentation about this entity. This
+            specification does not place any constraints on the data returned
+            from an HTTP GET to this value.
       required:
         - id
     RegistryTag:

--- a/registry/typespec/tspconfig.yaml
+++ b/registry/typespec/tspconfig.yaml
@@ -1,0 +1,2 @@
+emit:
+  - '@typespec/openapi3'


### PR DESCRIPTION
Hi everyone...
I'm working on a project where, essentially, we need a registry of API specifications. Actually, there could be multiple API registries that are queried, browsed, etc. You can think of this kind of like what [apis.guru](https://apis.guru/) is trying to do, but in a more standard and programmatic way so that anyone can spin up their own API registry. My primary use case would be managing a collection of OpenAPI specifications. I'm still exploring if this spec would work for this use case and would appreciate an example of how we could use the the registry in this manner.

However, one thing I noticed is the API for the registry itself is still in the process of being defined. Already, there are some interesting choices being made, e.g. the use of `/` vs. `/registry` as the entry point, a query parameter `/?model` vs. treating the metadata as a distinct resource `/registry/metadata`. 

One thing that might be helpful is to model the API in [TypeSpec](https://microsoft.github.io/typespec/) and [typespec repo](https://github.com/Microsoft/typespec). Taking this approach would give us a clean model of the API and a way to represent this in OpenAPI. That is, OpenAPI could become the contract for the registry. This would greatly simplify the spec document and, at the same time, make the API definition very precise. 

This PR is a very quick, rough cut, of what the registry API would look like in TypeSpec. 