### PR TITLE
docs: add vandewilly to contributors list

### DIFF
--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -89,6 +89,7 @@ Contributions do not constitute an official endorsement.
 - Matt Rutkowski - [@mrutkows](https://github.com/mrutkows)
 
 # S
+- Vandewilly Silva - [@vandewillysilva](https://github.com/vandewillysilva)
 - Jon Skeet - [@jskeet](https://github.com/jskeet)
 - Stevo Slavić - [@sslavic](https://github.com/sslavic)
 - Tihomir Surdilovic - [@tsurdilo](https://github.com/tsurdilo)


### PR DESCRIPTION
Adding myself to the contributors list. It's a small thing, but since I contributed to the deprecation extension, it's important for me to be included.

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note

```
