### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -27,6 +27,9 @@ on:
       end-sha:
         description: 'Ending SHA? (latest HEAD)'
 
+permissions:
+  contents: read
+
 jobs:
   release-notes:
     name: Release Notes

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,5 +1,8 @@
 name: verify
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: verify


### PR DESCRIPTION
Fixes #1383

Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

## Proposed Changes

- Add top-level `permissions: contents: read` to `.github/workflows/release-notes.yaml`
- Add top-level `permissions: contents: read` to `.github/workflows/verify.yaml`
- ~Additional changes~

**Release Note**

<!--
If this change has user-visible impact, write a release note in the block
below. If this change has no user-visible impact, no release note is needed.
-->

```release-note
NONE
```
