### PR TITLE
Vote: moving CESQL spec to v1

### DIFF
--- a/cesql/CESQLLexer.g4
+++ b/cesql/CESQLLexer.g4
@@ -70,7 +70,7 @@ FALSE: 'FALSE';
 
 DQUOTED_STRING_LITERAL:                      DQUOTA_STRING;
 SQUOTED_STRING_LITERAL:                      SQUOTA_STRING;
-INTEGER_LITERAL:                             INT_DIGIT+;
+INTEGER_LITERAL:                             ( '+' | '-' )? INT_DIGIT+;
 
 // Identifiers
 

--- a/cesql/README.md
+++ b/cesql/README.md
@@ -1,3 +1,3 @@
-# CloudEvents SQL Expression Language - Version 0.1-wip
+# CloudEvents SQL Expression Language - Version 1.0
 
 See the [CESQL specification](spec.md).

--- a/cesql/languages/zh-CN/spec.md
+++ b/cesql/languages/zh-CN/spec.md
@@ -1,4 +1,4 @@
-# CloudEvents SQL Expression Language - Version 0.1-wip
+# CloudEvents SQL Expression Language - Version 1.0
 
 本文档尚未被翻译，请先阅读英文[原版文档](../../spec.md) 。
 

--- a/cesql/spec.md
+++ b/cesql/spec.md
@@ -1,4 +1,4 @@
-# CloudEvents SQL Expression Language - Version 0.1-wip
+# CloudEvents SQL Expression Language - Version 1.0
 
 ## Abstract
 

--- a/cesql/spec.md
+++ b/cesql/spec.md
@@ -119,7 +119,7 @@ CESQL defines 3 different literal kinds: integer numbers, `true` or `false` bool
 
 ```ebnf
 digit ::= [0-9]
-integer-literal ::= ( '+' | '-' ) digit+
+integer-literal ::= ( '+' | '-' )? digit+
 
 boolean-literal ::= "true" | "false" (* Case insensitive *)
 


### PR DESCRIPTION
We'll be using this PR to vote on moving the CESQL to v1.0.

The following community members have voting rights:  Google, IBM/Red Hat, Microsoft, SAP, Mark Peek, Erik Erikson, Tommy Chung.

Other folks are welcome, and encouraged, to vote as well, but only "voting rights" members votes will be counted.

Please vote either with a thumb-up or thumb-down emoji on this comment, or with a new github comment.

The vote will close at the start of the next weekly call - June 13, 12pm ET.

Note: technically, IBM/Red Hat forgot to change their representatives in our tracking spreadsheet so they're not officially listed as having voting rights. However, @Cali0707 has been at the last 4 meetings so Red Hat really should have voting rights. I'll work with Calum on getting the spreadsheet updated.

Additionally, Mark Peek was listed as the rep for VMWare but he moved on earlier this year and the spreadsheet was not updated, so I've adjusted the comments in this PR to reflect this.


## Proposed Changes

- Mark spec as v1.0

**Release Note**

```release-note
The CloudEvents SQL Specification is now version 1.0
```
