### PR TITLE
test: verify that invalid string literals in LIKE expression are a parse error

### DIFF
--- a/cesql/cesql_tck/like_expression.yaml
+++ b/cesql/cesql_tck/like_expression.yaml
@@ -116,3 +116,10 @@ tests:
   - name: With type coercion from bool (4)
     expression: "FALSE LIKE 'fal%'"
     result: true 
+
+  - name: Invalid string literal in comparison causes parse error
+    expression: "x LIKE 123"
+    result: false
+    error: parse
+    eventOverrides:
+      x: "123"


### PR DESCRIPTION
Follow up on discussion in sdk-go: https://github.com/cloudevents/sdk-go/pull/1046#discussion_r1595307651
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add a test verifying that an invalid string literal in a LIKE expression is a parse error

