### PR TITLE
First pass at considering content-type in a case-insensitive way.

### DIFF
--- a/cloudevents/SDK.md
+++ b/cloudevents/SDK.md
@@ -128,6 +128,10 @@ and encoding:
   format, both in the [table below](#feature-support) and in any SDK-specific
   documentation provided.
 
+Note that when decoding an event, media types MUST be matched
+case-insensitively, as specified in [RFC 2045]
+(https://tools.ietf.org/html/rfc2045).
+
 #### Data
 
 Data access from the event has some considerations, the Event at rest could be

--- a/cloudevents/bindings/amqp-protocol-binding.md
+++ b/cloudevents/bindings/amqp-protocol-binding.md
@@ -105,9 +105,9 @@ an application, but are not defined here.
 
 The receiver of the event can distinguish between the two modes by inspecting
 the `content-type` message property field. If the value is prefixed with the
-CloudEvents media type `application/cloudevents`, indicating the use of a known
-[event format](#14-event-formats), the receiver uses _structured_ mode,
-otherwise it defaults to _binary_ mode.
+CloudEvents media type `application/cloudevents` (matched case-insensitively),
+indicating the use of a known [event format](#14-event-formats), the receiver
+uses _structured_ mode, otherwise it defaults to _binary_ mode.
 
 If a receiver detects the CloudEvents media type, but with an event format that
 it cannot handle, for instance `application/cloudevents+avro`, it MAY still

--- a/cloudevents/bindings/http-protocol-binding.md
+++ b/cloudevents/bindings/http-protocol-binding.md
@@ -138,10 +138,10 @@ gesture SHOULD allow the receiver to choose the maximum size of a batch.
 
 The receiver of the event can distinguish between the three modes by inspecting
 the `Content-Type` header value. If the value is prefixed with the CloudEvents
-media type `application/cloudevents`, indicating the use of a known
-[event format](#14-event-formats), the receiver uses _structured_ mode. If the
-value is prefixed with `application/cloudevents-batch`, the receiver uses the
-_batched_ mode. Otherwise it defaults to _binary_ mode.
+media type `application/cloudevents` (matched case-insensitively), indicating
+the use of a known [event format](#14-event-formats), the receiver uses
+_structured_ mode. If the value is prefixed with `application/cloudevents-batch`,
+the receiver uses the _batched_ mode. Otherwise it defaults to _binary_ mode.
 
 If a receiver detects the CloudEvents media type, but with an event format that
 it cannot handle, for instance `application/cloudevents+avro`, it MAY still

--- a/cloudevents/bindings/kafka-protocol-binding.md
+++ b/cloudevents/bindings/kafka-protocol-binding.md
@@ -133,9 +133,9 @@ here.
 The receiver of the event can distinguish between the two content modes by
 inspecting the `content-type` [Header][kafka-message-header] of the Kafka
 message. If the header is present and its value is prefixed with the CloudEvents
-media type `application/cloudevents`, indicating the use of a known
-[event format](#14-event-formats), the receiver uses _structured_ mode,
-otherwise it defaults to _binary_ mode.
+media type `application/cloudevents` (matched case-insensitively),
+indicating the use of a known [event format](#14-event-formats), the receiver
+uses _structured_ mode, otherwise it defaults to _binary_ mode.
 
 If a receiver finds a CloudEvents media type as per the above rule, but with an
 event format that it cannot handle, for instance `application/cloudevents+avro`,

--- a/cloudevents/bindings/nats-protocol-binding.md
+++ b/cloudevents/bindings/nats-protocol-binding.md
@@ -109,8 +109,8 @@ conditions:
 - If the server is a version earlier than NATS 2.2, the content mode is
 always _structured_.
 - If the server is version 2.2 or above and the `Content-Type` header of
-`application/cloudevents` is present, then the message is in _structured_
-mode, otherwise it is using binary mode.
+`application/cloudevents` is present (matched case-insensitively),
+then the message is in _structured_ mode, otherwise it is using binary mode.
 
 If the content mode is _structured_ then the NATS message payload MUST be
 the [JSON event format][json-format] serialized as specified by the

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -404,6 +404,12 @@ on the definition of OPTIONAL.
   The `datacontenttype` attribute MAY appear even if there is no `data` value
   present.
 
+  As specified in [RFC 2045](https://tools.ietf.org/html/rfc2045), the media
+  type part of the content type MUST be treated in a case-insensitive manner
+  by consumers, along with the attribute names in parameters. For example,
+  a `datacontenttype` of `text/plain; charset=utf-8` MUST be treated in the
+  same way as `TEXT/Plain; CharSet=utf-8`.
+
 - Constraints:
   - OPTIONAL
   - If present, MUST adhere to the format specified in


### PR DESCRIPTION
We don't note what "kind" of case insensitivity to consider though - should we only consider ASCII values as matching
"application/cloudevents" for example? (Case insensitivity is hard, basically...)

There may be other aspects I've missed, or I may have been too aggressive in imposing case-insensitivity in some bindings. Thoughts very welcome.