### PR TITLE
Use encrytped data in example as recommended in Privacy and Security section

### DIFF
--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -13,7 +13,7 @@ data.
 - [Event Data](#event-data)
 - [Size Limits](#size-limits)
 - [Privacy & Security](#privacy-and-security)
-- [Example](#example)
+- [Example](#examples)
 
 ## Overview
 

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -627,7 +627,14 @@ Consider the following to prevent inadvertent leakage especially when leveraging
 }
 ```
 
-### Example of a CloudEvent with encrypted data
+### Example of a CloudEvent with JOSE encrypted data
+
+For JOSE spec please see https://datatracker.ietf.org/doc/rfc7516/
+
+This example does not imply that CloudEvents has some inherent security features.
+The example shows how data can be encrypted thus achieving confidentiality.
+Security features are intentionally out-of-scope in this spec.
+The choice of encryption method and format is domain specific.
 
 The following example shows a CloudEvent serialized as JSON with line-breaks
 for display purposes only:
@@ -652,5 +659,34 @@ for display purposes only:
        5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6ji
        SdiwkIr3ajwQzaBtQD_A.
        XFBoMYUZodetZdvTiFvSkQ"
+}
+```
+
+
+### Example of a CloudEvent with xmlenc encrypted data
+
+For xmlenc spec please see [xmlenc](https://www.w3.org/TR/xmlenc-core1/)
+
+This example does not imply that CloudEvents has some inherent security features.
+The example shows how data can be encrypted thus achieving confidentiality.
+Security features are intentionally out-of-scope in this spec.
+The choice of encryption method and format is domain specific.
+
+The following example shows a CloudEvent serialized as xmlenc with line-breaks
+for display purposes only:
+
+```
+{
+    "specversion" : "1.0",
+    "type" : "PAYMENT.AUTHORIZATION.CREATED",
+    "source" : "https://paymentprocessor.example.com/",
+    "subject" : "c7bbb040-d458-4d47-82a8-45413f9f2d33",
+    "id" : "a978702e-ef48-4032-ac18-a057e0104076",
+    "time" : "2024-05-30T17:31:00Z",
+    "datacontenttype" : "application/xenc+xml",
+    "data" : "<EncryptedData xmlns=\"http://www.w3.org/2001/04/xmlenc#\"
+              MimeType=\"text/xml\">
+              <CipherData><CipherValue>A23B45C56</CipherValue></CipherData>
+              </EncryptedData>"
 }
 ```

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -622,7 +622,18 @@ The following example shows a CloudEvent serialized as JSON:
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
     "comexampleothervalue" : 5,
-    "datacontenttype" : "text/xml",
-    "data" : "<much wow=\"xml\"/>"
+    "datacontenttype" : "application/jose",
+    "data" : "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.
+     OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGe
+     ipsEdY3mx_etLbbWSrFr05kLzcSr4qKAq7YN7e9jwQRb23nfa6c9d-StnImGyFDb
+     Sv04uVuxIp5Zms1gNxKKK2Da14B8S4rzVRltdYwam_lDp5XnZAYpQdb76FdIKLaV
+     mqgfwX7XWRxv2322i-vDxRfqNzo_tETKzpVLzfiwQyeyPGLBIO56YJ7eObdv0je8
+     1860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vFWXRcZ_ZT2LawVCWTIy3brGPi
+     6UklfCpIMfIjf7iGdXKHzg.
+     48V1_ALb6US04U3b.
+     5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6ji
+     SdiwkIr3ajwQzaBtQD_A.
+     XFBoMYUZodetZdvTiFvSkQ
+"
 }
 ```

--- a/cloudevents/spec.md
+++ b/cloudevents/spec.md
@@ -608,9 +608,9 @@ Consider the following to prevent inadvertent leakage especially when leveraging
   Protocol level security SHOULD be employed to ensure the trusted and secure
   exchange of CloudEvents.
 
-## Example
+## Examples
 
-The following example shows a CloudEvent serialized as JSON:
+### Example of a CloudEvent with extension fields
 
 ```JSON
 {
@@ -622,18 +622,35 @@ The following example shows a CloudEvent serialized as JSON:
     "time" : "2018-04-05T17:31:00Z",
     "comexampleextension1" : "value",
     "comexampleothervalue" : 5,
+    "datacontenttype" : "text/xml",
+    "data" : "<much wow=\"xml\"/>"
+}
+```
+
+### Example of a CloudEvent with encrypted data
+
+The following example shows a CloudEvent serialized as JSON with line-breaks
+for display purposes only:
+
+```
+{
+    "specversion" : "1.0",
+    "type" : "PAYMENT.AUTHORIZATION.CREATED",
+    "source" : "https://paymentprocessor.example.com/",
+    "subject" : "c7bbb040-d458-4d47-82a8-45413f9f2d33",
+    "id" : "a978702e-ef48-4032-ac18-a057e0104076",
+    "time" : "2024-05-30T17:31:00Z",
     "datacontenttype" : "application/jose",
     "data" : "eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00ifQ.
-     OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGe
-     ipsEdY3mx_etLbbWSrFr05kLzcSr4qKAq7YN7e9jwQRb23nfa6c9d-StnImGyFDb
-     Sv04uVuxIp5Zms1gNxKKK2Da14B8S4rzVRltdYwam_lDp5XnZAYpQdb76FdIKLaV
-     mqgfwX7XWRxv2322i-vDxRfqNzo_tETKzpVLzfiwQyeyPGLBIO56YJ7eObdv0je8
-     1860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vFWXRcZ_ZT2LawVCWTIy3brGPi
-     6UklfCpIMfIjf7iGdXKHzg.
-     48V1_ALb6US04U3b.
-     5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6ji
-     SdiwkIr3ajwQzaBtQD_A.
-     XFBoMYUZodetZdvTiFvSkQ
-"
+       OKOawDo13gRp2ojaHV7LFpZcgV7T6DVZKTyKOMTYUmKoTCVJRgckCL9kiMT03JGe
+       ipsEdY3mx_etLbbWSrFr05kLzcSr4qKAq7YN7e9jwQRb23nfa6c9d-StnImGyFDb
+       Sv04uVuxIp5Zms1gNxKKK2Da14B8S4rzVRltdYwam_lDp5XnZAYpQdb76FdIKLaV
+       mqgfwX7XWRxv2322i-vDxRfqNzo_tETKzpVLzfiwQyeyPGLBIO56YJ7eObdv0je8
+       1860ppamavo35UgoRdbYaBcoh9QcfylQr66oc6vFWXRcZ_ZT2LawVCWTIy3brGPi
+       6UklfCpIMfIjf7iGdXKHzg.
+       48V1_ALb6US04U3b.
+       5eym8TW_c8SuK0ltJ3rpYIzOeDQz7TALvtu6UG9oMo4vpzs9tX_EFShS8iB7j6ji
+       SdiwkIr3ajwQzaBtQD_A.
+       XFBoMYUZodetZdvTiFvSkQ"
 }
 ```


### PR DESCRIPTION
Fixes # https://github.com/cloudevents/spec/issues/1288

The example should follow the recommendation of the Privacy and Security section and use encrypted data

## Proposed Changes

- change content-type in example as defined in [JWS](https://datatracker.ietf.org/doc/html/rfc7515)
- change data value in example. Value taken from [JWE](https://www.rfc-editor.org/rfc/rfc7516#section-3.3)

