### PR TITLE
Expand tck tests

### DIFF
--- a/cesql/cesql_tck/like_expression.yaml
+++ b/cesql/cesql_tck/like_expression.yaml
@@ -93,3 +93,26 @@ tests:
     eventOverrides:
       myext: "abc123123%456_dzf"
     result: false
+  
+  - name: With type coercion from int (1)
+    expression: "234 LIKE '23_'"
+    result: true
+  - name: With type coercion from int (2)
+    expression: "2344 LIKE '23%'"
+    result: true
+  - name: With type coercion from int (3)
+    expression: "2344 LIKE '23%'"
+    result: false 
+
+  - name: With type coercion from bool (1)
+    expression: "TRUE LIKE 'tr%'"
+    result: true
+  - name: With type coercion from bool (2)
+    expression: "TRUE LIKE '%ue'"
+    result: true
+  - name: With type coercion from bool (3)
+    expression: "FALSE LIKE 'tr%'"
+    result: false
+  - name: With type coercion from bool (4)
+    expression: "FALSE LIKE 'fal%'"
+    result: true 

--- a/cesql/cesql_tck/like_expression.yaml
+++ b/cesql/cesql_tck/like_expression.yaml
@@ -101,7 +101,7 @@ tests:
     expression: "2344 LIKE '23%'"
     result: true
   - name: With type coercion from int (3)
-    expression: "2344 LIKE '23%'"
+    expression: "2344 LIKE '23_'"
     result: false 
 
   - name: With type coercion from bool (1)

--- a/cesql/cesql_tck/subscriptions_api_recreations.yaml
+++ b/cesql/cesql_tck/subscriptions_api_recreations.yaml
@@ -105,12 +105,6 @@ tests:
     eventOverrides:
       id: "notmyId"
       source: "http://www.some-website.com"
-  - name: Prefix OR Suffix filter (5)
-    expression: "id LIKE 'my%' OR myext LIKE '%ext'"
-    error: missingAttribute
-    eventOverrides:
-      id: "notmyId"
-      source: "http://www.some-website.com"
 
   - name: Disjunctive Normal Form (1)
     expresion: "(id = 'myId' AND type LIKE '%.success') OR (id = 'notmyId' AND source LIKE 'http://%' AND type LIKE '%.warning')"
@@ -128,13 +122,6 @@ tests:
   - name: Disjunctive Normal Form (3)
     expresion: "(id = 'myId' AND type LIKE '%.success') OR (id = 'notmyId' AND source LIKE 'http://%' AND type LIKE '%.warning')"
     result: false 
-    eventOverrides:
-      id: "notmyId"
-      type: "example.event.warning"
-      source: "https://localhost.localdomain"
-  - name: Disjunctive Normal Form (4)
-    expresion: "(id = 'myId' AND type LIKE '%.success') OR (id = 'notmyId' AND source LIKE 'http://%' AND type LIKE '%.warning') OR (myext = 'cusomext')"
-    error: missingAttribute
     eventOverrides:
       id: "notmyId"
       type: "example.event.warning"

--- a/cesql/cesql_tck/subscriptions_api_recreations.yaml
+++ b/cesql/cesql_tck/subscriptions_api_recreations.yaml
@@ -1,0 +1,176 @@
+name: SubscriptionsAPI Recreations
+tests:
+  - name: Prefix filter (1)
+    expression: "source LIKE 'https://%'"
+    result: true
+    eventOverrides:
+      source: "https://example.com"
+  - name: Prefix filter (2)
+    expression: "source LIKE 'https://%'"
+    result: false
+    eventOverrides:
+      source: "http://example.com"
+  - name: Prefix filter on string extension
+    expression: "myext LIKE 'custom%'"
+    result: true
+    eventOverrides:
+      myext: "customext"
+  - name: Prefix filter on missing string extension
+    expression: "myext LIKE 'custom%'"
+    error: missingAttribute
+
+  - name: Suffix filter (1)
+    expression: "type like '%.error'"
+    result: true
+    eventOverrides:
+      type: "com.github.error"
+  - name: Suffix filter (2)
+    expression: "type like '%.error'"
+    result: false 
+    eventOverrides:
+      type: "com.github.success"
+  - name: Suffix filter on string extension
+    expression: "myext LIKE '%ext'"
+    result: true
+    eventOverrides:
+      myext: "customext"
+  - name: Suffix filter on missing string extension
+    expression: "myext LIKE '%ext'"
+    error: missingAttribute
+
+  - name: Exact filter (1)
+    expression: "id = 'myId'"
+    result: true
+    eventOverrides:
+      id: "myId"
+  - name: Exact filter  (2)
+    expression: "id = 'myId'"
+    result: false
+    eventOverrides:
+      id: "notmyId"
+  - name: Exact filter on string extension
+    expression: "myext = 'customext'"
+    result: true
+    eventOverrides:
+      myext: "customext"
+  - name: Exact filter on missing string extension
+    expression: "myext = 'customext'"
+    error: missingAttribute
+
+  - name: Prefix filter AND Suffix filter (1)
+    expression: "id LIKE 'my%' AND source LIKE '%.ca'"
+    result: true
+    eventOverrides:
+      id: "myId"
+      source: "http://www.some-website.ca"
+  - name: Prefix filter AND Suffix filter (2)
+    expression: "id LIKE 'my%' AND source LIKE '%.ca'"
+    result: false
+    eventOverrides:
+      id: "myId"
+      source: "http://www.some-website.com"
+  - name: Prefix filter AND Suffix filter (3)
+    expression: "myext LIKE 'custom%' AND type LIKE '%.error'"
+    result: true
+    eventOverrides:
+      myext: "customext"
+      type: "com.github.error"
+  - name: Prefix AND Suffix filter (4)
+    expression: "type LIKE 'example.%' AND myext LIKE 'custom%'"
+    error: missingAttribute
+    eventOverrides:
+      type: "example.event.type"
+
+  - name: Prefix OR Suffix filter (1)
+    expression: "id LIKE 'my%' OR source LIKE '%.ca'"
+    result: true
+    eventOverrides:
+      id: "myId"
+      source: "http://www.some-website.ca"
+  - name: Prefix OR Suffix filter (2)
+    expression: "id LIKE 'my%' OR source LIKE '%.ca'"
+    result: true
+    eventOverrides:
+      id: "myId"
+      source: "http://www.some-website.com"
+  - name: Prefix OR Suffix filter (3)
+    expression: "id LIKE 'my%' OR source LIKE '%.ca'"
+    result: true
+    eventOverrides:
+      id: "notmyId"
+      source: "http://www.some-website.ca"
+  - name: Prefix OR Suffix filter (4)
+    expression: "id LIKE 'my%' OR source LIKE '%.ca'"
+    result: false 
+    eventOverrides:
+      id: "notmyId"
+      source: "http://www.some-website.com"
+  - name: Prefix OR Suffix filter (5)
+    expression: "id LIKE 'my%' OR myext LIKE '%ext'"
+    error: missingAttribute
+    eventOverrides:
+      id: "notmyId"
+      source: "http://www.some-website.com"
+
+  - name: Disjunctive Normal Form (1)
+    expresion: "(id = 'myId' AND type LIKE '%.success') OR (id = 'notmyId' AND source LIKE 'http://%' AND type LIKE '%.warning')"
+    result: true
+    eventOverrides:
+      id: "myId"
+      type: "example.event.success"
+  - name: Disjunctive Normal Form (2)
+    expresion: "(id = 'myId' AND type LIKE '%.success') OR (id = 'notmyId' AND source LIKE 'http://%' AND type LIKE '%.warning')"
+    result: true
+    eventOverrides:
+      id: "notmyId"
+      type: "example.event.warning"
+      source: "http://localhost.localdomain"
+  - name: Disjunctive Normal Form (3)
+    expresion: "(id = 'myId' AND type LIKE '%.success') OR (id = 'notmyId' AND source LIKE 'http://%' AND type LIKE '%.warning')"
+    result: false 
+    eventOverrides:
+      id: "notmyId"
+      type: "example.event.warning"
+      source: "https://localhost.localdomain"
+  - name: Disjunctive Normal Form (4)
+    expresion: "(id = 'myId' AND type LIKE '%.success') OR (id = 'notmyId' AND source LIKE 'http://%' AND type LIKE '%.warning') OR (myext = 'cusomext')"
+    error: missingAttribute
+    eventOverrides:
+      id: "notmyId"
+      type: "example.event.warning"
+      source: "https://localhost.localdomain"
+
+  - name: Conjunctive Normal Form (1)
+    expression: "(id = 'myId' OR type LIKE '%.success') AND (id = 'notmyId' OR source LIKE 'https://%' OR type LIKE '%.warning')"
+    result: true
+    eventOverrides:
+      id: "myId" 
+      type: "example.event.warning"
+  - name: Conjunctive Normal Form (2)
+    expression: "(id = 'myId' OR type LIKE '%.success') AND (id = 'notmyId' OR source LIKE 'https://%' OR type LIKE '%.warning')"
+    result: true
+    eventOverrides:
+      id: "notmyId"
+      type: "example.event.success"
+  - name: Conjunctive Normal Form (3)
+    expression: "(id = 'myId' OR type LIKE '%.success') AND (id = 'notmyId' OR source LIKE 'https://%' OR type LIKE '%.warning')"
+    result: false
+    eventOverrides:
+      id: "notmyId"
+      type: "example.event.warning"
+  - name: Conjunctive Normal Form (4)
+    expression: "(id = 'myId' OR type LIKE '%.success') AND (id = 'notmyId' OR source LIKE 'https://%' OR type LIKE '%.warning')"
+    result: true
+    eventOverrides:
+      id: "myId" 
+      type: "example.event.success"
+  - name: Conjunctive Normal Form (5)
+    expression: "(id = 'myId' OR type LIKE '%.success') AND (id = 'notmyId' OR source LIKE 'https://%' OR type LIKE '%.warning') AND (myext = 'customext')"
+    error: missingAttribute
+    eventOverrides:
+      id: "myId" 
+      type: "example.event.success"
+
+
+
+

--- a/cesql/cesql_tck/subscriptions_api_recreations.yaml
+++ b/cesql/cesql_tck/subscriptions_api_recreations.yaml
@@ -146,30 +146,35 @@ tests:
     eventOverrides:
       id: "myId" 
       type: "example.event.warning"
+      source: "http://localhost.localdomain"
   - name: Conjunctive Normal Form (2)
     expression: "(id = 'myId' OR type LIKE '%.success') AND (id = 'notmyId' OR source LIKE 'https://%' OR type LIKE '%.warning')"
     result: true
     eventOverrides:
       id: "notmyId"
       type: "example.event.success"
+      source: "http://localhost.localdomain"
   - name: Conjunctive Normal Form (3)
     expression: "(id = 'myId' OR type LIKE '%.success') AND (id = 'notmyId' OR source LIKE 'https://%' OR type LIKE '%.warning')"
     result: false
     eventOverrides:
       id: "notmyId"
       type: "example.event.warning"
+      source: "http://localhost.localdomain"
   - name: Conjunctive Normal Form (4)
     expression: "(id = 'myId' OR type LIKE '%.success') AND (id = 'notmyId' OR source LIKE 'https://%' OR type LIKE '%.warning')"
     result: true
     eventOverrides:
       id: "myId" 
       type: "example.event.success"
+      source: "http://localhost.localdomain"
   - name: Conjunctive Normal Form (5)
     expression: "(id = 'myId' OR type LIKE '%.success') AND (id = 'notmyId' OR source LIKE 'https://%' OR type LIKE '%.warning') AND (myext = 'customext')"
     error: missingAttribute
     eventOverrides:
       id: "myId" 
       type: "example.event.success"
+      source: "http://localhost.localdomain"
 
 
 


### PR DESCRIPTION
Fixes #1225 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add tck test cases which verify that the "LIKE" operator works when the operand is not a string and needs to be coerced to string
- Add tck test cases for suffix, prefix, and exact filter implementations
- Add tck test cases for ANDs and ORs of suffix, prefix, and exact filter implementations


