### PR TITLE
SQL filter: Clarify that only boolean TRUE values pass filter

### DIFF
--- a/subscriptions/spec.md
+++ b/subscriptions/spec.md
@@ -872,10 +872,10 @@ this specification:
 
 Use of this MUST have a string value, representing a [CloudEvents SQL 
 Expression](../cesql/spec.md).
-The filter result MUST be true if the result value of the expression, 
-coerced to boolean, equals to the `TRUE` boolean value,
-otherwise MUST be false if an error occurred while evaluating the expression or if the result value,
-coerced to boolean, equals to the `FALSE` boolean value.
+The filter result MUST be true if the result value of the expression
+equals to the `TRUE` boolean value, otherwise MUST be false if an
+error occurred while evaluating the expression or if the result value
+is equal to the `FALSE` boolean value, or if the result value is not a boolean.
 
 Implementations SHOULD reject subscriptions with invalid CloudEvents SQL 
 expressions.


### PR DESCRIPTION
Fixes #1221

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Only CESQL results which are the `TRUE` boolean value should pass the filter.


**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note
Only CESQL results which are equal to the `TRUE` boolean value pass the CESQL subscriptions API filter.
```
