### PR TITLE
Update kafka-protocol-binding.md

### DIFF
--- a/cloudevents/bindings/kafka-protocol-binding.md
+++ b/cloudevents/bindings/kafka-protocol-binding.md
@@ -225,7 +225,7 @@ This example shows the _binary_ mode mapping of an event into the Kafka message.
 All other CloudEvents attributes are mapped to Kafka Header fields with prefix
 `ce_`.
 
-Mind that `content-type` here does refer to the event `data` content carried in the
+Note that `content-type` here refers to the event `data` content carried in the
 payload.
 
 ```text

--- a/cloudevents/bindings/kafka-protocol-binding.md
+++ b/cloudevents/bindings/kafka-protocol-binding.md
@@ -225,7 +225,7 @@ This example shows the _binary_ mode mapping of an event into the Kafka message.
 All other CloudEvents attributes are mapped to Kafka Header fields with prefix
 `ce_`.
 
-Mind that `ce_` here does refer to the event `data` content carried in the
+Mind that `content-type` here does refer to the event `data` content carried in the
 payload.
 
 ```text


### PR DESCRIPTION
Fixes #

The Binary Mode Content example section contains a statement with a typo possibly leading to confusion.

## Proposed Changes

- Change `ce_` to `content-type` in the binary mode content example section as that is what the statement intends to communicate.

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->
