### PR TITLE
xReg - Lots of changes

### DIFF
--- a/tools/verify.py
+++ b/tools/verify.py
@@ -44,7 +44,7 @@ _SKIP_TEXT_PATTERN = re.compile(
     r"<!--\s*no[\s-]+verify[\s-]+(?P<type>\w+)[\s-]*-->", re.IGNORECASE
 )
 _NEWLINE_PATTERN = re.compile(r"\n")
-_MARKDOWN_BOOKMARK_PATTERN = re.compile(r"\[.+?\]\[.+?\]", re.IGNORECASE)
+_MARKDOWN_BOOKMARK_PATTERN = re.compile(r"\[[^\?=].+?\]\[.+?\]", re.IGNORECASE)
 _PHRASES_THAT_MUST_BE_CAPITALIZED_PATTERN = re.compile(
     r"(?<!`)(MUST(\s+NOT)?|"
     # ignore the "required" in the jsonschema of the json-format.md


### PR DESCRIPTION
- Add support for ?model
- Add a Schema URL for the entire registry as part of the model
- Elaborate on ?inline=PATH
- s/version/versionID/, and remove "version" field from Version resource since
      `id` is now its version string
- fixed the spec verification tool so it doesn't flag optional query parmeters
      as markdown bookmarks (e.g. [?inline])
- define the 3 properties for each collection (xxxsUrl, xxxsCount, xxxs)