### PR TITLE
Add a "v2.md" file so we can close v2 issues/PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ native ecosystem by making our systems interoperable with CloudEvents.
   docs](https://drive.google.com/drive/folders/1eKH-tVNV25jwkuBEoi3ESqvVjNRlJqYX?usp=sharing)
 - [Demos & open source](docs/README.md) -- if you have something to share
   about your use of CloudEvents, please submit a PR!
+- [Potential CloudEvents v2 work items](cloudevents/v2.md)
 - [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 
 ### Security Concerns

--- a/cloudevents/languages/he/v2.md
+++ b/cloudevents/languages/he/v2.md
@@ -1,0 +1,2 @@
+# CloudEvents Version 2 Consideration List
+מסמך זה טרם תורגם. בבקשה תשתמשו [בגרסה האנגלית של המסמך](../../v2.md) לבינתיים.

--- a/cloudevents/languages/zh-CN/v2.md
+++ b/cloudevents/languages/zh-CN/v2.md
@@ -1,0 +1,6 @@
+# CloudEvents Version 2 Consideration List
+
+本文档尚未被翻译，请先阅读英文[原版文档](../../v2.md) 。
+
+如果您迫切地需要此文档的中文翻译，请[提交一个issue](https://github.com/cloudevents/spec/issues) ，
+我们会尽快安排专人进行翻译。

--- a/cloudevents/v2.md
+++ b/cloudevents/v2.md
@@ -1,0 +1,16 @@
+# CloudEvents Version 2 Consideration List
+
+<!-- no verify-specs -->
+
+The list below contains the set of changes that the group had identified as
+potential candidates for a v2 of the CloudEvents specification. There no
+guarantee as to when, or if, a v2 might happen, or that any of these will be
+adopted. Rather this list is just a reminder to consider them so that we can
+reduce the number of open issues and PRs on our backlog.
+
+- [Do we want a new optional "mustunderstand" core attribute](https://github.com/cloudevents/spec/issues/1321)
+- [Why does the HTTP binding for batch require the same spec version for all events in the batch?](https://github.com/cloudevents/spec/issues/807)
+- [handling of datacontenttype is inconsistent](https://github.com/cloudevents/spec/issues/558)
+- [fix(protobuf)!: Expose CloudEvent structure with explicit fields](https://github.com/cloudevents/spec/pull/1354)
+- [The case for minor version](https://github.com/cloudevents/spec/pull/1032)
+


### PR DESCRIPTION
ping @jskeet 

If we merge this then we will also close these:
- [Do we want a new optional "mustunderstand" core attribute](https://github.com/cloudevents/spec/issues/1321)
- [Why does the HTTP binding for batch require the same spec version for all events in the batch?](https://github.com/cloudevents/spec/issues/807)
- [handling of datacontenttype is inconsistent](https://github.com/cloudevents/spec/issues/558)
- [fix(protobuf)!: Expose CloudEvent structure with explicit fields](https://github.com/cloudevents/spec/pull/1354)
- [Minor version](https://github.com/cloudevents/spec/pull/1032)

Add the 'v2' label to each one we close