### PR TITLE
Prevent CE-namespaced elements other than event in an XML batch.

### DIFF
--- a/cloudevents/working-drafts/xml-format.md
+++ b/cloudevents/working-drafts/xml-format.md
@@ -216,8 +216,12 @@ Example _(XML preamble and namespace definitions omitted for brevity)_:
 In the _XML Batch Format_ several CloudEvents are batched into a single XML
 `<batch>` element. The element comprises a list of elements in the XML Format.
 
-The `<event>` element MUST NOT contain any direct child text nodes with non-whitespace
+The `<batch>` element MUST NOT contain any direct child text nodes with non-whitespace
 content.
+
+The `<batch>` element MUST NOT contain any direct child elements in
+the namespace `http://cloudevents.io/xmlformat/V1` except `<event>`
+elements.
 
 An XML Batch of CloudEvents MUST use the media type
 `application/cloudevents-batch+xml`.


### PR DESCRIPTION
Explanation: we view the CE namespace as "owned" by this spec, so while we allow for non-CE-namespaced elements in the batch to be present and ignored, there shouldn't be any elements in the CE namespace other than "event". (We don't permit nested batches, for example.)

Conformance tests in https://github.com/cloudevents/conformance/blob/format-tests/format/xml/invalid-batches.xml#L37

(Also a typo fix.)
