### PR TITLE
Ensure `traceparent` isn't an empty string

### DIFF
--- a/cloudevents/extensions/distributed-tracing.md
+++ b/cloudevents/extensions/distributed-tracing.md
@@ -45,6 +45,7 @@ this extension is being used.
   defined in [section 3.2](https://w3c.github.io/trace-context/#traceparent-header)
 - Constraints
   - REQUIRED
+  - MUST be a non-empty string
 
 ### tracestate
 


### PR DESCRIPTION
Fixes #1369