### PR TITLE
Update Google Pub/Sub binding link to new location.

### DIFF
--- a/cloudevents/proprietary-specs.md
+++ b/cloudevents/proprietary-specs.md
@@ -7,7 +7,7 @@ ensure that they are up to date with the current version of CloudEvents. That is
 the responsibility of the respective project maintainers.
 
 - [Apache RocketMQ Transport Binding](https://github.com/apache/rocketmq-externals/blob/master/rocketmq-cloudevents-binding/rocketmq-transport-binding.md)
-- [Google Cloud Pub/Sub Protocol Binding](https://github.com/google/knative-gcp/blob/master/docs/spec/pubsub-protocol-binding.md)
+- [Google Cloud Pub/Sub Protocol Binding](https://github.com/googleapis/google-cloudevents/blob/main/docs/spec/pubsub.md)
 
 **Want to add a binding to a proprietary transport?**
 


### PR DESCRIPTION
(This completes the long-standing AI in the weekly meeting agenda.)
