### PR TITLE
Update CESQL tck tests to match spec changes

### DIFF
--- a/cesql/cesql_tck/README.md
+++ b/cesql/cesql_tck/README.md
@@ -25,3 +25,4 @@ The `error` values could be any of the following:
 * `cast`: Casting error
 * `missingFunction`: Addressed a missing function
 * `functionEvaluation`: Error while evaluating a function
+* `missingAttribute`: Error due to a missing attribute

--- a/cesql/cesql_tck/README.md
+++ b/cesql/cesql_tck/README.md
@@ -26,3 +26,4 @@ The `error` values could be any of the following:
 * `missingFunction`: Addressed a missing function
 * `functionEvaluation`: Error while evaluating a function
 * `missingAttribute`: Error due to a missing attribute
+* `generic`: A generic error

--- a/cesql/cesql_tck/binary_comparison_operators.yaml
+++ b/cesql/cesql_tck/binary_comparison_operators.yaml
@@ -18,6 +18,10 @@ tests:
   - name: abc is equal to abc
     expression: "'abc' = 'abc'"
     result: true
+  - name: Equals operator returns false when encountering a missing attribute
+    expression: missing = 2
+    result: false
+    error: missingAttribute
 
   - name: True is not equal to false
     expression: TRUE != FALSE
@@ -37,6 +41,10 @@ tests:
   - name: abc is not equal to abc
     expression: "'abc' != 'abc'"
     result: false
+  - name: Not equal operator returns false when encountering a missing attribute
+    expression: missing != 2
+    result: false
+    error: missingAttribute
 
   - name: True is not equal to false (diamond operator)
     expression: TRUE <> FALSE
@@ -56,6 +64,10 @@ tests:
   - name: abc is not equal to abc (diamond operator)
     expression: "'abc' <> 'abc'"
     result: false
+  - name: Diamond operator returns false when encountering a missing attribute
+    expression: missing <> 2
+    result: false
+    error: missingAttribute
 
   - name: 1 is less or equal than 2
     expression: 2 <= 2
@@ -81,6 +93,10 @@ tests:
   - name: 2 is greater than 2
     expression: 2 > 2
     result: false
+  - name: Less than or equal operator returns false when encountering a missing attribute
+    expression: missing <= 2
+    result: false
+    error: missingAttribute
 
   - name: implicit casting with string as right type
     expression: "true = 'TRUE'"

--- a/cesql/cesql_tck/binary_logical_operators.yaml
+++ b/cesql/cesql_tck/binary_logical_operators.yaml
@@ -18,6 +18,7 @@ tests:
   - name: AND operator is NOT short circuit evaluated when the first operand evaluates to true
     expression: "true and (1 != 1 / 0)"
     error: math
+    result: false
 
   - name: False or false
     expression: FALSE OR FALSE
@@ -37,6 +38,7 @@ tests:
   - name: OR operator is NOT short circuit evaluated when the first operand evaluates to false
     expression: "false or (1 != 1 / 0)"
     error: math
+    result: false
 
   - name: False xor false
     expression: FALSE XOR FALSE

--- a/cesql/cesql_tck/binary_math_operators.yaml
+++ b/cesql/cesql_tck/binary_math_operators.yaml
@@ -21,6 +21,14 @@ tests:
     expression: 5 % 0
     result: 0
     error: math
+  - name: Missing attribute in division results in missing attribute error, not divide by 0 error
+    expression: missing / 0
+    result: 0
+    error: missingAttribute
+  - name: Missing attribute in modulo results in missing attribute error, not divide by 0 error
+    expression: missing % 0
+    result: 0
+    error: missingAttribute
 
   - name: Positive plus positive number
     expression: 4 + 1

--- a/cesql/cesql_tck/casting_functions.yaml
+++ b/cesql/cesql_tck/casting_functions.yaml
@@ -12,10 +12,12 @@ tests:
   - name: Cast identity -1
     expression: INT(-1)
     result: -1
-  - name: Invalid cast from boolean to int
+  - name: Cast from TRUE to int
     expression: INT(TRUE)
+    result: 1
+  - name: Cast from FALSE to int
+    expression: INT(FALSE)
     result: 0
-    error: cast
   - name: Invalid cast from string to int
     expression: INT('ABC')
     result: 0
@@ -37,10 +39,18 @@ tests:
     expression: BOOL('ABC')
     result: false
     error: cast
-  - name: Invalid cast from int to boolean
+  - name: Cast from 1 to boolean
     expression: BOOL(1)
+    result: true
+  - name: Cast from 0 to boolean
+    expression: BOOL(0)
     result: false
-    error: cast
+  - name: Cast from 100 to boolean
+    expression: BOOL(100)
+    result: true
+  - name: Cast from -50 to boolean
+    expression: BOOL(-50)
+    result: true
 
   - name: Cast TRUE to string
     expression: STRING(TRUE)
@@ -87,3 +97,4 @@ tests:
   - name: IS_STRING does not exists
     expression: IS_STRING('ABC')
     error: missingFunction
+    result: false

--- a/cesql/cesql_tck/context_attributes_access.yaml
+++ b/cesql/cesql_tck/context_attributes_access.yaml
@@ -18,6 +18,7 @@ tests:
       source: localhost.localdomain
       type: myType
     result: false
+    error: missingAttribute
   - name: Access to optional boolean extension
     expression: mybool
     eventOverrides:

--- a/cesql/cesql_tck/integer_builtin_functions.yaml
+++ b/cesql/cesql_tck/integer_builtin_functions.yaml
@@ -9,3 +9,8 @@ tests:
   - name: ABS (3)
     expression: ABS(0)
     result: 0
+  - name: ABS overflow
+    expression: ABS(-2147483648)
+    result: 2147483647
+    error: math
+

--- a/cesql/cesql_tck/like_expression.yaml
+++ b/cesql/cesql_tck/like_expression.yaml
@@ -123,3 +123,7 @@ tests:
     error: parse
     eventOverrides:
       x: "123"
+  - name: Missing attribute returns empty string
+    expression: "missing LIKE 'missing'"
+    result: false
+    error: missingAttribute

--- a/cesql/cesql_tck/negate_operator.yaml
+++ b/cesql/cesql_tck/negate_operator.yaml
@@ -14,7 +14,11 @@ tests:
     expression: --'10'
     result: 10
 
-  - name: Invalid boolean cast
+  - name: Minus with boolean cast
     expression: -TRUE
+    result: -1
+
+  - name: Minus with missing attribute
+    expression: -missing
     result: 0
-    error: cast
+    error: match

--- a/cesql/cesql_tck/negate_operator.yaml
+++ b/cesql/cesql_tck/negate_operator.yaml
@@ -21,4 +21,4 @@ tests:
   - name: Minus with missing attribute
     expression: -missing
     result: 0
-    error: match
+    error: missingAttribute

--- a/cesql/cesql_tck/not_operator.yaml
+++ b/cesql/cesql_tck/not_operator.yaml
@@ -18,3 +18,8 @@ tests:
     expression: NOT 10
     result: true
     error: cast
+
+  - name: Not missing attribute
+    expression: NOT missing
+    result: false
+    error: missingAttribute

--- a/cesql/cesql_tck/spec_examples.yaml
+++ b/cesql/cesql_tck/spec_examples.yaml
@@ -62,3 +62,16 @@ tests:
     eventOverrides:
       subject: Francesco Guardiani
     result: true
+
+  - name: Missing attribute (1)
+    expression: true AND (missing = "")
+    result: false
+    error: missingAttribute
+  - name: Missing attribute (2)
+    expression: missing * 5
+    result: 0
+    error: missingAttribute
+  - name: Missing attribute (3)
+    expression: 1 / missing
+    result: 0
+    error: missingAttribute

--- a/cesql/cesql_tck/string_builtin_functions.yaml
+++ b/cesql/cesql_tck/string_builtin_functions.yaml
@@ -35,6 +35,7 @@ tests:
   - name: CONCAT_WS without arguments doesn't exist
     expression: CONCAT_WS()
     error: missingFunction
+    result: false
 
   - name: LOWER (1)
     expression: "LOWER('ABC')"


### PR DESCRIPTION
With all of the CESQL spec changes recently, the spec needed some updates to reflect what had changed

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add results to every expression that has an error, as CESQL spec has been clarified on what should happen in that case
- Added missing attribute errors back, as well as tests to ensure that operators handle it correctly
- Add test for the `ABS` function overflow error
- Fix boolean casting now that it is defined for all types


