### PR TITLE
Add unknown value for authtype enum of Auth Context ext

### DIFF
--- a/cloudevents/extensions/authcontext.md
+++ b/cloudevents/extensions/authcontext.md
@@ -37,8 +37,9 @@ this extension is being used.
     was deleted based on a TTL.
   - `unauthenticated`: No credentials were used to authenticate the change that
     triggered the occurence.
+  - `unknown`: The type of principal cannot be determined and is unknown.
 - Constraints
-  - OPTIONAL
+  - REQUIRED
   - This specification defines the following values, and it is RECOMMENDED that
     they be used. However, implementations MAY define additional values.
 

--- a/cloudevents/extensions/authcontext.md
+++ b/cloudevents/extensions/authcontext.md
@@ -38,7 +38,7 @@ this extension is being used.
   - `unauthenticated`: No credentials were used to authenticate the change that
     triggered the occurence.
 - Constraints
-  - REQUIRED
+  - OPTIONAL
   - This specification defines the following values, and it is RECOMMENDED that
     they be used. However, implementations MAY define additional values.
 


### PR DESCRIPTION
Issue created for this change: https://github.com/cloudevents/spec/issues/1245

Fixes #

For the recently added extension Auth Context /extensions/authcontext.md the attribute of authtype could be not identified reliable and be unknown.

The key principle here is that authtype classification results should be predictable and should not change. However, for some cases the type is preferred to be unknown when we can't determine reliable. The main concern we have is how authtype classifications might change when we are able to classify the request in the future. As a result if we change from unknown to app_user it is a "breaking" change for API consumers. Since their code may build business logic based on authtype results.

In https://github.com/cloudevents/spec/blob/main/cloudevents/documented-extensions.md , this already mentioned:

>The attributes defined in this document have no official standing and might be changed, or removed, at any time. As such, inclusion of an attribute in this document does not need to meet the same level of maturity, or popularity, as attributes defined in the [CloudEvents specification](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md).

For this reason, the proposal is to add `unknown` enum value for authtype.

**Alternative**:

- Making authtype OPTIONAL to avoid having customers build business logic around it. If we have to return an authtype in a situation where we don't know for certain, I would prefer to add the enum value unknown. 

Cons: The [#1247](github.com/cloudevents/spec/pull/1247) ensures all extensions have at least one REQUIRED field. So clients can determine if an extension is present.

## Proposed Changes

- Add `unknown` value for `authtype` enum of Auth Context extension.

**Release Note**

```release-note
Add `unknown` value for `authtype` enum of Auth Context extension
```
