### PR TITLE
feat: add the `expirytime` extension attribute

### DIFF
--- a/cloudevents/documented-extensions.md
+++ b/cloudevents/documented-extensions.md
@@ -42,6 +42,7 @@ for more information.
 
 - [Dataref (Claim Check Pattern)](extensions/dataref.md)
 - [Distributed Tracing](extensions/distributed-tracing.md)
+- [Expiry Time](extensions/expirytime.md)
 - [Partitioning](extensions/partitioning.md)
 - [Recorded Time](extensions/recordedtime.md)
 - [Sampling](extensions/sampledrate.md)

--- a/cloudevents/extensions/expirytime.md
+++ b/cloudevents/extensions/expirytime.md
@@ -1,7 +1,7 @@
 # Expiry Time Extension
 
 This extension provides a mechanism to hint to [consumers](../spec.md#consumer)
-or [intermediaries](../spec.md#intermediary) a time after which an
+or [intermediaries](../spec.md#intermediary) a timestamp after which an
 [event](../spec.md#event) can be ignored.
 
 In distributed systems with message delivery guarantees, events might be delivered
@@ -20,8 +20,6 @@ depending on the event type or producer.
   indicated time.
 - Constraints:
   - REQUIRED
-  - If present, MUST adhere to the format specified in
-    [RFC 3339](https://tools.ietf.org/html/rfc3339)
   - SHOULD be equal to or later than the `time` attribute, if present
 
 ## Usage
@@ -31,7 +29,8 @@ attribute.
 
 Intermediaries and consumers MAY ignore and discard an event that has an
 `expirytime` at or before the current timestamp at the time of any checks.
-Any adjacent system SHOULD NOT make any assumptions on whether a consumer will
+Any system that directly or indirectly interacts with a consumer SHOULD NOT
+make any assumptions on whether a consumer will
 keep or discard an event based on this extension alone. The reasoning for this
 is that time-keeping can be inaccurate between any two given systems.
 
@@ -40,7 +39,7 @@ remove it.
 
 ## Potential Scenarios
 
-#### Web dashboard for sensors
+### Web dashboard for sensors
 
 A series of sensors produce CloudEvents at regular intervals that vary per
 sensor. Each sensor can pick an `expirytime` that suits its configured sample
@@ -48,7 +47,7 @@ rate. In the event that an intermediary delays delivery of events to a
 consumer, older events can be skipped to avoid excessive processing or UI
 updates upon resuming delivery.
 
-#### Jobs triggered by Continuous Integration
+### Jobs triggered by Continuous Integration
 
 A Continuous Integration (CI) system uses CloudEvents to delegate a job to a
 runner machine. The job has a set deadline and needs to complete before that time

--- a/cloudevents/extensions/expirytime.md
+++ b/cloudevents/extensions/expirytime.md
@@ -2,13 +2,13 @@
 
 This extension provides a mechanism to hint to [consumers](../spec.md#consumer)
 or [intermediaries](../spec.md#intermediary) a time after which an
-[event](../spec.md#event) may be ignored.
+[event](../spec.md#event) can be ignored.
 
-In distributed systems with message delivery guarantees, events may be delivered
-to a consumer some significant amount of time after an event has been sent via
-an intermediary. In this situation, it may be desirable to ignore events that
-are no longer relevant. The [`time` attribute](../spec.md#time) may be used
-to handle this on the consumer side but can be tricky if the logic should vary
+In distributed systems with message delivery guarantees, events might be delivered
+to a consumer some significant amount of time after an event has been sent.
+In this situation, it might be desirable to ignore events that
+are no longer relevant. The [`time` attribute](../spec.md#time) could be used
+to handle this on the consumer side but can be tricky if the logic varies
 depending on the event type or producer.
 
 ## Attributes
@@ -27,7 +27,7 @@ depending on the event type or producer.
 ## Usage
 
 When this extension is used, producers MUST set the value of the `expirytime`
-attribute. The attribute value SHOULD be a timestamp in the future.
+attribute.
 
 Intermediaries and consumers MAY ignore and discard an event that has an
 `expirytime` at or before the current timestamp at the time of any checks.
@@ -51,8 +51,8 @@ updates upon resuming delivery.
 #### Jobs triggered by Continuous Integration
 
 A Continuous Integration (CI) system uses CloudEvents to delegate a job to a
-runner machine. The job has a set deadline and must complete before that time
+runner machine. The job has a set deadline and needs to complete before that time
 has elapsed to be considered successful. The CI system can set the
-`expirytime` to match the deadline. The job runner may ignore/reject the job
-if the `expirytime` has elapsed since the CI may have likely already determined
+`expirytime` to match the deadline. The job runner would ignore/reject the job
+if the `expirytime` has elapsed since the CI might have likely already determined
 the job state.

--- a/cloudevents/extensions/expirytime.md
+++ b/cloudevents/extensions/expirytime.md
@@ -1,0 +1,58 @@
+# Expiry Time Extension
+
+This extension provides a mechanism to hint to [consumers](../spec.md#consumer)
+or [intermediaries](../spec.md#intermediary) a time after which an
+[event](../spec.md#event) may be ignored.
+
+In distributed systems with message delivery guarantees, events may be delivered
+to a consumer some significant amount of time after an event has been sent via
+an intermediary. In this situation, it may be desirable to ignore events that
+are no longer relevant. The [`time` attribute](../spec.md#time) may be used
+to handle this on the consumer side but can be tricky if the logic should vary
+depending on the event type or producer.
+
+## Attributes
+
+### expirytime
+
+- Type: `Timestamp`
+- Description: Timestamp indicating an event is no longer useful after the
+  indicated time.
+- Constraints:
+  - REQUIRED
+  - If present, MUST adhere to the format specified in
+    [RFC 3339](https://tools.ietf.org/html/rfc3339)
+  - SHOULD be equal to or later than the `time` attribute, if present
+
+## Usage
+
+When this extension is used, producers MUST set the value of the `expirytime`
+attribute. The attribute value SHOULD be a timestamp in the future.
+
+Intermediaries and consumers MAY ignore and discard an event that has an
+`expirytime` at or before the current timestamp at the time of any checks.
+Any adjacent system SHOULD NOT make any assumptions on whether a consumer will
+keep or discard an event based on this extension alone. The reasoning for this
+is that time-keeping can be inaccurate between any two given systems.
+
+Intermediaries MAY modify the `expirytime` attribute, however, they MUST NOT
+remove it.
+
+## Potential Scenarios
+
+#### Web dashboard for sensors
+
+A series of sensors produce CloudEvents at regular intervals that vary per
+sensor. Each sensor can pick an `expirytime` that suits its configured sample
+rate. In the event that an intermediary delays delivery of events to a
+consumer, older events can be skipped to avoid excessive processing or UI
+updates upon resuming delivery.
+
+#### Jobs triggered by Continuous Integration
+
+A Continuous Integration (CI) system uses CloudEvents to delegate a job to a
+runner machine. The job has a set deadline and must complete before that time
+has elapsed to be considered successful. The CI system can set the
+`expirytime` to match the deadline. The job runner may ignore/reject the job
+if the `expirytime` has elapsed since the CI may have likely already determined
+the job state.

--- a/cloudevents/languages/he/extensions/expirytime.md
+++ b/cloudevents/languages/he/extensions/expirytime.md
@@ -1,0 +1,2 @@
+# Expiry Time Extension
+מסמך זה טרם תורגם. בבקשה תשתמשו [בגרסה האנגלית של המסמך](../../../extensions/expirytime.md) לבינתיים.

--- a/cloudevents/languages/zh-CN/documented-extensions.md
+++ b/cloudevents/languages/zh-CN/documented-extensions.md
@@ -16,6 +16,8 @@
 
 - [Dataref (Claim Check Pattern)](../../extensions/dataref.md)
 - [Distributed Tracing](../../extensions/distributed-tracing.md)
+- [Expiry Time](../../extensions/expirytime.md)
 - [Partitioning](../../extensions/partitioning.md)
+- [Recorded Time](../../extensions/recordedtime.md)
 - [Sampling](../../extensions/sampledrate.md)
 - [Sequence](../../extensions/sequence.md)

--- a/cloudevents/languages/zh-CN/extensions/expirytime.md
+++ b/cloudevents/languages/zh-CN/extensions/expirytime.md
@@ -1,0 +1,6 @@
+# Recorded Time Extension
+
+本文档尚未被翻译，请先阅读英文[原版文档](../../../extensions/recordedtime.md) 。
+
+如果您迫切地需要此文档的中文翻译，请[提交一个issue](https://github.com/cloudevents/spec/issues) ，
+我们会尽快安排专人进行翻译。

--- a/cloudevents/languages/zh-CN/extensions/expirytime.md
+++ b/cloudevents/languages/zh-CN/extensions/expirytime.md
@@ -1,6 +1,6 @@
-# Recorded Time Extension
+# Expiry Time Extension
 
-本文档尚未被翻译，请先阅读英文[原版文档](../../../extensions/recordedtime.md) 。
+本文档尚未被翻译，请先阅读英文[原版文档](../../../extensions/expirytime.md) 。
 
 如果您迫切地需要此文档的中文翻译，请[提交一个issue](https://github.com/cloudevents/spec/issues) ，
 我们会尽快安排专人进行翻译。


### PR DESCRIPTION
This extension provides a mechanism to hint to consumers or intermediaries a time after which an event may be ignored.

See linked issue and spec document for reasoning and use cases.

Fixes #1205

## Proposed Changes

- Add an `expirytime` extension attribute

**Release Note**

N/A
