### PR TITLE
Fixup for new process & support shortened release names

### DIFF
--- a/docs/CE-Security-Self-Assessment.md.sav
+++ b/docs/CE-Security-Self-Assessment.md.sav
@@ -1,0 +1,183 @@
+# CloudEvents Security Self-assessment
+
+## Table of contents
+
+* [Metadata](#metadata)
+  * [Security links](#security-links)
+* [Overview](#overview)
+  * [Actors](#actors)
+  * [Actions](#actions)
+  * [Background](#background)
+  * [Goals](#goals)
+  * [Non-goals](#non-goals)
+* [Self-assessment use](#self-assessment-use)
+* [Security functions and features](#security-functions-and-features)
+* [Project compliance](#project-compliance)
+* [Secure development practices](#secure-development-practices)
+* [Security issue resolution](#security-issue-resolution)
+* [Appendix](#appendix)
+
+## Metadata
+
+A table at the top for quick reference information, later used for indexing.
+
+|   |  |
+| -- | -- |
+| Software | Specification: https://github.com/cloudevents/spec |
+| Security Provider | No. The primary function of the project is NOT to support the security of an integrating system  |
+| Languages | n/a |
+| SBOM | n/a |
+| | |
+
+### Security links
+
+Provide the list of links to existing security documentation for the project.
+You may use the table below as an example:
+| Information | URL |
+| -- | -- |
+| Raising security issues information | https://github.com/cloudevents/spec#security-concerns |
+
+## Overview
+
+CloudEvents is a specification for describing common event data in popular
+formats and transports to provide interoperability across services, platforms
+and systems.
+
+While there are SDKs for CloudEvents, they are community driven activities
+and while they are hosted within the CloudEvents github org, the focus of
+the security review should be on the specification itself. It is worth
+mentioning though that the SDKs (and the CloudEvents specification) do not
+introduce (or deal with) any security mechanisms beyond what is available
+as part of whatever transport is used to move an event between actors.
+
+### Background
+
+For more detailed information, please see either the
+[Graduation Proposal](https://github.com/cncf/toc/blob/845ec88ca3908824d6fead0c2840947f8941a355/proposals/graduation/cloudevents.md)
+or the
+ [Primer](https://github.com/cloudevents/spec/blob/main/cloudevents/primer.md).
+
+
+### Actors
+
+CloudEvents has 2 main actors:
+1 - an event producer
+2 - an event consumer
+
+There may be additional variants of these, for example, an event intermediary
+that receives events and then forwards them on to another event receiver, or
+an actor the receives and event and generates one or more events. However,
+these could be considered variants of the 2 main actors.
+
+The CloudEvents specification only deals with serialziation of
+Events and their metadata, not the transport (or transport protection)
+mechanisms used to move events between the actors. For that, the specification
+and the users of the transports will rely on the transport-specific
+specifications and implementations. Basically, transport security concerns are
+out of scope for CloudEvents.
+
+### Actions
+
+CloudEvents is just a specification
+
+These are the steps that a project performs in order to provide some service
+or functionality.  These steps are performed by different actors in the system.
+Note, that an action need not be overly descriptive at the function call level.  
+It is sufficient to focus on the security checks performed, use of sensitive 
+data, and interactions between actors to perform an action.  
+
+For example, the access server receives the client request, checks the format, 
+validates that the request corresponds to a file the client is authorized to 
+access, and then returns a token to the client.  The client then transmits that 
+token to the file server, which, after confirming its validity, returns the file.
+
+### Goals
+The intended goals of the projects including the security guarantees the project
+ is meant to provide (e.g., Flibble only allows parties with an authorization
+key to change data it stores).
+
+### Non-goals
+Non-goals that a reasonable reader of the project’s literature could believe may
+be in scope (e.g., Flibble does not intend to stop a party with a key from storing
+an arbitrarily large amount of data, possibly incurring financial cost or overwhelming
+ the servers)
+
+## Self-assessment use
+
+This self-assessment is created by the [project] team to perform an internal analysis of the
+project's security.  It is not intended to provide a security audit of [project], or
+function as an independent assessment or attestation of [project]'s security health.
+
+This document serves to provide [project] users with an initial understanding of
+[project]'s security, where to find existing security documentation, [project] plans for
+security, and general overview of [project] security practices, both for development of
+[project] as well as security of [project].
+
+This document provides the CNCF TAG-Security with an initial understanding of [project]
+to assist in a joint-assessment, necessary for projects under incubation.  Taken
+together, this document and the joint-assessment serve as a cornerstone for if and when
+[project] seeks graduation and is preparing for a security audit.
+
+## Security functions and features
+
+* Critical.  A listing critical security components of the project with a brief
+description of their importance.  It is recommended these be used for threat modeling.
+These are considered critical design elements that make the product itself secure and
+are not configurable.  Projects are encouraged to track these as primary impact items
+for changes to the project.
+* Security Relevant.  A listing of security relevant components of the project with
+  brief description.  These are considered important to enhance the overall security of
+the project, such as deployment configurations, settings, etc.  These should also be
+included in threat modeling.
+
+## Project compliance
+
+* Compliance.  List any security standards or sub-sections the project is
+  already documented as meeting (PCI-DSS, COBIT, ISO, GDPR, etc.).
+
+## Secure development practices
+
+* Development Pipeline.  A description of the testing and assessment processes that
+  the software undergoes as it is developed and built. Be sure to include specific
+information such as if contributors are required to sign commits, if any container
+images immutable and signed, how many reviewers before merging, any automated checks for
+vulnerabilities, etc.
+* Communication Channels. Reference where you document how to reach your team or
+  describe in corresponding section.
+  * Internal. How do team members communicate with each other?
+  * Inbound. How do users or prospective users communicate with the team?
+  * Outbound. How do you communicate with your users? (e.g. flibble-announce@
+    mailing list)
+* Ecosystem. How does your software fit into the cloud native ecosystem?  (e.g.
+  Flibber is integrated with both Flocker and Noodles which covers
+virtualization for 80% of cloud users. So, our small number of "users" actually
+represents very wide usage across the ecosystem since every virtual instance uses
+Flibber encryption by default.)
+
+## Security issue resolution
+
+* Responsible Disclosures Process. A outline of the project's responsible
+  disclosures process should suspected security issues, incidents, or
+vulnerabilities be discovered both external and internal to the project. The
+outline should discuss communication methods/strategies.
+  * Vulnerability Response Process. Who is responsible for responding to a
+    report. What is the reporting process? How would you respond?
+* Incident Response. A description of the defined procedures for triage,
+  confirmation, notification of vulnerability or security incident, and
+patching/update availability.
+
+## Appendix
+
+* Known Issues Over Time. List or summarize statistics of past vulnerabilities
+  with links. If none have been reported, provide data, if any, about your track
+record in catching issues in code review or automated testing.
+* [CII Best Practices](https://www.coreinfrastructure.org/programs/best-practices-program/).
+  Best Practices. A brief discussion of where the project is at
+  with respect to CII best practices and what it would need to
+  achieve the badge.
+* Case Studies. Provide context for reviewers by detailing 2-3 scenarios of
+  real-world use cases.
+* Related Projects / Vendors. Reflect on times prospective users have asked
+  about the differences between your project and projectX. Reviewers will have
+the same question.
+

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -246,13 +246,21 @@ Note that these rules do not apply to unversioned documents, such as the
   updated, you'll need to move the tag for that release to point to the head
   of that branch. We'll eventually setup a GitHub action to automatically do
   it but for now you can do it via the CLI:
-  - `git pull --tags` to make sure you have all latest branches and tags
+  - `git pull --tags -a` to make sure you have all latest branches and tags
   - `git tag -d SUBJECT@vX.Y.Z` to delete the old tag for the release
   - `git tag SUBJECT@vX.Y.Z SUBJECT@vX.Y.Z-branch` to create a new tag for
     the head of the release branch
   - `git push REMOTE SUBJECT@vX.Y.Z -f` to force the tag to updated in the
     GitHub repo, where `REMOTE` is replaced with the git "remote" name that
     you have defined that references the GitHub repo
+
+- If a new commit was pushed to the latest release of a group/subject of
+  specifications, and if that subject has a shortened tag name
+  (e.g. `ce@v1.0`), then update that tag to point to the head of the branch:
+  - `git pull --tags -a`
+  - `git tag -d SUBJECT@vX.Y`
+  - `git tag SUBJECT@vX.Y SUBJECT@vX.Y.Z-branch`
+  - `git push REMOTE SUBJECT@vX.Y -f`
 
 ## Additional Information
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -3,9 +3,9 @@
 | Specification Group | Version                                                              | Release Date | Release Notes                                            |
 | :------------------ | :------------------------------------------------------------------: | :----------- | :------------------------------------------------------: |
 | CESQL               | [1.0.0](https://github.com/cloudevents/spec/tree/cesql@v1.0.0)         | 2024/06/13   | [Notes](../cesql/RELEASE_NOTES.md#v100---20240613)       |
-| CloudEvents         | [1.0.2](https://github.com/cloudevents/spec/tree/v1.0.2/cloudevents) | 2022/02/05   | [Notes](../cloudevents/RELEASE_NOTES.md#v102---20220205) |
-| CloudEvents         | [1.0.1](https://github.com/cloudevents/spec/tree/v1.0.1)             | 2020/12/12   | [Notes](../cloudevents/RELEASE_NOTES.md#v101---20201212) |
-| CloudEvents         | [1.0](https://github.com/cloudevents/spec/tree/v1.0)                 | 2019/10/24   | [Notes](../cloudevents/RELEASE_NOTES.md#v100---20191024) |
+| CloudEvents         | [1.0.2](https://github.com/cloudevents/spec/tree/ce@v1.0.2/cloudevents) | 2022/02/05   | [Notes](../cloudevents/RELEASE_NOTES.md#v102---20220205) |
+| CloudEvents         | [1.0.1](https://github.com/cloudevents/spec/tree/ce@v1.0.1)             | 2020/12/12   | [Notes](../cloudevents/RELEASE_NOTES.md#v101---20201212) |
+| CloudEvents         | [1.0](https://github.com/cloudevents/spec/tree/ce@v1.0)                 | 2019/10/24   | [Notes](../cloudevents/RELEASE_NOTES.md#v100---20191024) |
 | CloudEvents         | [0.3](https://github.com/cloudevents/spec/tree/v0.3)                 | 2019/06/13   | [Notes](../cloudevents/RELEASE_NOTES.md#v03---20190613)  |
 | CloudEvents         | [0.2](https://github.com/cloudevents/spec/tree/v0.2)                 | 2018/12/06   | [Notes](../cloudevents/RELEASE_NOTES.md#v02---20181206)  |
 | CloudEvents         | [0.1](https://github.com/cloudevents/spec/tree/v0.1)                 | 2018/04/20   | [Notes](../cloudevents/RELEASE_NOTES.md#v01---20180420)  |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -83,12 +83,12 @@ _1.0_ - Completed - 2019/10/24
 
 _1.0.1_ - Completed - 2020/12/10
 
-1. See [V1.0.1 Release](https://github.com/cloudevents/spec/releases/tag/v1.0.1)
+1. See [V1.0.1 Release](https://github.com/cloudevents/spec/releases/tag/ce@v1.0.1)
    for details.
 
 _1.0.2_ - Completed - 2022/02/03
 
-1. See [V1.0.2 Release](https://github.com/cloudevents/spec/releases/tag/v1.0.2)
+1. See [V1.0.2 Release](https://github.com/cloudevents/spec/releases/tag/ce@v1.0.2)
    for details.
 
 _Future_


### PR DESCRIPTION
- typos
- use new tags names in URLs
- support shortened tag names - e.g. ce@v1.0 points to HEAD of ce@v1.0.2-branch (which is ce@v1.0.2 tag)