### PR TITLE
Resolve deprecation warnings

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -7,7 +7,7 @@ verify:
 	@python tools/verify.py .
 
 test_tools:
-	@pytest tools/
+	@pytest -o asyncio_mode=auto -o asyncio_default_fixture_loop_scope=function tools/
 
 docker:
 	@docker run -ti -v $(PWD):/tmp/spec -w /tmp/spec python:latest \

--- a/tools/verify.py
+++ b/tools/verify.py
@@ -125,7 +125,7 @@ def _skip_type(text: str) -> Optional[str]:
 
 
 def _find_all_uris(html: HtmlText) -> Iterable[Uri]:
-    for a in _html_parser(html).findAll("a"):
+    for a in _html_parser(html).find_all("a"):
         uri = a.get("href")
         if uri:
             yield Uri(uri.strip())


### PR DESCRIPTION
## Proposed Changes
This small PR fixes the `bs4` and `pytest` deprecation warnings found in the [CI logs](https://github.com/cloudevents/spec/actions/runs/14521973353/job/40744953269#step:5:27). More specificly:
- Fix the `bs4` deprecation warnings:
```python
  /home/runner/work/spec/spec/tools/verify.py:128: DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.
    for a in _html_parser(html).findAll("a"):
```
- Fix the `pytest` deprecation warnings:
```python
/usr/local/lib/python3.13/site-packages/pytest_asyncio/plugin.py:217: 
PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope"
is unset.
```

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note
Resolve bs4 and pytest deprecation warnings
```
