### PR TITLE
Clarify that missing attributes should not result in errors

### DIFF
--- a/cesql/cesql_tck/README.md
+++ b/cesql/cesql_tck/README.md
@@ -23,6 +23,5 @@ The `error` values could be any of the following:
 * `parse`: Error while parsing the expression
 * `math`: Math error while evaluating a math operator
 * `cast`: Casting error
-* `missingAttribute`: Addressed a missing attribute
 * `missingFunction`: Addressed a missing function
 * `functionEvaluation`: Error while evaluating a function

--- a/cesql/cesql_tck/context_attributes_access.yaml
+++ b/cesql/cesql_tck/context_attributes_access.yaml
@@ -17,7 +17,7 @@ tests:
       id: myId
       source: localhost.localdomain
       type: myType
-    result: "" 
+    result: false
   - name: Access to optional boolean extension
     expression: mybool
     eventOverrides:

--- a/cesql/cesql_tck/context_attributes_access.yaml
+++ b/cesql/cesql_tck/context_attributes_access.yaml
@@ -17,8 +17,7 @@ tests:
       id: myId
       source: localhost.localdomain
       type: myType
-    result: ""
-    error: missingAttribute
+    result: "" 
   - name: Access to optional boolean extension
     expression: mybool
     eventOverrides:

--- a/cesql/cesql_tck/subscriptions_api_recreations.yaml
+++ b/cesql/cesql_tck/subscriptions_api_recreations.yaml
@@ -17,7 +17,7 @@ tests:
       myext: "customext"
   - name: Prefix filter on missing string extension
     expression: "myext LIKE 'custom%'"
-    error: missingAttribute
+    result: false
 
   - name: Suffix filter (1)
     expression: "type like '%.error'"
@@ -36,7 +36,7 @@ tests:
       myext: "customext"
   - name: Suffix filter on missing string extension
     expression: "myext LIKE '%ext'"
-    error: missingAttribute
+    result: false
 
   - name: Exact filter (1)
     expression: "id = 'myId'"
@@ -55,7 +55,7 @@ tests:
       myext: "customext"
   - name: Exact filter on missing string extension
     expression: "myext = 'customext'"
-    error: missingAttribute
+    result: false
 
   - name: Prefix filter AND Suffix filter (1)
     expression: "id LIKE 'my%' AND source LIKE '%.ca'"
@@ -77,7 +77,7 @@ tests:
       type: "com.github.error"
   - name: Prefix AND Suffix filter (4)
     expression: "type LIKE 'example.%' AND myext LIKE 'custom%'"
-    error: missingAttribute
+    result: false
     eventOverrides:
       type: "example.event.type"
 
@@ -157,7 +157,7 @@ tests:
       source: "http://localhost.localdomain"
   - name: Conjunctive Normal Form (5)
     expression: "(id = 'myId' OR type LIKE '%.success') AND (id = 'notmyId' OR source LIKE 'https://%' OR type LIKE '%.warning') AND (myext = 'customext')"
-    error: missingAttribute
+    result: false
     eventOverrides:
       id: "myId" 
       type: "example.event.success"

--- a/cesql/spec.md
+++ b/cesql/spec.md
@@ -197,7 +197,8 @@ Unless otherwise specified, every attribute and extension MUST be represented by
 Through implicit type casting, the user can convert the addressed value instances to _Integer_ and
 _Boolean_.
 
-When addressing an attribute not included in the input event, an empty _String_ MUST be assumed as its value.
+When addressing an attribute not included in the input event, the entire subexpression MUST evaluate to `false`.
+For example, `true AND (missingAttribute = "")` would evaluate to `false` as the subexpression `missingAttribute = ""` would be false.
 
 ### 3.3. Errors
 
@@ -205,9 +206,6 @@ Because every operator and function is total, an expression evaluation flow is d
 by expected or unexpected errors. Nevertheless CESQL includes the concept of errors: when an expression is evaluated, in
 case an error arises, the evaluator collects a list of errors, referred in this spec as _error list_, which is then
 returned together with the evaluated value of the CESQL expression.
-
-Addressing an attribute which is missing from the input event MUST NOT return an error due to the missing attribute. Instead, 
-an empty string MUST be assumed as its value, and execution MUST proceed as it would with any other string value.
 
 Whenever possible, some error checks SHOULD be done at compile time by the expression evaluator, in order to prevent
 runtime errors.

--- a/cesql/spec.md
+++ b/cesql/spec.md
@@ -206,7 +206,7 @@ by expected or unexpected errors. Nevertheless CESQL includes the concept of err
 case an error arises, the evaluator collects a list of errors, referred in this spec as _error list_, which is then
 returned together with the evaluated value of the CESQL expression.
 
-Addressing an attribute which is missing from the input event MUST not return an error due to the missing attribute. Instead, 
+Addressing an attribute which is missing from the input event MUST NOT return an error due to the missing attribute. Instead, 
 an empty string MUST be assumed as its value, and execution MUST proceed as it would with any other string value.
 
 Whenever possible, some error checks SHOULD be done at compile time by the expression evaluator, in order to prevent

--- a/cesql/spec.md
+++ b/cesql/spec.md
@@ -206,6 +206,9 @@ by expected or unexpected errors. Nevertheless CESQL includes the concept of err
 case an error arises, the evaluator collects a list of errors, referred in this spec as _error list_, which is then
 returned together with the evaluated value of the CESQL expression.
 
+Addressing an attribute which is missing from the input event MUST not return an error due to the missing attribute. Instead, 
+an empty string MUST be assumed as its value, and execution MUST proceed as it would with any other string value.
+
 Whenever possible, some error checks SHOULD be done at compile time by the expression evaluator, in order to prevent
 runtime errors.
 

--- a/cesql/spec.md
+++ b/cesql/spec.md
@@ -197,7 +197,7 @@ Unless otherwise specified, every attribute and extension MUST be represented by
 Through implicit type casting, the user can convert the addressed value instances to _Integer_ and
 _Boolean_.
 
-When addressing an attribute not included in the input event, the entire subexpression MUST evaluate to `false`.
+When addressing an attribute not included in the input event, the subexpression referencing the missing attribute MUST evaluate to `false`.
 For example, `true AND (missingAttribute = "")` would evaluate to `false` as the subexpression `missingAttribute = ""` would be false.
 
 ### 3.3. Errors


### PR DESCRIPTION
Fixes #1230

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Clarify that missing attributes should not result in an error

Note: this is actually something that the SDKs currently implement incorrectly, so if this PR is merged I will go and fix them.

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note
CESQL expressions should not return an error when there is a missing attribute
```
