### PR TITLE
Suggestion about Structuring a Composite "subject" Field

### DIFF
--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -419,7 +419,7 @@ on the definition of OPTIONAL.
 #### subject
 
 - Type: `String`
-- Description: This describes the subject of the event in the context of the
+- Description: This identifies the subject of the event in the context of the
   event producer (identified by `source`). In publish-subscribe scenarios, a
   subscriber will typically subscribe to events emitted by a `source`, but the
   `source` identifier alone might not be sufficient as a qualifier for any
@@ -450,9 +450,9 @@ on the definition of OPTIONAL.
     subscription scope (CRM part of an eCommerce system), the `type` identifies
     the "client updated" event, and the `id` uniquely identifies the event
     instance to distinguish separate occurrences of a same client being
-    updated multiple times; the affiliate partner and client ids of the updated
+    updated multiple times; the affiliate partner id and client id of the updated
     client are carried in `subject`. Here, it is a composite string
-    (affiliate partner id:client id) that is made up of one or more identifying
+    (`affiliate partner id:client id`) that is made up of one or more identifying
     pieces of data separated by some symbol (like, colon), assuming that each
     affiliate partner has its own client base:
       - `source`: `https://example.com/eCommerce/crm`

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -450,11 +450,9 @@ on the definition of OPTIONAL.
     subscription scope (CRM part of an eCommerce system), the `type` identifies
     the "client updated" event, and the `id` uniquely identifies the event
     instance to distinguish separate occurrences of a same client being
-    updated multiple times; the affiliate partner id and client id of the updated
-    client are carried in `subject`. Here, it is a composite string
-    (`affiliate partner id:client id`) that is made up of one or more identifying
-    pieces of data separated by some symbol (like, colon), assuming that each
-    affiliate partner has its own client base:
+    updated multiple times; the `subject` uniquely identifies the client within
+    the scope of the `source` by including a "partner id" and "client id"
+    (which is unique within the scope of the "partner id") separated by a colon:
       - `source`: `https://example.com/eCommerce/crm`
       - `subject`: `5:100`
 

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -454,7 +454,7 @@ on the definition of OPTIONAL.
     the scope of the `source` by including a "partner id" and "client id"
     (which is unique within the scope of the "partner id") separated by a colon:
       - `source`: `https://example.com/eCommerce/crm`
-      - `subject`: `5:100`
+      - `subject`: `partnerid/5/clientid/100`
 
 #### time
 

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -448,7 +448,7 @@ on the definition of OPTIONAL.
   - Building on the previous example, a subscriber might register interest for when new
      blobs are created inside a blob-storage container. However, this time both the name
      and/or size of the newly created blob are relevant for decision making purposes.
-     In this case, the `subject` may simply list meta-properties (including custom extensions),
+     In this case, the `subject` MAY simply list meta-properties (including custom extensions),
      separated with comma, containing additional data:
        - `source`: `https://example.com/storage/tenant/container`
        - `subject`: `myextensionfilename,myextensionfilesize`

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -436,15 +436,24 @@ on the definition of OPTIONAL.
 - Constraints:
   - OPTIONAL
   - If present, MUST be a non-empty string
-- Example:
+- Examples:
   - A subscriber might register interest for when new blobs are created inside a
     blob-storage container. In this case, the event `source` identifies the
     subscription scope (storage container), the `type` identifies the "blob
     created" event, and the `id` uniquely identifies the event instance to
     distinguish separate occurrences of a same-named blob having been created;
     the name of the newly created blob is carried in `subject`:
-    - `source`: `https://example.com/storage/tenant/container`
-    - `subject`: `mynewfile.jpg`
+      - `source`: `https://example.com/storage/tenant/container`
+      - `subject`: `mynewfile.jpg`
+  - Building on the previous example, a subscriber might register interest for when new
+     blobs are created inside a blob-storage container. However, this time both the name
+     and/or size of the newly created blob are relevant for decision making purposes.
+     In this case, the `subject` may simply list meta-properties (including custom extensions),
+     separated with comma, containing additional data:
+       - `source`: `https://example.com/storage/tenant/container`
+       - `subject`: `myextensionfilename,myextensionfilesize`
+       - `myextensionfilename`: `mynewfile.jpg`
+       - `myextensionfilesize`: `100MB`
 
 #### time
 

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -446,14 +446,14 @@ on the definition of OPTIONAL.
       - `source`: `https://example.com/storage/tenant/container`
       - `subject`: `mynewfile.jpg`
   - Building on the previous example, a subscriber might register interest for when new
-     blobs are created inside a blob-storage container. However, this time both the name
-     and/or size of the newly created blob are relevant for decision making purposes.
-     In this case, the `subject` MAY simply list meta-properties (including custom extensions),
-     separated with comma, containing additional data:
-       - `source`: `https://example.com/storage/tenant/container`
-       - `subject`: `myextensionfilename,myextensionfilesize`
-       - `myextensionfilename`: `mynewfile.jpg`
-       - `myextensionfilesize`: `100MB`
+    blobs are created inside a blob-storage container. However, this time both the name
+    and/or size of the newly created blob are relevant for decision making purposes.
+    In this case, the `subject` MAY simply list meta-properties (including custom extensions),
+    separated with comma, containing additional data:
+      - `source`: `https://example.com/storage/tenant/container`
+      - `subject`: `myextensionfilename,myextensionfilesize`
+      - `myextensionfilename`: `mynewfile.jpg`
+      - `myextensionfilesize`: `100MB`
 
 #### time
 

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -446,14 +446,12 @@ on the definition of OPTIONAL.
       - `source`: `https://example.com/storage/tenant/container`
       - `subject`: `mynewfile.jpg`
   - Building on the previous example, a subscriber might register interest for when new
-    blobs are created inside a blob-storage container. However, this time both the name
+    blobs are created inside a blob-storage container. Here, both the name
     and/or size of the newly created blob are relevant for decision making purposes.
-    In this case, the `subject` MAY simply list custom extensions, separated with comma,
-    containing additional data:
+    In this case, the `subject` MAY simply list multiple values, separated with comma,
+    adorned with custom prefixes:
       - `source`: `https://example.com/storage/tenant/container`
-      - `subject`: `myextensionfilename,myextensionfilesize`
-      - `myextensionfilename`: `mynewfile.jpg`
-      - `myextensionfilesize`: `100MB`
+      - `subject`: `filename:mynewfile.jpg,filesize:100MB`
 
 #### time
 

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -445,13 +445,18 @@ on the definition of OPTIONAL.
     the name of the newly created blob is carried in `subject`:
       - `source`: `https://example.com/storage/tenant/container`
       - `subject`: `mynewfile.jpg`
-  - Building on the previous example, a subscriber might register interest for when new
-    blobs are created inside a blob-storage container. Here, both the name
-    and/or size of the newly created blob are relevant for decision making purposes.
-    In this case, the `subject` MAY simply list multiple values, separated with comma,
-    adorned with custom prefixes:
-      - `source`: `https://example.com/storage/tenant/container`
-      - `subject`: `filename:mynewfile.jpg,filesize:100MB`
+  - A subscriber might register interest for when new updates are made to a client
+    in an eCommerce system. In this case, the event `source` identifies the
+    subscription scope (CRM part of an eCommerce system), the `type` identifies
+    the "client updated" event, and the `id` uniquely identifies the event
+    instance to distinguish separate occurrences of a same client being
+    updated multiple times; the affiliate partner and client ids of the updated
+    client are carried in `subject`. Here, it is a composite string
+    (affiliate partner id:client id) that is made up of one or more identifying
+    pieces of data separated by some symbol (like, colon), assuming that each
+    affiliate partner has its own client base:
+      - `source`: `https://example.com/eCommerce/crm`
+      - `subject`: `5:100`
 
 #### time
 

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -448,8 +448,8 @@ on the definition of OPTIONAL.
   - Building on the previous example, a subscriber might register interest for when new
     blobs are created inside a blob-storage container. However, this time both the name
     and/or size of the newly created blob are relevant for decision making purposes.
-    In this case, the `subject` MAY simply list meta-properties (including custom extensions),
-    separated with comma, containing additional data:
+    In this case, the `subject` MAY simply list custom extensions, separated with comma,
+    containing additional data:
       - `source`: `https://example.com/storage/tenant/container`
       - `subject`: `myextensionfilename,myextensionfilesize`
       - `myextensionfilename`: `mynewfile.jpg`


### PR DESCRIPTION
## Background

The core specification lacks any recommendation how to cope with a composite `subject` field. Leaving everything to a producer may create an undesirable situation of packing, even semantically similar, `subject` content in arcane manner. 

## Proposed Changes

This PR adds an additional example, suggesting a different way to structure the content of the `subject` field, while fully preserving compatibility with the existing standard.