### PR TITLE
Clarify boolean literals in specification

### DIFF
--- a/cesql/spec.md
+++ b/cesql/spec.md
@@ -117,7 +117,7 @@ CESQL defines 3 different literal kinds: integer numbers, `true` or `false` bool
 digit ::= [0-9]
 number-literal ::= digit+
 
-boolean-literal ::= "true" | "false"
+boolean-literal ::= "true" | "false" (* Case insensitive *)
 
 string-literal ::= ( "'" ( [^'] | "\'" )* "'" ) | ( '"' ( [^"] | '\"' )* '"')
 


### PR DESCRIPTION
Fixes #1232 

## Proposed Changes

Include "TRUE" | "FALSE" when you define boolean literals in the spec.md

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note

```
