### PR TITLE
Add CloudEvents extension for deprecated events

### DIFF
--- a/cloudevents/extensions/README.md
+++ b/cloudevents/extensions/README.md
@@ -43,6 +43,7 @@ for more information.
 - [Auth Context](authcontext.md)
 - [BAM](bam.md)
 - [Dataref (Claim Check Pattern)](dataref.md)
+- [Deprecation](deprecation.md)
 - [Distributed Tracing](distributed-tracing.md)
 - [Expiry Time](expirytime.md)
 - [OPC UA](opcua.md)

--- a/cloudevents/extensions/deprecation.md
+++ b/cloudevents/extensions/deprecation.md
@@ -27,7 +27,7 @@ extension is being used.
   `false` if not specified.
 - Constraints
   - OPTIONAL
-- Example: `"deprecated": "true"`
+- Example: `"deprecated": true`
 
 ### deprecationfrom
 
@@ -61,8 +61,8 @@ the migration path from the deprecated event to an alternative. This helps
 consumers transition away from the deprecated event.
 - Constraints
   - OPTIONAL
-  - The URI SHOULD point to valid and accessible resources that help the
-    consumer understand what SHOULD replace the deprecated event
+  - The URI SHOULD point to a valid and accessible resource that helps the
+    consumer understand what SHOULD replace the deprecated event.
 - Example: `"deprecationmigration": "https://example.com/migrate-to-new-evt"`
 
 ## Usage

--- a/cloudevents/extensions/deprecation.md
+++ b/cloudevents/extensions/deprecation.md
@@ -2,8 +2,8 @@
 
 This specification defines attributes that can be included in CloudEvents to
 indicate to [consumers](../spec.md#consumer) or
-[intermediaries](../spec.md#intermediary) the deprecation of the events. These
-attributes inform consumers of CloudEvents about upcoming changes or removals,
+[intermediaries](../spec.md#intermediary) the deprecation of events. These
+attributes inform CloudEvents consumers about upcoming changes or removals,
 facilitating smoother transitions and proactive adjustments.
 
 ## Notational Conventions
@@ -37,7 +37,7 @@ extension is being used.
 - Constraints
   - OPTIONAL
   - The `deprecationfrom` timestamp SHOULD remain stable once set and SHOULD
-    reflect a point in the past or the present. Pre-announcing deprecation by
+    reflect a point in the past or present. Pre-announcing deprecation by
     setting a future date is not encouraged.
 - Example: `"deprecationfrom": "2024-10-11T00:00:00Z"`
 
@@ -61,8 +61,8 @@ the migration path from the deprecated event to an alternative. This helps
 consumers transition away from the deprecated event.
 - Constraints
   - OPTIONAL
-  - The URI SHOULD point to a valid and accessible resource that helps the
-    consumer understand what SHOULD replace the deprecated event.
+  - The URI SHOULD point to a valid and accessible resource that helps
+    consumers understand what SHOULD replace the deprecated event.
 - Example: `"deprecationmigration": "https://example.com/migrate-to-new-evt"`
 
 ## Usage

--- a/cloudevents/extensions/deprecation.md
+++ b/cloudevents/extensions/deprecation.md
@@ -27,7 +27,6 @@ extension is being used.
   `false` if not specified.
 - Constraints
   - OPTIONAL
-  - The value MUST be a boolean (`true` or `false`).
 - Example: `"deprecated": "true"`
 
 ### deprecationfrom

--- a/cloudevents/extensions/deprecation.md
+++ b/cloudevents/extensions/deprecation.md
@@ -37,8 +37,6 @@ extension is being used.
   officially marked as deprecated.
 - Constraints
   - OPTIONAL
-  - If present, MUST adhere to the format specified in
-    [RFC 3339](https://tools.ietf.org/html/rfc3339)
   - The `deprecationfrom` timestamp SHOULD remain stable once set and SHOULD
     reflect a point in the past or the present. Pre-announcing deprecation by
     setting a future date is not encouraged.
@@ -54,8 +52,6 @@ extension is being used.
   - The timestamp MUST be later than or the same as the one given in the
     `deprecationfrom` field, if present. It MAY be extended to a later date but
     MUST NOT be shortened once set.
-  - If present, MUST adhere to the format specified in
-    [RFC 3339](https://tools.ietf.org/html/rfc3339)
 - Example: `"deprecationsunset": "2024-11-12T00:00:00Z"`
 
 ### deprecationmigration

--- a/cloudevents/extensions/deprecation.md
+++ b/cloudevents/extensions/deprecation.md
@@ -20,14 +20,15 @@ extension is being used.
 
 ## Attributes
 
-### deprecation
+### deprecated
 
 - Type: `Boolean`
-- Description: Indicates whether the event type is deprecated.
+- Description: Indicates whether the event type is deprecated. Defaults to
+  `false` if not specified.
 - Constraints
-  - REQUIRED
+  - OPTIONAL
   - The value MUST be a boolean (`true` or `false`).
-- Example: `"deprecation": "true"`
+- Example: `"deprecated": "true"`
 
 ### deprecationfrom
 
@@ -38,6 +39,9 @@ extension is being used.
   - OPTIONAL
   - If present, MUST adhere to the format specified in
     [RFC 3339](https://tools.ietf.org/html/rfc3339)
+  - The `deprecationfrom` timestamp SHOULD remain stable once set and SHOULD
+    reflect a point in the past or the present. Pre-announcing deprecation by
+    setting a future date is not encouraged.
 - Example: `"deprecationfrom": "2024-10-11T00:00:00Z"`
 
 ### deprecationsunset
@@ -47,8 +51,9 @@ extension is being used.
   become unsupported.
 - Constraints
   - OPTIONAL
-  - The timestamp MUST be later or the same as the one given in the
-    `deprecationfrom` field.
+  - The timestamp MUST be later than or the same as the one given in the
+    `deprecationfrom` field, if present. It MAY be extended to a later date but
+    MUST NOT be shortened once set.
   - If present, MUST adhere to the format specified in
     [RFC 3339](https://tools.ietf.org/html/rfc3339)
 - Example: `"deprecationsunset": "2024-11-12T00:00:00Z"`
@@ -67,14 +72,14 @@ consumers transition away from the deprecated event.
 
 ## Usage
 
-When this extension is used, producers MUST set the value of the `deprecation`
+When this extension is used, producers MUST set the value of the `deprecated`
 attribute to `true`. This gives consumers a heads-up that they SHOULD begin
 migrating to a new event or version.
 
-Consumers SHOULD use the `deprecation` and `deprecationfrom` attributes to
-monitor the lifecycle of events they rely on. If `deprecationsunset` has been
-reached, consumers SHOULD consider switching to the RECOMMENDED replacement, as
-events MAY no longer be supported.
+Consumers SHOULD make efforts to switch to the suggested replacement before the
+specified `deprecationsunset` timestamp. It is advisable to begin transitioning
+as soon as the event is marked as deprecated to ensure a smooth migration and
+avoid potential disruptions after the sunset date.
 
 If an event is received after the `deprecationsunset` timestamp, consumers
 SHOULD choose to stop processing such events, especially if unsupported events

--- a/cloudevents/extensions/deprecation.md
+++ b/cloudevents/extensions/deprecation.md
@@ -25,7 +25,7 @@ extension is being used.
 - Type: `Boolean`
 - Description: Indicates whether the event type is deprecated.
 - Constraints
-  - MUST be true
+  - MUST be `true`
   - REQUIRED
 - Example: `"deprecated": true`
 

--- a/cloudevents/extensions/deprecation.md
+++ b/cloudevents/extensions/deprecation.md
@@ -23,9 +23,9 @@ extension is being used.
 ### deprecated
 
 - Type: `Boolean`
-- Description: Indicates whether the event type is deprecated. Defaults to
-  `false` if not specified.
+- Description: Indicates whether the event type is deprecated.
 - Constraints
+  - MUST be true
   - REQUIRED
 - Example: `"deprecated": true`
 

--- a/cloudevents/extensions/deprecation.md
+++ b/cloudevents/extensions/deprecation.md
@@ -73,8 +73,8 @@ migrating to a new event or version.
 
 Consumers SHOULD use the `deprecation` and `deprecationfrom` attributes to
 monitor the lifecycle of events they rely on. If `deprecationsunset` has been
-reached, consumers SHOULD consider switching to the recommended replacement, as
-events may no longer be supported.
+reached, consumers SHOULD consider switching to the RECOMMENDED replacement, as
+events MAY no longer be supported.
 
 If an event is received after the `deprecationsunset` timestamp, consumers
 SHOULD choose to stop processing such events, especially if unsupported events

--- a/cloudevents/extensions/deprecation.md
+++ b/cloudevents/extensions/deprecation.md
@@ -1,0 +1,58 @@
+# Deprecation and Sunset extension
+
+This specification defines attributes that can be included in CloudEvents to
+indicate to [consumers](../spec.md#consumer) or
+[intermediaries](../spec.md#intermediary) the deprecation and sunset status of
+the event type. These attributes inform consumers of CloudEvents about upcoming
+changes or removals, facilitating smoother transitions and proactive
+adjustments.
+
+## Notational Conventions
+
+As with the main [CloudEvents specification](../spec.md), the key words "MUST",
+"MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
+"RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as
+described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+However, the scope of these key words is limited to when this extension is
+used. For example, an attribute being marked as "REQUIRED" does not mean it
+needs to be in all CloudEvents, rather it needs to be included only when this
+extension is being used.
+
+## Attributes
+
+### deprecation
+
+- Type: `String`
+- Description: Indicates that the event type is deprecated. This can be a
+  boolean `true` or a date in [RFC 5322](https://tools.ietf.org/html/rfc5322)
+  format indicating when the deprecation was announced.
+- Constraints
+  - REQUIRED
+  - If the value is a date, it MUST be formatted according to RFC 5322.
+- Examples:
+  - A boolean deprecation: `"deprecation": "true"`
+  - A date-based deprecation: `"deprecation": "Sun, 11 Aug 2024 23:59:59 GMT"`
+
+### sunset
+
+- Type: `String`
+- Description: Specifies the future date and time when the event type will
+  become unsupported, formatted according to
+  [RFC 8594](https://tools.ietf.org/html/rfc8594).
+- Constraints
+  - OPTIONAL
+  - The timestamp MUST be later or the same as the one given in the
+    `deprecation` field.
+- Example: `"sunset": "Wed, 14 Aug 2024 23:59:59 GMT"`
+
+## Usage
+
+When this extension is used, producers MUST set the value of the `deprecation`
+attribute to `true` or the `timestamp` of when an event is being phased out but
+still supported. This gives consumers a heads-up that they SHOULD begin
+migrating to a new event type or version.
+
+The `sunset` attribute SHOULD specify the exact date and time when the event
+will no longer be supported. This is the final cutoff date after which the
+event will no longer function as expected.

--- a/cloudevents/extensions/deprecation.md
+++ b/cloudevents/extensions/deprecation.md
@@ -26,7 +26,7 @@ extension is being used.
 - Description: Indicates whether the event type is deprecated. Defaults to
   `false` if not specified.
 - Constraints
-  - OPTIONAL
+  - REQUIRED
 - Example: `"deprecated": true`
 
 ### deprecationfrom

--- a/cloudevents/languages/he/extensions/deprecation.md
+++ b/cloudevents/languages/he/extensions/deprecation.md
@@ -1,2 +1,2 @@
-# Deprecation and Sunset extension
+# Deprecation extension
 מסמך זה טרם תורגם. בבקשה תשתמשו [בגרסה האנגלית של המסמך](../../../extensions/deprecation.md) לבינתיים.

--- a/cloudevents/languages/he/extensions/deprecation.md
+++ b/cloudevents/languages/he/extensions/deprecation.md
@@ -1,0 +1,2 @@
+# Deprecation and Sunset extension
+מסמך זה טרם תורגם. בבקשה תשתמשו [בגרסה האנגלית של המסמך](../../../extensions/deprecation.md) לבינתיים.

--- a/cloudevents/languages/zh-CN/extensions/deprecation.md
+++ b/cloudevents/languages/zh-CN/extensions/deprecation.md
@@ -1,4 +1,4 @@
-# Deprecation and Sunset extension
+# Deprecation extension
 
 本文档尚未被翻译，请先阅读英文[原版文档](../../../extensions/deprecation.md) 。
 

--- a/cloudevents/languages/zh-CN/extensions/deprecation.md
+++ b/cloudevents/languages/zh-CN/extensions/deprecation.md
@@ -1,0 +1,6 @@
+# Deprecation and Sunset extension
+
+本文档尚未被翻译，请先阅读英文[原版文档](../../../extensions/deprecation.md) 。
+
+如果您迫切地需要此文档的中文翻译，请[提交一个issue](https://github.com/cloudevents/spec/issues) ，
+我们会尽快安排专人进行翻译。


### PR DESCRIPTION
Introduced the `deprecation` attribute to indicate when an event type is deprecated, and added the `sunset` attribute to specify the date and time when the event will become unsupported. This extension provides clear guidelines and examples for implementing these attributes, aiming to improve lifecycle management and ensure better communication with consumers.